### PR TITLE
Self contained follower

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 lib/**
 coverage/**
 ./tmp/**
+**/*.Dockerfile

--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -169,6 +169,19 @@ jobs:
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
           push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
 
+      - name: Build/Tag/Push standalone Image
+        uses: docker/build-push-action@v1
+        with:
+          dockerfile: follower.Dockerfile
+          repository: blockstack/${{ github.workflow }}-standalone
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          tags: ${{ steps.semantic.outputs.new_release_version }}
+          tag_with_ref: true
+          add_git_labels: true
+          # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
+          push: ${{ (github.ref != 'refs/heads/master' || steps.semantic.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+
   notify-end:
     runs-on: ubuntu-latest
     needs:

--- a/docker-compose.dev.stacks-blockchain-follower.yml
+++ b/docker-compose.dev.stacks-blockchain-follower.yml
@@ -1,0 +1,16 @@
+version: '3.7'
+services:
+  stacks-blockchain:
+    build:
+      context: ./stacks-blockchain/docker
+    command: stacks-node start --config=/app/config/Stacks-follower.toml
+    restart: on-failure
+    environment:
+      STACKS_EVENT_OBSERVER: host.docker.internal:3700
+      NOP_BLOCKSTACK_DEBUG: 1
+    ports:
+      - "20443:20443"
+      - "20444:20444"
+    volumes:
+      - ./stacks-blockchain/:/app/config
+      - ./stacks-blockchain/.chaindata:/tmp/stacks-blockchain-data

--- a/docker-compose.dev.stacks-blockchain.yml
+++ b/docker-compose.dev.stacks-blockchain.yml
@@ -6,7 +6,7 @@ services:
     command: stacks-node start --config=/app/config/Stacks-dev.toml
     restart: on-failure
     environment:
-      STACKS_EVENT_OBSERVER: http://host.docker.internal:3700/
+      STACKS_EVENT_OBSERVER: host.docker.internal:3700
       NOP_BLOCKSTACK_DEBUG: 1
     ports:
       - "20443:20443"

--- a/docker-compose.follower.yml
+++ b/docker-compose.follower.yml
@@ -1,4 +1,0 @@
-version: '3.7'
-services:
-  stacks-blockchain:
-    command: stacks-node argon

--- a/docker-compose.follower.yml
+++ b/docker-compose.follower.yml
@@ -1,0 +1,4 @@
+version: '3.7'
+services:
+  stacks-blockchain:
+    command: stacks-node argon

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     command: stacks-node start --config=/app/config/Stacks-follower.toml
     restart: on-failure
     environment:
-      STACKS_EVENT_OBSERVER: http://stacks-blockchain-api:3700/
+      STACKS_EVENT_OBSERVER: stacks-blockchain-api:3700
       XBLOCKSTACK_DEBUG: 1
       RUST_BACKTRACE: 1
     ports:

--- a/follower.Dockerfile
+++ b/follower.Dockerfile
@@ -23,7 +23,7 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update
 
 ### Install utils
-RUN apt-get install -y sudo curl
+RUN apt-get install -y sudo curl pslist
 
 ### Set noninteractive apt-get
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
@@ -106,7 +106,7 @@ do\n\
   stacks_node_pid=$!\n\
   wait $stacks_node_pid\n\
   echo "node exit, restarting..."\n\
-  kill -9 $stacks_api_pid\n\
+  rkill -9 $stacks_api_pid\n\
   pg_stop\n\
   rm -rf $PGDATA\n\
   sleep 5\n\

--- a/follower.Dockerfile
+++ b/follower.Dockerfile
@@ -1,0 +1,95 @@
+FROM node:13.14.0-buster as build
+WORKDIR /app
+COPY . .
+RUN echo "GIT_TAG=$(git tag --points-at HEAD)" >> .env
+RUN npm install
+RUN npm run build
+RUN npm prune --production
+
+### Fetch stacks-node binary
+FROM everpeace/curl-jq as stacks-node-build
+ENV ARTIFACTS "http://blockstack-stacks-blockchain_artifacts.storage.googleapis.com/index.json"
+RUN curl -s "$ARTIFACTS" --output ./artifacts-resp.json \
+  && cat ./artifacts-resp.json | jq -r '."stacks-node"."linux-x64-test".latest.url' > ./url \
+  && mkdir -p /app \
+  && echo "Fetching $(cat ./url)" \
+  && curl --compressed $(cat ./url) --output /stacks-node \
+  && chmod +x /stacks-node
+
+FROM ubuntu:focal
+
+ENV SHELL /bin/bash
+
+RUN apt-get update
+
+### Install utils
+RUN apt-get install -y sudo curl
+
+### Set noninteractive apt-get
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+## apt-get clear cache
+# RUN apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/* /tmp/*
+
+### stacky user ###
+# '-l': see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+RUN useradd -l -u 33333 -G sudo -md /home/stacky -s /bin/bash -p stacky stacky \
+    # passwordless sudo for users in the 'sudo' group
+    && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
+ENV HOME=/home/stacky
+WORKDIR $HOME
+# custom Bash prompt
+# RUN { echo && echo "PS1='\[\e]0;\u \w\a\]\[\033[01;32m\]\u\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\] \\\$ '" ; } >> .bashrc
+
+### stacky user (2) ###
+USER stacky
+RUN sudo chown -R stacky:stacky $HOME
+# use sudo so that user does not get sudo usage info on (the first) login
+RUN sudo echo "Running 'sudo' for stacky: success" && \
+  # create .bashrc.d folder and source it in the bashrc
+  mkdir /home/stacky/.bashrc.d
+  # && \
+  # (echo; echo "for i in \$(ls \$HOME/.bashrc.d/*); do source \$i; done"; echo) >> /home/stacky/.bashrc
+
+### Node.js
+ENV NODE_VERSION=13.14.0
+RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash \
+    && bash -c ". .nvm/nvm.sh \
+        && nvm install $NODE_VERSION \
+        && nvm alias default $NODE_VERSION"
+ENV PATH=$PATH:/home/stacky/.nvm/versions/node/v${NODE_VERSION}/bin
+RUN node -e 'console.log("Node.js runs")'
+
+### Setup stacks-node
+COPY --from=stacks-node-build /stacks-node stacks-node
+
+### Setup stacks-blockchain-api
+COPY --from=build /app stacks-blockchain-api
+RUN sudo chown -Rh stacky:stacky stacks-blockchain-api
+RUN printf '#!/bin/bash\ncd $(dirname $0)\nnpm run start\n' > stacks-blockchain-api/start \
+  && chmod +x stacks-blockchain-api/start
+
+
+### Install Postgres
+RUN sudo apt-get install -y postgresql-12 postgresql-contrib-12
+
+### Setup Postgres
+# Borrowed from https://github.com/gitpod-io/workspace-images/blob/master/postgres/Dockerfile
+ENV PATH="$PATH:/usr/lib/postgresql/12/bin"
+ENV PGDATA="/home/stacky/.pgsql/data"
+RUN mkdir -p ~/.pg_ctl/bin ~/.pg_ctl/sockets \
+  && printf '#!/bin/bash\n[ ! -d $PGDATA ] && mkdir -p $PGDATA && initdb -D $PGDATA\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" start\n' > ~/.pg_ctl/bin/pg_start \
+  && printf '#!/bin/bash\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" stop\n' > ~/.pg_ctl/bin/pg_stop \
+  && chmod +x ~/.pg_ctl/bin/*
+ENV PATH="$PATH:$HOME/.pg_ctl/bin"
+ENV DATABASE_URL="postgresql://stacky@localhost"
+ENV PGHOSTADDR="127.0.0.1"
+ENV PGDATABASE="postgres"
+
+# This is a bit of a hack. At the moment we have no means of starting background
+# tasks from a Dockerfile. This workaround checks, on each bashrc eval, if the
+# PostgreSQL server is running, and if not starts it.
+RUN printf "\n# Auto-start PostgreSQL server.\n[[ \$(pg_ctl status | grep PID) ]] || pg_start > /dev/null\n" >> ~/.bashrc
+
+
+

--- a/follower.Dockerfile
+++ b/follower.Dockerfile
@@ -74,7 +74,7 @@ RUN mkdir -p ~/.pg_ctl/bin ~/.pg_ctl/sockets \
 ENV PATH="$PATH:$HOME/.pg_ctl/bin"
 
 ### Clear caches
-RUN apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/* /tmp/*
+RUN sudo apt-get clean && sudo rm -rf /var/cache/apt/* /var/lib/apt/lists/* /tmp/*
 
 ### Setup service env vars
 ENV PG_HOST=127.0.0.1
@@ -89,7 +89,7 @@ ENV STACKS_CORE_EVENT_HOST=127.0.0.1
 ENV STACKS_EVENT_OBSERVER=127.0.0.1:3700
 
 ENV STACKS_BLOCKCHAIN_API_PORT=3999
-ENV STACKS_BLOCKCHAIN_API_HOST=127.0.0.1
+ENV STACKS_BLOCKCHAIN_API_HOST=0.0.0.0
 
 ENV STACKS_CORE_RPC_HOST=127.0.0.1
 ENV STACKS_CORE_RPC_PORT=20443

--- a/follower.Dockerfile
+++ b/follower.Dockerfile
@@ -1,10 +1,13 @@
+### Build blockstack-core-sidecar API
 FROM node:13.14.0-buster as build
 WORKDIR /app
 COPY . .
+RUN apt-get update && apt-get install -y openjdk-11-jre-headless
 RUN echo "GIT_TAG=$(git tag --points-at HEAD)" >> .env
 RUN npm install
 RUN npm run build
 RUN npm prune --production
+
 
 ### Fetch stacks-node binary
 FROM everpeace/curl-jq as stacks-node-build
@@ -16,13 +19,14 @@ RUN curl -s "$ARTIFACTS" --output ./artifacts-resp.json \
   && curl --compressed $(cat ./url) --output /stacks-node \
   && chmod +x /stacks-node
 
+
+### Begin building base image
 FROM ubuntu:focal
 
 SHELL ["/bin/bash", "-c"]
 
-RUN apt-get update
-
 ### Install utils
+RUN apt-get update
 RUN apt-get install -y sudo curl pslist
 
 ### Set noninteractive apt-get

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.1",
     "@awaitjs/express": "^0.5.1",
     "@blockstack/stacks-blockchain-api-types": "file:docs",
-    "@blockstack/stacks-transactions": "github:blockstack/stacks-transactions-js#fce7593c5df26331ff56b86fbbc5d96bbca965c8",
+    "@blockstack/stacks-transactions": "0.6.0-beta.1",
     "@types/express-list-endpoints": "^4.0.1",
     "@types/ws": "^7.2.5",
     "big-integer": "^1.6.48",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "cross-env NODE_ENV=development STACKS_BLOCKCHAIN_API_DB=pg ts-node src/index.ts",
     "dev:watch": "cross-env NODE_ENV=development STACKS_BLOCKCHAIN_API_DB=pg nodemon -e ts -x 'ts-node src/index.ts'",
     "dev:integrated": "npm run devenv:build && concurrently npm:dev npm:devenv:deploy",
+    "dev:follower": "npm run devenv:build && concurrently npm:dev npm:devenv:follower",
     "test": "cross-env NODE_ENV=development jest --config ./jest.config.js --coverage --runInBand",
     "test:watch": "cross-env NODE_ENV=development jest --config ./jest.config.js --watch",
     "test:integration": "npm run devenv:deploy -- -d && cross-env NODE_ENV=development jest --config ./jest.config.js --coverage --no-cache --runInBand; npm run devenv:stop",
@@ -18,6 +19,7 @@
     "migrate": "node-pg-migrate -m src/migrations",
     "devenv:build": "docker-compose -f docker-compose.dev.postgres.yml -f docker-compose.dev.stacks-blockchain.yml -f docker-compose.dev.bitcoind.yml build --no-cache",
     "devenv:deploy": "docker-compose -f docker-compose.dev.postgres.yml -f docker-compose.dev.stacks-blockchain.yml -f docker-compose.dev.bitcoind.yml up",
+    "devenv:follower": "docker-compose -f docker-compose.dev.postgres.yml -f docker-compose.dev.stacks-blockchain-follower.yml up",
     "devenv:stop": "docker-compose -f docker-compose.dev.postgres.yml -f docker-compose.dev.stacks-blockchain.yml -f docker-compose.dev.bitcoind.yml down -v -t 0",
     "devenv:logs": "docker-compose -f docker-compose.dev.postgres.yml -f docker-compose.dev.stacks-blockchain.yml -f docker-compose.dev.bitcoind.yml logs -t -f"
   },

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,20 @@
 
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/blockstack/stacks-blockchain-api)
 
-## Quick Start
+## Quick start
+
+A self-contained Docker image is provided which will start a Stacks 2.0 blockchain and API testnet.
+
+Ensure Docker is installed, then run the command:
+
+```
+docker run -p 3999:3999 <docker image TBD>
+```
+
+Once the blockchain has synced with network, the API will be available at:
+[http://localhost:3999](http://localhost:3999)
+
+## Development quick start
 
 First, ensure Docker is installed on your machine. 
 

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ A self-contained Docker image is provided which will start a Stacks 2.0 blockcha
 Ensure Docker is installed, then run the command:
 
 ```
-docker run -p 3999:3999 <docker image TBD>
+docker run -p 3999:3999 blockstack/stacks-blockchain-api-standalone
 ```
 
 Once the blockchain has synced with network, the API will be available at:

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -746,7 +746,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       } finally {
         client.end(() => {});
       }
-    } while (initTimer.getElapsed() < 10000);
+    } while (initTimer.getElapsed() < 30000);
     if (!connectionOkay) {
       connectionError = connectionError ?? new Error('Error connecting to database');
       throw connectionError;

--- a/stacks-blockchain/Stacks-follower.toml
+++ b/stacks-blockchain/Stacks-follower.toml
@@ -1,14 +1,15 @@
 [node]
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
-bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@35.245.47.179:20444"
+bootstrap_node = "048dd4f26101715853533dee005f0915375854fd5be73405f679c1917a5d4d16aaaf3c4c0d7a9c132a36b8c5fe1287f07dad8c910174d789eb24bdfb5ae26f5f27@argon-master.blockstack.xyz:20444"
 
 [burnchain]
 chain = "bitcoin"
-mode = "neon"
-peer_host = "35.245.47.179"
+mode = "argon"
+peer_host = "argon.blockstack.org"
 rpc_port = 18443
 peer_port = 18444
+process_exit_at_block_height = 28160
 
 [[mstx_balance]]
 address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"

--- a/stacks-blockchain/dist-tool/index.js
+++ b/stacks-blockchain/dist-tool/index.js
@@ -18,7 +18,7 @@ const envVars = {
   STACKS_BLOCKCHAIN_REPO: 'https://github.com/blockstack/stacks-blockchain.git',
   STACKS_BLOCKCHAIN_BRANCH: 'master',
   STACKS_BLOCKCHAIN_BIN: 'stacks-node',
-  STACKS_BLOCKCHAIN_DIST_PLATFORM: 'linux-x64',
+  STACKS_BLOCKCHAIN_DIST_PLATFORM: 'linux-x64-test',
 };
 Object.entries(envVars).forEach(([key, val]) => envVars[key] = process.env[key] || val);
 

--- a/stacks-blockchain/docker/Dockerfile
+++ b/stacks-blockchain/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM everpeace/curl-jq as build
 ENV ARTIFACTS "http://blockstack-stacks-blockchain_artifacts.storage.googleapis.com/index.json"
 
 RUN curl -s "$ARTIFACTS" --output ./artifacts-resp.json \
-  && cat ./artifacts-resp.json | jq -r '."stacks-node"."linux-x64".latest.url' > ./url \
+  && cat ./artifacts-resp.json | jq -r '."stacks-node"."linux-x64-test".latest.url' > ./url \
   && mkdir -p /app \
   && echo "Fetching $(cat ./url)" \
   && curl --compressed $(cat ./url) --output /bin/stacks-node \


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/184

A self-contained Docker image which will start a Stacks 2.0 blockchain and API testnet.

```
docker run -p 3999:3999 blockstack/stacks-blockchain-api-standalone
```

Once the blockchain has synced with network, the API will be available at:
[http://localhost:3999](http://localhost:3999)

When the core-node exits (due to chain reset or any other reason), the API service and postgres is stopped, data is wiped, and the whole thing is restarted. This behavior can be tested by entering shell for a running image and killing the `stacks-node` process e.g. `pkill -9 stacks-node`