### PR TITLE
rosetta api: base

### DIFF
--- a/rosetta-cli-config/bootstrap_balances.json
+++ b/rosetta-cli-config/bootstrap_balances.json
@@ -1,0 +1,42 @@
+[
+  {
+    "account_identifier": {
+      "address": "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
+    },
+    "currency": {
+      "symbol": "STX",
+      "decimals": 6
+    },
+    "value": "10000000000000000"
+  },
+  {
+    "account_identifier": {
+      "address": "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
+    },
+    "currency": {
+      "symbol": "STX",
+      "decimals": 6
+    },
+    "value": "10000000000000000"
+  },
+  {
+    "account_identifier": {
+      "address": "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
+    },
+    "currency": {
+      "symbol": "STX",
+      "decimals": 6
+    },
+    "value": "10000000000000000"
+  },
+  {
+    "account_identifier": {
+      "address": "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
+    },
+    "currency": {
+      "symbol": "STX",
+      "decimals": 6
+    },
+    "value": "10000000000000000"
+  }
+]

--- a/rosetta-cli-config/exempt_accounts.json
+++ b/rosetta-cli-config/exempt_accounts.json
@@ -1,0 +1,20 @@
+[
+  {
+    "account_identifier": {
+      "address": "STF9B75ADQAVXQHNEQ6KGHXTG7JP305J2GRWF3A2"
+    },
+    "currency": {
+      "symbol": "STX",
+      "decimals": 6
+    }
+  },
+  {
+    "account_identifier": {
+      "address": "ST18MDW2PDTBSCR1ACXYRJP2JX70FWNM6YY2VX4SS"
+    },
+    "currency": {
+      "symbol": "STX",
+      "decimals": 6
+    }
+  }
+]

--- a/rosetta-cli-config/rosetta-config.json
+++ b/rosetta-cli-config/rosetta-config.json
@@ -1,0 +1,92 @@
+{
+  "network": {
+    "blockchain": "stacks",
+    "network": "testnet"
+  },
+  "online_url": "http://localhost:3999/rosetta/v1",
+  "data_directory": "",
+  "http_timeout": 10,
+  "sync_concurrency": 8,
+  "transaction_concurrency": 16,
+  "tip_delay": 300,
+  "data": {
+    "active_reconciliation_concurrency": 16,
+    "inactive_reconciliation_concurrency": 4,
+    "inactive_reconciliation_frequency": 250,
+    "log_blocks": true,
+    "log_transactions": true,
+    "log_balance_changes": true,
+    "log_reconciliations": false,
+    "ignore_reconciliation_error": false,
+    "exempt_accounts": "rosetta-cli-config/exempt_accounts.json",
+    "bootstrap_balances": "rosetta-cli-config/bootstrap_balances.json",
+    "historical_balance_disabled": true,
+    "interesting_accounts": "",
+    "reconciliation_disabled": false,
+    "inactive_discrepency_search_disabled": false,
+    "balance_tracking_disabled": false
+  },
+  "construction": {
+    "offline_url": "http://localhost:3999/rosetta/v1",
+    "currency": {
+      "symbol": "STX",
+      "decimals": 6
+    },
+    "minimum_balance": "0",
+    "maximum_fee": "10000000000000000",
+    "curve_type": "secp256k1",
+    "accounting_model": "account",
+    "scenario": [
+      {
+        "operation_identifier": {
+          "index": 0
+        },
+        "type": "NATIVE_TRANSFER",
+        "status": "",
+        "account": {
+          "address": "{{ SENDER }}"
+        },
+        "amount": {
+          "value": "{{ SENDER_VALUE }}",
+          "currency": {
+            "symbol": "STX",
+            "decimals": 6
+          }
+        }
+      },
+      {
+        "operation_identifier": {
+          "index": 1
+        },
+        "related_operations": [
+          {
+            "index": 0
+          }
+        ],
+        "type": "NATIVE_TRANSFER",
+        "status": "",
+        "account": {
+          "address": "{{ RECIPIENT }}"
+        },
+        "amount": {
+          "value": "{{ RECIPIENT_VALUE }}",
+          "currency": {
+            "symbol": "STX",
+            "decimals": 6
+          }
+        }
+      }
+    ],
+    "confirmation_depth": 5,
+    "stale_depth": 30,
+    "broadcast_limit": 3,
+    "ignore_broadcast_failures": false,
+    "change_scenario": null,
+    "clear_broadcasts": false,
+    "broadcast_behind_tip": false,
+    "block_broadcast_limit": 5,
+    "rebroadcast_all": false,
+    "new_account_probability": 0.5,
+    "max_addresses": 200
+  }
+}

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -17,10 +17,10 @@ import { createBlockRouter } from './routes/block';
 import { createFaucetRouter } from './routes/faucets';
 import { createAddressRouter } from './routes/address';
 import { createSearchRouter } from './routes/search';
-import { createRNetworkRouter } from './routes/rosetta/network';
-import { createRMempoolRouter } from './routes/rosetta/mempool';
-import { createRBlockRouter } from './routes/rosetta/block';
-import { createRAccountRouter } from './routes/rosetta/account';
+import { createRosettaNetworkRouter } from './routes/rosetta/network';
+import { createRosettaMempoolRouter } from './routes/rosetta/mempool';
+import { createRosettaBlockRouter } from './routes/rosetta/block';
+import { createRosettaAccountRouter } from './routes/rosetta/account';
 import { logger } from '../helpers';
 import { createWsRpcRouter } from './routes/ws-rpc';
 
@@ -91,10 +91,10 @@ export async function startApiServer(datastore: DataStore): Promise<ApiServer> {
     (() => {
       const router = addAsync(express.Router());
       router.use(cors());
-      router.use('/network', createRNetworkRouter(datastore));
-      router.use('/mempool', createRMempoolRouter(datastore));
-      router.use('/block', createRBlockRouter(datastore));
-      router.use('/account', createRAccountRouter(datastore));
+      router.use('/network', createRosettaNetworkRouter(datastore));
+      router.use('/mempool', createRosettaMempoolRouter(datastore));
+      router.use('/block', createRosettaBlockRouter(datastore));
+      router.use('/account', createRosettaAccountRouter(datastore));
       return router;
     })()
   );

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -100,11 +100,10 @@ export async function startApiServer(datastore: DataStore): Promise<ApiServer> {
   );
 
   // Validation middleware for Rosetta API
-  app.use('/rosetta/v1', async (req, res, next) => {
+  app.use('/rosetta/v1', (req, res, next) => {
     // await validateRequest(req.originalUrl, req.body);
     next();
   });
-
 
   // Setup error handler (must be added at the end of the middleware stack)
   app.use(((error, req, res, next) => {

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -1,0 +1,124 @@
+export const RosettaConstants = {
+  blockchain: 'stacks',
+  network: 'testnet',
+  rosettaVersion: '1.4.2',
+  symbol: 'STX',
+  decimals: 6,
+};
+
+export const RosettaOperationTypes = [
+  'token_transfer',
+  'contract_call',
+  'smart_contract',
+  'coinbase',
+  'poison_microblock',
+  'fee',
+];
+
+export const RosettaOperationStatuses = [
+  {
+    status: 'success',
+    successful: true,
+  },
+  {
+    status: 'pending',
+    successful: true,
+  },
+  {
+    status: 'abort_by_response',
+    successful: false,
+  },
+  {
+    status: 'abort_by_post_condition',
+    successful: false,
+  },
+];
+
+// All possible errors
+export const RosettaErrors = {
+  invalidAccount: {
+    code: 601,
+    message: 'Invalid Account',
+    retriable: true,
+  },
+  insufficientFunds: {
+    code: 602,
+    message: 'Insufficient Funds',
+    retriable: true,
+  },
+  accountEmpty: {
+    code: 603,
+    message: 'Account is empty',
+    retriable: true,
+  },
+  invalidBlockIndex: {
+    code: 604,
+    message: 'Invalid block index',
+    retriable: true,
+  },
+  blockNotFound: {
+    code: 605,
+    message: 'Block not found',
+    retriable: true,
+  },
+  invalidBlockHash: {
+    code: 606,
+    message: 'Invalid block hash',
+    retriable: true,
+  },
+  transactionNotFound: {
+    code: 607,
+    message: 'Transaction not found',
+    retriable: true,
+  },
+  invalidTransactionHash: {
+    code: 608,
+    message: 'Invalid transaction hash',
+    retriable: true,
+  },
+  invalidParams: {
+    code: 609,
+    message: 'invalid params',
+    retriable: true,
+  },
+  invalidNetwork: {
+    code: 610,
+    message: 'Invalid network.',
+    retriable: true,
+  },
+  invalidBlockchain: {
+    code: 611,
+    message: 'Invalid blockchain.',
+    retriable: true,
+  },
+  unknownError: {
+    code: 612,
+    message: 'Unknown error.',
+    retriable: false,
+  },
+  emptyNetworkIdentifier: {
+    code: 613,
+    message: 'Network identifier object is null',
+    retriable: true,
+  },
+  emptyAccountIdentifier: {
+    code: 614,
+    message: 'Account identifier object is null',
+    retriable: true,
+  },
+  invalidBlockIdentifier: {
+    code: 615,
+    message: 'Block identifier is null',
+    retriable: true,
+  },
+  emptyBlockchain: {
+    code: 616,
+    message: 'Blockchain name is null',
+    retriable: true,
+  },
+  emptyNetwork: {
+    code: 617,
+    message: 'Network name is null',
+    retriable: true,
+  },
+};

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -6,9 +6,9 @@ export function createRAccountRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
   router.use(express.json());
 
-  router.postAsync('/balance', async (req, res) => {
-    res.json({status: 'ready'});
+  router.post('/balance', (req, res) => {
+    res.json({ status: 'ready' });
   });
 
   return router;
-};
+}

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -1,0 +1,14 @@
+import * as express from 'express';
+import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { DataStore } from '../../../datastore/common';
+
+export function createRAccountRouter(db: DataStore): RouterWithAsync {
+  const router = addAsync(express.Router());
+  router.use(express.json());
+
+  router.postAsync('/balance', async (req, res) => {
+    res.json({status: 'ready'});
+  });
+
+  return router;
+};

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import { DataStore } from '../../../datastore/common';
 
-export function createRAccountRouter(db: DataStore): RouterWithAsync {
+export function createRosettaAccountRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
   router.use(express.json());
 

--- a/src/api/routes/rosetta/block.ts
+++ b/src/api/routes/rosetta/block.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import { DataStore } from '../../../datastore/common';
 
-export function createRBlockRouter(db: DataStore): RouterWithAsync {
+export function createRosettaBlockRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
 
   router.post('/', (req, res) => {

--- a/src/api/routes/rosetta/block.ts
+++ b/src/api/routes/rosetta/block.ts
@@ -1,0 +1,17 @@
+import * as express from 'express';
+import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { DataStore } from '../../../datastore/common';
+
+export function createRBlockRouter(db: DataStore): RouterWithAsync {
+  const router = addAsync(express.Router());
+
+  router.postAsync('/', async (req, res) => {
+    res.json({status: 'ready'});
+  });
+
+  router.postAsync('/transaction', async (req, res) => {
+    res.json({status: 'ready'});
+  });
+
+  return router;
+};

--- a/src/api/routes/rosetta/block.ts
+++ b/src/api/routes/rosetta/block.ts
@@ -5,13 +5,13 @@ import { DataStore } from '../../../datastore/common';
 export function createRBlockRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
 
-  router.postAsync('/', async (req, res) => {
-    res.json({status: 'ready'});
+  router.post('/', (req, res) => {
+    res.json({ status: 'ready' });
   });
 
-  router.postAsync('/transaction', async (req, res) => {
-    res.json({status: 'ready'});
+  router.post('/transaction', (req, res) => {
+    res.json({ status: 'ready' });
   });
 
   return router;
-};
+}

--- a/src/api/routes/rosetta/mempool.ts
+++ b/src/api/routes/rosetta/mempool.ts
@@ -1,0 +1,17 @@
+import * as express from 'express';
+import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { DataStore } from '../../../datastore/common';
+
+export function createRMempoolRouter(db: DataStore): RouterWithAsync {
+  const router = addAsync(express.Router());
+
+  router.postAsync('/', async (req, res) => {
+    res.json({status: 'ready'});
+  });
+
+  router.postAsync('/transaction', async (req, res) => {
+    res.json({status: 'ready'});
+  });
+
+  return router;
+};

--- a/src/api/routes/rosetta/mempool.ts
+++ b/src/api/routes/rosetta/mempool.ts
@@ -5,13 +5,13 @@ import { DataStore } from '../../../datastore/common';
 export function createRMempoolRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
 
-  router.postAsync('/', async (req, res) => {
-    res.json({status: 'ready'});
+  router.post('/', (req, res) => {
+    res.json({ status: 'ready' });
   });
 
-  router.postAsync('/transaction', async (req, res) => {
-    res.json({status: 'ready'});
+  router.post('/transaction', (req, res) => {
+    res.json({ status: 'ready' });
   });
 
   return router;
-};
+}

--- a/src/api/routes/rosetta/mempool.ts
+++ b/src/api/routes/rosetta/mempool.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import { DataStore } from '../../../datastore/common';
 
-export function createRMempoolRouter(db: DataStore): RouterWithAsync {
+export function createRosettaMempoolRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
 
   router.post('/', (req, res) => {

--- a/src/api/routes/rosetta/network.ts
+++ b/src/api/routes/rosetta/network.ts
@@ -7,6 +7,7 @@ import {
   RosettaOperationStatuses,
   RosettaErrors,
 } from '../../rosetta-constants';
+const middleware_version = require('../../../../package.json').version;
 
 export function createRNetworkRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
@@ -33,7 +34,7 @@ export function createRNetworkRouter(db: DataStore): RouterWithAsync {
       version: {
         rosetta_version: RosettaConstants.rosettaVersion,
         node_version: process.version,
-        middleware_version: process.env.npm_package_version,
+        middleware_version: middleware_version,
       },
       allow: {
         operation_statuses: RosettaOperationStatuses,

--- a/src/api/routes/rosetta/network.ts
+++ b/src/api/routes/rosetta/network.ts
@@ -1,21 +1,50 @@
 import * as express from 'express';
 import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import { DataStore } from '../../../datastore/common';
+import {
+  RosettaConstants,
+  RosettaOperationTypes,
+  RosettaOperationStatuses,
+  RosettaErrors,
+} from '../../rosetta-constants';
 
 export function createRNetworkRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
 
-  router.postAsync('/list', async (req, res) => {
-    res.json({status: 'ready'});
+  router.postAsync('/list', async (_req, res) => {
+    const response = {
+      network_identifiers: [
+        {
+          blockchain: RosettaConstants.blockchain,
+          network: RosettaConstants.network,
+        },
+      ],
+    };
+
+    res.json(response);
   });
 
   router.postAsync('/status', async (req, res) => {
     res.json({status: 'ready'});
   });
 
-  router.postAsync('/options', async (req, res) => {
-    res.json({status: 'ready'});
+  router.postAsync('/options', async (_req, res) => {
+    const response = {
+      version: {
+        rosetta_version: RosettaConstants.rosettaVersion,
+        node_version: process.version,
+        middleware_version: process.env.npm_package_version,
+      },
+      allow: {
+        operation_statuses: RosettaOperationStatuses,
+        operation_types: RosettaOperationTypes,
+        errors: Object.values(RosettaErrors),
+        historical_balance_lookup: true,
+      },
+    };
+
+    res.json(response);
   });
 
   return router;
-};
+}

--- a/src/api/routes/rosetta/network.ts
+++ b/src/api/routes/rosetta/network.ts
@@ -9,7 +9,7 @@ import {
 } from '../../rosetta-constants';
 const middleware_version = require('../../../../package.json').version;
 
-export function createRNetworkRouter(db: DataStore): RouterWithAsync {
+export function createRosettaNetworkRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
 
   router.post('/list', (_req, res) => {

--- a/src/api/routes/rosetta/network.ts
+++ b/src/api/routes/rosetta/network.ts
@@ -1,0 +1,21 @@
+import * as express from 'express';
+import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { DataStore } from '../../../datastore/common';
+
+export function createRNetworkRouter(db: DataStore): RouterWithAsync {
+  const router = addAsync(express.Router());
+
+  router.postAsync('/list', async (req, res) => {
+    res.json({status: 'ready'});
+  });
+
+  router.postAsync('/status', async (req, res) => {
+    res.json({status: 'ready'});
+  });
+
+  router.postAsync('/options', async (req, res) => {
+    res.json({status: 'ready'});
+  });
+
+  return router;
+};

--- a/src/api/routes/rosetta/network.ts
+++ b/src/api/routes/rosetta/network.ts
@@ -11,7 +11,7 @@ import {
 export function createRNetworkRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
 
-  router.postAsync('/list', async (_req, res) => {
+  router.post('/list', (_req, res) => {
     const response = {
       network_identifiers: [
         {
@@ -24,11 +24,11 @@ export function createRNetworkRouter(db: DataStore): RouterWithAsync {
     res.json(response);
   });
 
-  router.postAsync('/status', async (req, res) => {
-    res.json({status: 'ready'});
+  router.post('/status', (req, res) => {
+    res.json({ status: 'ready' });
   });
 
-  router.postAsync('/options', async (_req, res) => {
+  router.post('/options', (_req, res) => {
     const response = {
       version: {
         rosetta_version: RosettaConstants.rosettaVersion,


### PR DESCRIPTION
This PR contains the implementation for two Rosetta API endpoints -- `/network/list` and `/network/options` -- and stubs for the others.

`/network/status` is not included in this PR because it requires several changes to the datastore interface, and to the postgres and memory store implementations.

Type information is not present because that requires a large number of entity/schema files.  That's in the next pull request.

The rosetta config files are included, and `rosetta-cli --configuration-file rosetta-cli-config/rosetta-config.json view:networks` can test the implemented endpoints.