### PR TITLE
fix: make address stx balance take fees into account

### DIFF
--- a/docs/api/address/get-address-stx-balance.example.json
+++ b/docs/api/address/get-address-stx-balance.example.json
@@ -1,0 +1,5 @@
+{
+  "balance": "1000000",
+  "total_sent": "0",
+  "total_received": "1000000"
+}

--- a/docs/api/address/get-address-stx-balance.schema.json
+++ b/docs/api/address/get-address-stx-balance.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "GET request that returns address balances",
+  "title": "AddressStxBalanceResponse",
+  "type": "object",
+  "required": ["stx", "fungible_tokens", "non_fungible_tokens"],
+  "$ref": "../../entities/balance/balance.schema.json"
+}

--- a/docs/api/address/get-address-stx-balance.schema.json
+++ b/docs/api/address/get-address-stx-balance.schema.json
@@ -3,6 +3,5 @@
   "description": "GET request that returns address balances",
   "title": "AddressStxBalanceResponse",
   "type": "object",
-  "required": ["stx", "fungible_tokens", "non_fungible_tokens"],
   "$ref": "../../entities/balance/balance.schema.json"
 }

--- a/docs/api/address/get-address-transactions.schema.json
+++ b/docs/api/address/get-address-transactions.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "GET request that returns account transactions",
-  "title": "AccountTransactionsListResponse",
+  "title": "AddressTransactionsListResponse",
   "type": "object",
   "additionalProperties": false,
   "required": ["results", "limit", "offset", "total"],

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -58,9 +58,9 @@ export interface AddressBalanceResponse {
  * GET request that returns address balances
  */
 export interface AddressStxBalanceResponse {
-  balance?: string;
-  total_sent?: string;
-  total_received?: string;
+  balance: string;
+  total_sent: string;
+  total_received: string;
 }
 
 /**

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -55,9 +55,18 @@ export interface AddressBalanceResponse {
 }
 
 /**
+ * GET request that returns address balances
+ */
+export interface AddressStxBalanceResponse {
+  balance?: string;
+  total_sent?: string;
+  total_received?: string;
+}
+
+/**
  * GET request that returns account transactions
  */
-export interface AccountTransactionsListResponse {
+export interface AddressTransactionsListResponse {
   limit: number;
   offset: number;
   total: number;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -445,6 +445,29 @@ paths:
               example:
                 $ref: ./api/address/get-address-balances.example.json
 
+  /extended/v1/address/{principal}/stx:
+    get:
+      summary: Get account STX balance
+      tags:
+        - Accounts
+      operationId: get_account_stx_balance
+      parameters:
+        - name: principal
+          in: path
+          description: Stacks address or a Contract identifier (e.g. `SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0.get-info`)
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: ./api/address/get-address-stx-balance.schema.json
+              example:
+                $ref: ./api/address/get-address-stx-balance.example.json
+
   /extended/v1/address/{principal}/transactions:
     get:
       summary: Get account transactions

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -9,6 +9,7 @@ import {
   TransactionResults,
   TransactionEvent,
   AddressBalanceResponse,
+  AddressStxBalanceResponse,
 } from '@blockstack/stacks-blockchain-api-types';
 
 const MAX_TX_PER_REQUEST = 50;
@@ -33,6 +34,21 @@ interface AddressAssetEvents {
 
 export function createAddressRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
+
+  router.getAsync('/:stx_address/stx', async (req, res) => {
+    const stxAddress = req.params['stx_address'];
+    if (!isValidPrincipal(stxAddress)) {
+      return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
+    }
+    // Get balance info for STX token
+    const { balance, totalSent, totalReceived } = await db.getStxBalance(stxAddress);
+    const result: AddressStxBalanceResponse = {
+      balance: balance.toString(),
+      total_sent: totalSent.toString(),
+      total_received: totalReceived.toString(),
+    };
+    res.json(result);
+  });
 
   // get balances for STX, FTs, and counts for NFTs
   router.getAsync('/:stx_address/balances', async (req, res) => {

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1470,9 +1470,18 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       `,
       [stxAddress]
     );
+    const feeQuery = await this.pool.query<{ fee_sum: string }>(
+      `
+      SELECT sum(fee_rate) as fee_sum
+      FROM txs
+      WHERE canonical = true AND sender_address = $1
+      `,
+      [stxAddress]
+    );
+    const totalFees = BigInt(feeQuery.rows[0].fee_sum ?? 0);
     const totalSent = BigInt(result.rows[0].debit_total ?? 0);
     const totalReceived = BigInt(result.rows[0].credit_total ?? 0);
-    const balanceTotal = totalReceived - totalSent;
+    const balanceTotal = totalReceived - totalSent - totalFees;
     return {
       balance: balanceTotal,
       totalSent,

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -925,6 +925,14 @@ describe('api tests', () => {
     };
     expect(JSON.parse(fetchAddrBalance2.text)).toEqual(expectedResp2);
 
+    const fetchAddrStxBalance1 = await supertest(api.server).get(
+      `/extended/v1/address/${testContractAddr}/stx`
+    );
+    expect(fetchAddrStxBalance1.status).toBe(200);
+    expect(fetchAddrStxBalance1.type).toBe('application/json');
+    const expectedStxResp1 = { balance: '101', total_sent: '15', total_received: '1350' };
+    expect(JSON.parse(fetchAddrStxBalance1.text)).toEqual(expectedStxResp1);
+
     const fetchAddrAssets1 = await supertest(api.server).get(
       `/extended/v1/address/${testContractAddr}/assets?limit=8&offset=2`
     );

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -788,7 +788,7 @@ describe('api tests', () => {
     const events = [
       createStxEvent(testAddr1, testAddr2, 100_000),
       createStxEvent(testAddr2, testContractAddr, 100),
-      createStxEvent(testAddr2, testContractAddr, 250),
+      createStxEvent(testAddr2, testContractAddr, 1250),
       createStxEvent(testAddr2, testContractAddr, 40, false),
       createStxEvent(testContractAddr, testAddr4, 15),
       createStxEvent(testAddr2, testAddr4, 35),
@@ -891,7 +891,7 @@ describe('api tests', () => {
     expect(fetchAddrBalance1.status).toBe(200);
     expect(fetchAddrBalance1.type).toBe('application/json');
     const expectedResp1 = {
-      stx: { balance: '99615', total_sent: '385', total_received: '100000' },
+      stx: { balance: '94913', total_sent: '1385', total_received: '100000' },
       fungible_tokens: {
         bux: { balance: '99615', total_sent: '385', total_received: '100000' },
         cash: { balance: '500000', total_sent: '0', total_received: '500000' },
@@ -913,7 +913,7 @@ describe('api tests', () => {
     expect(fetchAddrBalance2.status).toBe(200);
     expect(fetchAddrBalance2.type).toBe('application/json');
     const expectedResp2 = {
-      stx: { balance: '335', total_sent: '15', total_received: '350' },
+      stx: { balance: '101', total_sent: '15', total_received: '1350' },
       fungible_tokens: {
         bux: { balance: '335', total_sent: '15', total_received: '350' },
         gox: { balance: '525', total_sent: '25', total_received: '550' },

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -78,8 +78,13 @@ describe('postgres datastore', () => {
       post_conditions: Buffer.from([0x01, 0xf5]),
       fee_rate: BigInt(1234),
       sponsored: false,
-      sender_address: 'sender-addr',
+      sender_address: 'addrA',
       origin_hash_mode: 1,
+    };
+    const tx2 = {
+      ...tx,
+      tx_id: '0x2345',
+      fee_rate: BigInt(100),
     };
     const createStxEvent = (
       sender: string,
@@ -112,6 +117,8 @@ describe('postgres datastore', () => {
     for (const event of events) {
       await db.updateStxEvent(client, tx, event);
     }
+    await db.updateTx(client, tx);
+    await db.updateTx(client, tx2);
 
     const addrAResult = await db.getStxBalance('addrA');
     const addrBResult = await db.getStxBalance('addrB');
@@ -119,7 +126,7 @@ describe('postgres datastore', () => {
     const addrDResult = await db.getStxBalance('addrD');
 
     expect(addrAResult).toEqual({
-      balance: BigInt(99615),
+      balance: BigInt(98281),
       totalReceived: BigInt(100000),
       totalSent: BigInt(385),
     });


### PR DESCRIPTION
Fixed bug where address STX balance value was not taking fees into account.

Also added a new API for STX-only wallets which doesn't perform queries on FTs/NFTs: `/extended/v1/address/{principal}/stx`