### PR TITLE
rosetta: rest of the data api endpoints

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,5 @@
 gulpfile.js
-jest.config.js
+jest.config*.js
 migrations/
 coverage/
 .tmp/

--- a/.github/workflows/stacks-blockchain-api.yml
+++ b/.github/workflows/stacks-blockchain-api.yml
@@ -129,10 +129,46 @@ jobs:
         uses: codecov/codecov-action@v1
         if: always()
 
+  test-rosetta:
+     runs-on: ubuntu-latest
+     steps:
+       - uses: actions/checkout@v2
+
+       - name: Use Node.js
+         uses: actions/setup-node@v1
+         with:
+           node-version: '13.x'
+
+       - name: Install deps
+         run: npm install
+
+       - name: Setup integration environment
+         run: |
+           sudo ufw disable
+           echo "::set-env name=STACKS_CORE_EVENT_HOST::http://0.0.0.0"
+           npm run devenv:deploy -- -d
+           npm run devenv:logs -- --no-color &> docker-compose-logs.txt &
+
+       - name: Run tests
+         run: npm run test:rosetta
+
+       - name: Print integration environment logs
+         run: cat docker-compose-logs.txt
+         if: failure()
+
+       - name: Teardown integration environment
+         run: npm run devenv:stop
+         if: always()
+
+       - name: Upload coverage to Codecov
+         uses: codecov/codecov-action@v1
+         if: always()
+
   build-publish:
     runs-on: ubuntu-latest
     needs:
       - test
+      - test-rosetta
       - lint
       - lint-docs
     steps:
@@ -189,6 +225,7 @@ jobs:
       - lint
       - lint-docs
       - test
+      - test-rosetta
       - build-publish
     # Only run on non-PR events or only PRs that aren't from forks 
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,9 +9,7 @@
       "request": "launch",
       "name": "stacks-blockchain dist-tool",
       "program": "${workspaceFolder}/stacks-blockchain/dist-tool/index.js",
-      "skipFiles": [
-        "<node_internals>/**"
-      ],
+      "skipFiles": ["<node_internals>/**"],
       "env": {
         "STACKS_BLOCKCHAIN_BRANCH": "feature/event-observer-envvar"
       }
@@ -43,7 +41,7 @@
       "env": {
         "STACKS_BLOCKCHAIN_API_DB": "pg",
         "NODE_ENV": "development",
-        "TS_NODE_SKIP_IGNORE": "true",
+        "TS_NODE_SKIP_IGNORE": "true"
       }
     },
     {
@@ -61,7 +59,24 @@
       "outputCapture": "std",
       "console": "integratedTerminal",
       "preLaunchTask": "stacks-node:deploy-dev",
-      "postDebugTask": "stacks-node:stop-dev",
+      "postDebugTask": "stacks-node:stop-dev"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest: Rosetta",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": [
+        "--testTimeout=3600000",
+        "--runInBand",
+        "--no-cache",
+        "--config",
+        "${workspaceRoot}/jest.config.rosetta.js"
+      ],
+      "outputCapture": "std",
+      "console": "integratedTerminal",
+      "preLaunchTask": "stacks-node:deploy-dev",
+      "postDebugTask": "stacks-node:stop-dev"
     },
     {
       "type": "node",
@@ -76,6 +91,6 @@
         "NODE_ENV": "development",
         "TS_NODE_SKIP_IGNORE": "true"
       }
-    },
+    }
   ]
 }

--- a/docs/api/rosetta/rosetta-block-request.schema.json
+++ b/docs/api/rosetta/rosetta-block-request.schema.json
@@ -4,7 +4,7 @@
   "type": "object",
   "title": "RosettaBlockRequest",
   "description": "A BlockRequest is utilized to make a block request on the /block endpoint.",
-  "required": ["network_identifier", "block_identifier"],
+  "required": ["network_identifier"],
   "properties": {
     "network_identifier": {
       "$ref": "./../../entities/rosetta/rosetta-network-identifier.schema.json"

--- a/docs/entities/rosetta/rosetta-block-identifier-hash.schema.json
+++ b/docs/entities/rosetta/rosetta-block-identifier-hash.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "rosetta-block-identifier-hash.schema.json",
+  "type": "object",
+  "title": "RosettaBlockIdentifierHash",
+  "description": "This is also known as the block hash.",
+  "properties": {
+    "hash": {
+      "type": "string",
+      "description": "This is also known as the block hash."
+    }
+  }
+}

--- a/docs/entities/rosetta/rosetta-block-identifier-height.schema.json
+++ b/docs/entities/rosetta/rosetta-block-identifier-height.schema.json
@@ -1,0 +1,12 @@
+{
+  "$id": "rosetta-block-identifier-height.schema.json",
+  "type": "object",
+  "title": "RosettaBlockIdentifierHeight",
+  "description": "This is also known as the block height.",
+  "properties": {
+    "index": {
+      "type": "integer",
+      "description": "This is also known as the block height."
+    }
+  }
+}

--- a/docs/entities/rosetta/rosetta-block-identifier.schema.json
+++ b/docs/entities/rosetta/rosetta-block-identifier.schema.json
@@ -1,17 +1,15 @@
 {
   "$id": "rosetta-block-identifier.schema.json",
-  "type": "object",
   "title": "RosettaBlockIdentifier",
   "description": "The block_identifier uniquely identifies a block in a particular network.",
-  "required": ["index", "hash"],
-  "properties": {
-    "index": {
-      "type": "integer",
-      "description": "This is also known as the block height."
+  "allOf": [
+    {
+      "$ref": "./rosetta-block-identifier-hash.schema.json",
+      "required": ["hash"]
     },
-    "hash": {
-      "type": "string",
-      "description": "Block hash"
+    {
+      "$ref": "./rosetta-block-identifier-height.schema.json",
+      "required": ["index"]
     }
-  }
+  ]
 }

--- a/docs/entities/rosetta/rosetta-partial-block-identifier.schema.json
+++ b/docs/entities/rosetta/rosetta-partial-block-identifier.schema.json
@@ -3,15 +3,12 @@
   "type": "object",
   "title": "RosettaPartialBlockIdentifier",
   "description": "When fetching data by BlockIdentifier, it may be possible to only specify the index or hash. If neither property is specified, it is assumed that the client is making a request at the current block.",
-  "required": [],
-  "properties": {
-    "index": {
-      "type": "integer",
-      "description": "This is also known as the block height."
+  "anyOf": [
+    {
+      "$ref": "./rosetta-block-identifier-hash.schema.json"
     },
-    "hash": {
-      "type": "string",
-      "description": "Block hash"
+    {
+      "$ref": "./rosetta-block-identifier-height.schema.json"
     }
-  }
+  ]
 }

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -245,7 +245,7 @@ export interface RosettaAccountBalanceResponse {
  */
 export interface RosettaBlockRequest {
   network_identifier: NetworkIdentifier;
-  block_identifier: RosettaPartialBlockIdentifier;
+  block_identifier?: RosettaPartialBlockIdentifier;
 }
 
 /**
@@ -816,17 +816,37 @@ export interface RosettaAmount {
 }
 
 /**
+ * This is also known as the block hash.
+ */
+export interface RosettaBlockIdentifierHash {
+  /**
+   * This is also known as the block hash.
+   */
+  hash?: string;
+}
+
+/**
+ * This is also known as the block height.
+ */
+export interface RosettaBlockIdentifierHeight {
+  /**
+   * This is also known as the block height.
+   */
+  index?: number;
+}
+
+/**
  * The block_identifier uniquely identifies a block in a particular network.
  */
 export interface RosettaBlockIdentifier {
   /**
+   * This is also known as the block hash.
+   */
+  hash: string;
+  /**
    * This is also known as the block height.
    */
   index: number;
-  /**
-   * Block hash
-   */
-  hash: string;
 }
 
 /**
@@ -1105,16 +1125,7 @@ export interface RosettaParentBlockIdentifier {
 /**
  * When fetching data by BlockIdentifier, it may be possible to only specify the index or hash. If neither property is specified, it is assumed that the client is making a request at the current block.
  */
-export interface RosettaPartialBlockIdentifier {
-  /**
-   * This is also known as the block height.
-   */
-  index?: number;
-  /**
-   * Block hash
-   */
-  hash?: string;
-}
+export type RosettaPartialBlockIdentifier = RosettaBlockIdentifierHash | RosettaBlockIdentifierHeight;
 
 /**
  * Restrict referenced related_operations to identifier indexes < the current operation_identifier.index. This ensures there exists a clear DAG-structure of relations. Since operations are one-sided, one could imagine relating operations in a single transfer or linking operations in a call tree.

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   testMatch: ['<rootDir>/tests/**/*.ts'],
   testPathIgnorePatterns: ['<rootDir>/tests/setup.ts', '<rootDir>/tests/teardown.ts'],
   collectCoverageFrom: ['<rootDir>/**/*.ts'],
+  coveragePathIgnorePatterns: ['<rootDir>/tests-rosetta'],
   coverageDirectory: '../coverage',
   globalSetup: '<rootDir>/tests/setup.ts',
   globalTeardown: '<rootDir>/tests/teardown.ts',

--- a/jest.config.rosetta.js
+++ b/jest.config.rosetta.js
@@ -1,0 +1,16 @@
+module.exports = {
+   preset: 'ts-jest',
+   testEnvironment: 'node',
+   rootDir: 'src',
+   testMatch: ['<rootDir>/tests-rosetta/**/*.ts'],
+   testPathIgnorePatterns: ['<rootDir>/tests-rosetta/setup.ts', '<rootDir>/tests-rosetta/teardown.ts'],
+   collectCoverageFrom: ['<rootDir>/**/*.ts'],
+   coveragePathIgnorePatterns: ['<rootDir>/tests'],
+   coverageDirectory: '../coverage',
+   globalSetup: '<rootDir>/tests-rosetta/setup.ts',
+   globalTeardown: '<rootDir>/tests-rosetta/teardown.ts',
+   testTimeout: 60000,
+   transformIgnorePatterns: [
+     "node_modules/(?!(@blockstack/stacks-transactions)/)"
+   ]
+ }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:rosetta": "cross-env NODE_ENV=development jest --config ./jest.config.rosetta.js --coverage --runInBand",
     "test:watch": "cross-env NODE_ENV=development jest --config ./jest.config.js --watch",
     "test:integration": "npm run devenv:deploy -- -d && cross-env NODE_ENV=development jest --config ./jest.config.js --coverage --no-cache --runInBand; npm run devenv:stop",
+     "test:integration:rosetta": "npm run devenv:deploy -- -d && cross-env NODE_ENV=development jest --config ./jest.config.rosetta.js --coverage --no-cache --runInBand; npm run devenv:stop",
     "build": "rimraf ./lib && tsc",
     "start": "node ./lib/index.js",
     "lint": "npm run lint:eslint && npm run lint:prettier",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev:integrated": "npm run devenv:build && concurrently npm:dev npm:devenv:deploy",
     "dev:follower": "npm run devenv:build && concurrently npm:dev npm:devenv:follower",
     "test": "cross-env NODE_ENV=development jest --config ./jest.config.js --coverage --runInBand",
+    "test:rosetta": "cross-env NODE_ENV=development jest --config ./jest.config.rosetta.js --coverage --runInBand",
     "test:watch": "cross-env NODE_ENV=development jest --config ./jest.config.js --watch",
     "test:integration": "npm run devenv:deploy -- -d && cross-env NODE_ENV=development jest --config ./jest.config.js --coverage --no-cache --runInBand; npm run devenv:stop",
     "build": "rimraf ./lib && tsc",

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -332,7 +332,6 @@ export async function getRosettaTransactionFromDataStore(
   return { found: true, result: result };
 }
 
-
 export function parseDbMempoolTx(dbTx: DbMempoolTx): MempoolTransaction {
   const apiTx: Partial<MempoolTransaction> = {
     tx_id: dbTx.tx_id,

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -316,6 +316,23 @@ export async function getRosettaBlockTransactionsFromDataStore(
   return { found: true, result: transactions };
 }
 
+export async function getRosettaTransactionFromDataStore(
+  txId: string,
+  db: DataStore
+): Promise<{ found: true; result: RosettaTransaction } | { found: false }> {
+  const txQuery = await db.getTx(txId);
+  if (!txQuery.found) {
+    return { found: false };
+  }
+  const operations = getOperations(txQuery.result);
+  const result = {
+    transaction_identifier: { hash: txId },
+    operations: operations,
+  };
+  return { found: true, result: result };
+}
+
+
 export function parseDbMempoolTx(dbTx: DbMempoolTx): MempoolTransaction {
   const apiTx: Partial<MempoolTransaction> = {
     tx_id: dbTx.tx_id,

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -39,6 +39,7 @@ import {
   assertNotNullish as unwrapOptional,
   bufferToHexPrefixString,
   ElementType,
+  FoundOrNot,
   hexToBuffer,
   unixEpochToIso,
 } from '../../helpers';
@@ -227,7 +228,7 @@ export async function getRosettaBlockFromDataStore(
   db: DataStore,
   blockHash?: string,
   blockHeight?: number
-): Promise<{ found: true; result: RosettaBlock } | { found: false }> {
+): Promise<FoundOrNot<RosettaBlock>> {
   let query;
   if (blockHeight && blockHeight > 0) {
     query = db.getBlockByHeight(blockHeight);
@@ -277,7 +278,7 @@ export async function getRosettaBlockFromDataStore(
 export async function getBlockFromDataStore(
   blockHash: string,
   db: DataStore
-): Promise<{ found: true; result: Block } | { found: false }> {
+): Promise<FoundOrNot<Block>> {
   const blockQuery = await db.getBlock(blockHash);
   if (!blockQuery.found) {
     return { found: false };
@@ -300,7 +301,7 @@ export async function getBlockFromDataStore(
 export async function getRosettaBlockTransactionsFromDataStore(
   indexBlockHash: string,
   db: DataStore
-): Promise<{ found: true; result: RosettaTransaction[] } | { found: false }> {
+): Promise<FoundOrNot<RosettaTransaction[]>> {
   const txsQuery = await db.getBlockTxsRows(indexBlockHash);
 
   if (!txsQuery.found) {
@@ -319,7 +320,7 @@ export async function getRosettaBlockTransactionsFromDataStore(
 export async function getRosettaTransactionFromDataStore(
   txId: string,
   db: DataStore
-): Promise<{ found: true; result: RosettaTransaction } | { found: false }> {
+): Promise<FoundOrNot<RosettaTransaction>> {
   const txQuery = await db.getTx(txId);
   if (!txQuery.found) {
     return { found: false };
@@ -426,7 +427,7 @@ export function parseDbMempoolTx(dbTx: DbMempoolTx): MempoolTransaction {
 export async function getTxFromDataStore(
   txId: string,
   db: DataStore
-): Promise<{ found: true; result: Transaction } | { found: false }> {
+): Promise<FoundOrNot<Transaction>> {
   let dbTx: DbTx | DbMempoolTx;
   let dbTxEvents: DbEvent[] = [];
   // First check mempool

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -299,10 +299,10 @@ export async function getBlockFromDataStore(
 }
 
 export async function getRosettaBlockTransactionsFromDataStore(
-  indexBlockHash: string,
+  blockHash: string,
   db: DataStore
 ): Promise<FoundOrNot<RosettaTransaction[]>> {
-  const txsQuery = await db.getBlockTxsRows(indexBlockHash);
+  const txsQuery = await db.getBlockTxsRows(blockHash);
 
   if (!txsQuery.found) {
     return { found: false };

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -29,6 +29,7 @@ export interface ApiServer {
   server: Server;
   wss: WebSocket.Server;
   address: string;
+  datastore: DataStore;
   terminate: () => Promise<void>;
 }
 
@@ -175,6 +176,7 @@ export async function startApiServer(datastore: DataStore): Promise<ApiServer> {
     server: server,
     wss: wss,
     address: addrStr,
+    datastore: datastore,
     terminate,
   };
 }

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -99,12 +99,6 @@ export async function startApiServer(datastore: DataStore): Promise<ApiServer> {
     })()
   );
 
-  // Validation middleware for Rosetta API
-  app.use('/rosetta/v1', (req, res, next) => {
-    // await validateRequest(req.originalUrl, req.body);
-    next();
-  });
-
   // Setup error handler (must be added at the end of the middleware stack)
   app.use(((error, req, res, next) => {
     if (error && !res.headersSent) {

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -179,6 +179,7 @@ export const RosettaSchemas: Record<string, SchemaFiles> = {
   '/rosetta/v1/block/transaction': {
     request:
       '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-block-transaction-request.schema.json',
-    response: '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-transaction.schema.json',
+    response:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-block-transaction-response.schema.json',
   },
 };

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -142,7 +142,7 @@ export type RosettaRequestType =
   | T.RosettaAccountBalanceRequest
   | T.RosettaBlockRequest
   | T.RosettaBlockTransactionRequest
-  | T.RosettaMempoolTransactionListRequest
+  | T.RosettaMempoolTransactionRequest
   | T.RosettaMempoolTransactionRequest
   | T.RosettaNetworkListRequest
   | T.RosettaOptionsRequest
@@ -183,5 +183,17 @@ export const RosettaSchemas: Record<string, SchemaFiles> = {
       '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-block-transaction-request.schema.json',
     response:
       '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-block-transaction-response.schema.json',
+  },
+  '/rosetta/v1/mempool': {
+    request:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-mempool-request.schema.json',
+    response:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-mempool-response.schema.json',
+  },
+  '/rosetta/v1/mempool/transaction': {
+    request:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-mempool-transaction-request.schema.json',
+    response:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-mempool-transaction-response.schema.json',
   },
 };

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -35,7 +35,14 @@ export const RosettaOperationStatuses = [
 ];
 
 // All possible errors
-export const RosettaErrors = {
+export interface RosettaError {
+  code: number;
+  message: string;
+  retriable: boolean;
+  details?: Record<string, string>;
+}
+
+export const RosettaErrors: Record<string, RosettaError> = {
   invalidAccount: {
     code: 601,
     message: 'Invalid Account',

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -1,3 +1,5 @@
+import * as T from '@blockstack/stacks-blockchain-api-types';
+
 export const RosettaConstants = {
   blockchain: 'stacks',
   network: 'testnet',
@@ -127,5 +129,36 @@ export const RosettaErrors: Record<string, RosettaError> = {
     code: 617,
     message: 'Network name is null',
     retriable: true,
+  },
+};
+
+// All request types, used to validate input (eventually).
+// This does not contain RosettaNetworkListRequest because
+// it's the only request without a NetworkIdentifier.
+export type RosettaRequestType = T.RosettaOptionsRequest | T.RosettaStatusRequest;
+
+export interface SchemaFiles {
+  request: string;
+  response: string;
+}
+
+export const RosettaSchemas: Record<string, SchemaFiles> = {
+  '/rosetta/v1/network/list': {
+    request:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-network-list-request.schema.json',
+    response:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-network-list-response.schema.json',
+  },
+  '/rosetta/v1/network/options': {
+    request:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-network-options-request.schema.json',
+    response:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-network-options-response.schema.json',
+  },
+  '/rosetta/v1/network/status': {
+    request:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-network-status-request.schema.json',
+    response:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-network-status-response.schema.json',
   },
 };

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -142,6 +142,8 @@ export type RosettaRequestType =
   | T.RosettaAccountBalanceRequest
   | T.RosettaBlockRequest
   | T.RosettaBlockTransactionRequest
+  | T.RosettaMempoolTransactionListRequest
+  | T.RosettaMempoolTransactionRequest
   | T.RosettaNetworkListRequest
   | T.RosettaOptionsRequest
   | T.RosettaStatusRequest;

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -47,47 +47,47 @@ export interface RosettaError {
 export const RosettaErrors: Record<string, RosettaError> = {
   invalidAccount: {
     code: 601,
-    message: 'Invalid Account',
+    message: 'Invalid Account.',
     retriable: true,
   },
   insufficientFunds: {
     code: 602,
-    message: 'Insufficient Funds',
+    message: 'Insufficient Funds.',
     retriable: true,
   },
   accountEmpty: {
     code: 603,
-    message: 'Account is empty',
+    message: 'Account is empty.',
     retriable: true,
   },
   invalidBlockIndex: {
     code: 604,
-    message: 'Invalid block index',
+    message: 'Invalid block index.',
     retriable: true,
   },
   blockNotFound: {
     code: 605,
-    message: 'Block not found',
+    message: 'Block not found.',
     retriable: true,
   },
   invalidBlockHash: {
     code: 606,
-    message: 'Invalid block hash',
+    message: 'Invalid block hash.',
     retriable: true,
   },
   transactionNotFound: {
     code: 607,
-    message: 'Transaction not found',
+    message: 'Transaction not found.',
     retriable: true,
   },
   invalidTransactionHash: {
     code: 608,
-    message: 'Invalid transaction hash',
+    message: 'Invalid transaction hash.',
     retriable: true,
   },
   invalidParams: {
     code: 609,
-    message: 'invalid params',
+    message: 'Invalid params.',
     retriable: true,
   },
   invalidNetwork: {
@@ -107,35 +107,44 @@ export const RosettaErrors: Record<string, RosettaError> = {
   },
   emptyNetworkIdentifier: {
     code: 613,
-    message: 'Network identifier object is null',
+    message: 'Network identifier object is null.',
     retriable: true,
   },
   emptyAccountIdentifier: {
     code: 614,
-    message: 'Account identifier object is null',
+    message: 'Account identifier object is null.',
     retriable: true,
   },
   invalidBlockIdentifier: {
     code: 615,
-    message: 'Block identifier is null',
+    message: 'Block identifier is null.',
+    retriable: true,
+  },
+  invalidTransactionIdentifier: {
+    code: 616,
+    message: 'Transaction identifier is null.',
     retriable: true,
   },
   emptyBlockchain: {
-    code: 616,
-    message: 'Blockchain name is null',
+    code: 617,
+    message: 'Blockchain name is null.',
     retriable: true,
   },
   emptyNetwork: {
-    code: 617,
-    message: 'Network name is null',
+    code: 618,
+    message: 'Network name is null.',
     retriable: true,
   },
 };
 
-// All request types, used to validate input (eventually).
-// This does not contain RosettaNetworkListRequest because
-// it's the only request without a NetworkIdentifier.
-export type RosettaRequestType = T.RosettaOptionsRequest | T.RosettaStatusRequest;
+// All request types, used to validate input.
+export type RosettaRequestType =
+  | T.RosettaAccountBalanceRequest
+  | T.RosettaBlockRequest
+  | T.RosettaBlockTransactionRequest
+  | T.RosettaNetworkListRequest
+  | T.RosettaOptionsRequest
+  | T.RosettaStatusRequest;
 
 export interface SchemaFiles {
   request: string;
@@ -160,5 +169,16 @@ export const RosettaSchemas: Record<string, SchemaFiles> = {
       '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-network-status-request.schema.json',
     response:
       '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-network-status-response.schema.json',
+  },
+  '/rosetta/v1/block': {
+    request:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-block-request.schema.json',
+    response:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-block-response.schema.json',
+  },
+  '/rosetta/v1/block/transaction': {
+    request:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-block-transaction-request.schema.json',
+    response: '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-transaction.schema.json',
   },
 };

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -196,4 +196,10 @@ export const RosettaSchemas: Record<string, SchemaFiles> = {
     response:
       '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-mempool-transaction-response.schema.json',
   },
+  '/rosetta/v1/account/balance': {
+    request:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-account-balance-request.schema.json',
+    response:
+      '@blockstack/stacks-blockchain-api-types/api/rosetta/rosetta-account-response.schema.json',
+  },
 };

--- a/src/api/rosetta-validate.ts
+++ b/src/api/rosetta-validate.ts
@@ -1,6 +1,6 @@
 import * as Ajv from 'ajv';
 import * as RefParser from '@apidevtools/json-schema-ref-parser';
-import { hexToBuffer, logger, has0xPrefix } from '../helpers';
+import { hexToBuffer, logger, has0xPrefix, isValidC32Address } from '../helpers';
 import {
   RosettaConstants,
   RosettaError,
@@ -68,6 +68,10 @@ export async function rosettaValidateRequest(
 
   if ('transaction_identifier' in body && !validHexId(body.transaction_identifier)) {
     return { valid: false, errorType: 'invalidTransactionHash' };
+  }
+
+  if ('account_identifier' in body && !isValidC32Address(body.account_identifier.address)) {
+    return { valid: false, errorType: 'invalidAccount' };
   }
 
   return { valid: true };

--- a/src/api/rosetta-validate.ts
+++ b/src/api/rosetta-validate.ts
@@ -35,8 +35,13 @@ export async function rosettaValidateRequest(
   url: string,
   body: RosettaRequestType
 ): Promise<ValidSchema> {
+  // remove trailing slashes, if any
+  if (url.endsWith('/')) {
+    url = url.slice(0, url.length - 1);
+  }
   // Check schemas
   const schemas: SchemaFiles = RosettaSchemas[url];
+  // Return early if we don't know about this endpoint.
   if (!schemas) return { valid: true };
 
   const path = require.resolve(schemas.request);

--- a/src/api/rosetta-validate.ts
+++ b/src/api/rosetta-validate.ts
@@ -81,6 +81,7 @@ function validHexId(
     try {
       if (!has0xPrefix(hash)) {
         hash = '0x' + hash;
+        hexToBuffer(hash);
       }
     } catch (_e) {
       return false;

--- a/src/api/rosetta-validate.ts
+++ b/src/api/rosetta-validate.ts
@@ -1,0 +1,81 @@
+import * as Ajv from 'ajv';
+import * as RefParser from '@apidevtools/json-schema-ref-parser';
+import { logger } from '../helpers';
+import {
+  RosettaConstants,
+  RosettaError,
+  RosettaErrors,
+  RosettaSchemas,
+  SchemaFiles,
+  RosettaRequestType,
+} from './rosetta-constants';
+import { NetworkIdentifier } from '@blockstack/stacks-blockchain-api-types';
+
+export interface ValidSchema {
+  valid: boolean;
+  error?: string; // discovered during schema validation
+  errorType?: string; // discovered using our validation
+}
+
+async function validate(schemaFilePath: string, data: any): Promise<ValidSchema> {
+  const schemaDef = await RefParser.dereference(schemaFilePath);
+  const ajv = new Ajv({ schemaId: 'auto' });
+  const valid = await ajv.validate(schemaDef, data);
+  if (!valid) {
+    logger.error(`Schema validation:\n\n ${JSON.stringify(ajv.errors, null, 2)}`);
+    const errors = ajv.errors || [{ message: 'error' }];
+    return { valid: false, error: errors[0].message };
+  }
+
+  return { valid: true };
+}
+
+export async function rosettaValidateRequest(
+  url: string,
+  body: RosettaRequestType
+): Promise<ValidSchema> {
+  // Check schemas
+  const schemas: SchemaFiles = RosettaSchemas[url];
+  if (!schemas) return { valid: true };
+
+  const path = require.resolve(schemas.request);
+  const valid = await validate(path, body);
+
+  if (!valid.valid) {
+    return valid;
+  }
+
+  // Other request checks
+  if (RosettaConstants.blockchain != body.network_identifier.blockchain) {
+    return { valid: false, errorType: 'invalidBlockchain' };
+  }
+
+  if (RosettaConstants.network != body.network_identifier.network) {
+    return { valid: false, errorType: 'invalidNetwork' };
+  }
+
+  return { valid: true };
+}
+
+// TODO: there has to be a better way to go from ajv errors to rosetta errors.
+export function makeRosettaError(notValid: ValidSchema): RosettaError {
+  let resp: RosettaError = RosettaErrors.unknownError;
+
+  // we've already identified the problem
+  if (notValid.errorType !== undefined) {
+    return RosettaErrors[notValid.errorType];
+  }
+
+  const error = notValid.error || '';
+  if (error.search(/network_identifier/) != -1) {
+    resp = RosettaErrors.emptyNetworkIdentifier;
+    resp.details = { message: error };
+  } else if (error.search(/blockchain/) != -1) {
+    resp = RosettaErrors.emptyBlockchain;
+    resp.details = { message: error };
+  } else if (error.search(/network/) != -1) {
+    resp = RosettaErrors.emptyNetwork;
+    resp.details = { message: error };
+  }
+  return resp;
+}

--- a/src/api/rosetta-validate.ts
+++ b/src/api/rosetta-validate.ts
@@ -74,7 +74,11 @@ export async function rosettaValidateRequest(
 }
 
 function validHexId(
-  identifier: T.RosettaBlockIdentifier | T.TransactionIdentifier | undefined
+  identifier:
+    | T.RosettaBlockIdentifier
+    | T.RosettaPartialBlockIdentifier
+    | T.TransactionIdentifier
+    | undefined
 ): boolean {
   if (identifier === undefined) {
     return true;
@@ -82,6 +86,10 @@ function validHexId(
 
   if ('hash' in identifier) {
     let hash = identifier.hash;
+
+    if (hash === undefined) {
+      return true;
+    }
 
     try {
       if (!has0xPrefix(hash)) {

--- a/src/api/rosetta-validate.ts
+++ b/src/api/rosetta-validate.ts
@@ -11,6 +11,7 @@ import {
 } from './rosetta-constants';
 import * as T from '@blockstack/stacks-blockchain-api-types';
 import { NetworkIdentifier } from '@blockstack/stacks-blockchain-api-types';
+import { dereferenceSchema } from './validate';
 
 export interface ValidSchema {
   valid: boolean;
@@ -19,7 +20,7 @@ export interface ValidSchema {
 }
 
 async function validate(schemaFilePath: string, data: any): Promise<ValidSchema> {
-  const schemaDef = await RefParser.dereference(schemaFilePath);
+  const schemaDef = await dereferenceSchema(schemaFilePath);
   const ajv = new Ajv({ schemaId: 'auto' });
   const valid = await ajv.validate(schemaDef, data);
   if (!valid) {

--- a/src/api/rosetta-validate.ts
+++ b/src/api/rosetta-validate.ts
@@ -42,7 +42,10 @@ export async function rosettaValidateRequest(
   // Check schemas
   const schemas: SchemaFiles = RosettaSchemas[url];
   // Return early if we don't know about this endpoint.
-  if (!schemas) return { valid: true };
+  if (!schemas) {
+    logger.warn(`Schema validation:\n\n unknown endpoint: ${url}`);
+    return { valid: true };
+  }
 
   const path = require.resolve(schemas.request);
   const valid = await validate(path, body);

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -1,13 +1,75 @@
 import * as express from 'express';
 import { addAsync, RouterWithAsync } from '@awaitjs/express';
-import { DataStore } from '../../../datastore/common';
+import { DataStore, DbBlock } from '../../../datastore/common';
+import { has0xPrefix, FoundOrNot } from '../../../helpers';
+import {
+  NetworkIdentifier,
+  RosettaAccount,
+  RosettaBlockIdentifier,
+  RosettaAccountBalanceResponse,
+} from '@blockstack/stacks-blockchain-api-types';
+import { RosettaErrors, RosettaConstants } from '../../rosetta-constants';
+import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
 
 export function createRosettaAccountRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
   router.use(express.json());
 
-  router.post('/balance', (req, res) => {
-    res.json({ status: 'ready' });
+  router.postAsync('/balance', async (req, res) => {
+    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body);
+    if (!valid.valid) {
+      res.status(400).json(makeRosettaError(valid));
+      return;
+    }
+
+    const accountIdentifier: RosettaAccount = req.body.account_identifier;
+    const blockIdentifier: RosettaBlockIdentifier = req.body.block_identifier;
+    let blockQuery: FoundOrNot<DbBlock>;
+
+    // we need to return the block height/hash in the response, so we
+    // need to fetch the block first.
+    if (blockIdentifier === undefined) {
+      blockQuery = await db.getCurrentBlock();
+    } else if (blockIdentifier.index >= 0) {
+      blockQuery = await db.getBlockByHeight(blockIdentifier.index);
+    } else if (blockIdentifier.hash !== undefined) {
+      let blockHash = blockIdentifier.hash;
+      if (!has0xPrefix(blockHash)) {
+        blockHash = '0x' + blockHash;
+      }
+      blockQuery = await db.getBlock(blockHash);
+    } else {
+      return res.status(400).json(RosettaErrors.invalidBlockIdentifier);
+    }
+
+    if (!blockQuery.found) {
+      return res.status(400).json(RosettaErrors.blockNotFound);
+    }
+
+    const block = blockQuery.result;
+    const result = await db.getStxBalanceAtBlock(accountIdentifier.address, block.block_height);
+
+    const response: RosettaAccountBalanceResponse = {
+      block_identifier: {
+        index: block.block_height,
+        hash: block.block_hash,
+      },
+      balances: [
+        {
+          value: result.balance.toString(),
+          currency: {
+            symbol: RosettaConstants.symbol,
+            decimals: RosettaConstants.decimals,
+          },
+        },
+      ],
+      coins: [],
+      metadata: {
+        sequence_number: 0,
+      },
+    };
+
+    res.json(response);
   });
 
   return router;

--- a/src/api/routes/rosetta/block.ts
+++ b/src/api/routes/rosetta/block.ts
@@ -30,7 +30,7 @@ export function createRosettaBlockRouter(db: DataStore): RouterWithAsync {
     const block = await getRosettaBlockFromDataStore(db, block_hash, index);
 
     if (!block.found) {
-      res.status(400).json(RosettaErrors.blockNotFound);
+      res.status(404).json(RosettaErrors.blockNotFound);
       return;
     }
     const blockResponse: RosettaBlockResponse = {
@@ -53,7 +53,7 @@ export function createRosettaBlockRouter(db: DataStore): RouterWithAsync {
 
     const transaction = await getRosettaTransactionFromDataStore(tx_hash, db);
     if (!transaction.found) {
-      res.status(400).json(RosettaErrors.transactionNotFound);
+      res.status(404).json(RosettaErrors.transactionNotFound);
       return;
     }
 

--- a/src/api/routes/rosetta/block.ts
+++ b/src/api/routes/rosetta/block.ts
@@ -1,16 +1,63 @@
 import * as express from 'express';
 import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import { RosettaBlock, RosettaBlockResponse } from '@blockstack/stacks-blockchain-api-types';
 import { DataStore } from '../../../datastore/common';
+import {
+  getRosettaTransactionFromDataStore,
+  getRosettaBlockFromDataStore,
+} from '../../controllers/db-controller';
+import { has0xPrefix } from '../../../helpers';
+import { RosettaErrors } from '../../rosetta-constants';
+import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
 
 export function createRosettaBlockRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
+  router.use(express.json());
 
-  router.post('/', (req, res) => {
-    res.json({ status: 'ready' });
+  router.postAsync('/', async (req, res) => {
+    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body);
+    if (!valid.valid) {
+      res.status(400).json(makeRosettaError(valid));
+      return;
+    }
+
+    let block_hash = req.body.block_identifier.hash;
+    const index = req.body.block_identifier.index;
+    if (block_hash && !has0xPrefix(block_hash)) {
+      block_hash = '0x' + block_hash;
+    }
+
+    const block = await getRosettaBlockFromDataStore(db, block_hash, index);
+
+    if (!block.found) {
+      res.status(400).json(RosettaErrors.blockNotFound);
+      return;
+    }
+    const blockResponse: RosettaBlockResponse = {
+      block: block.result,
+    };
+    res.json(blockResponse);
   });
 
-  router.post('/transaction', (req, res) => {
-    res.json({ status: 'ready' });
+  router.postAsync('/transaction', async (req, res) => {
+    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body);
+    if (!valid.valid) {
+      res.status(400).json(makeRosettaError(valid));
+      return;
+    }
+
+    let tx_hash = req.body.transaction_identifier.hash;
+    if (!has0xPrefix(tx_hash)) {
+      tx_hash = '0x' + tx_hash;
+    }
+
+    const transaction = await getRosettaTransactionFromDataStore(tx_hash, db);
+    if (!transaction.found) {
+      res.status(400).json(RosettaErrors.transactionNotFound);
+      return;
+    }
+
+    res.json(transaction.result);
   });
 
   return router;

--- a/src/api/routes/rosetta/block.ts
+++ b/src/api/routes/rosetta/block.ts
@@ -21,8 +21,8 @@ export function createRosettaBlockRouter(db: DataStore): RouterWithAsync {
       return;
     }
 
-    let block_hash = req.body.block_identifier.hash;
-    const index = req.body.block_identifier.index;
+    let block_hash = req.body.block_identifier?.hash;
+    const index = req.body.block_identifier?.index;
     if (block_hash && !has0xPrefix(block_hash)) {
       block_hash = '0x' + block_hash;
     }

--- a/src/api/routes/rosetta/mempool.ts
+++ b/src/api/routes/rosetta/mempool.ts
@@ -64,7 +64,7 @@ export function createRosettaMempoolRouter(db: DataStore): RouterWithAsync {
     const mempoolTxQuery = await db.getMempoolTx(tx_id);
 
     if (!mempoolTxQuery.found) {
-      return res.status(400).json(RosettaErrors.transactionNotFound);
+      return res.status(404).json(RosettaErrors.transactionNotFound);
     }
 
     const operations = getOperations(mempoolTxQuery.result);

--- a/src/api/routes/rosetta/mempool.ts
+++ b/src/api/routes/rosetta/mempool.ts
@@ -1,16 +1,78 @@
 import * as express from 'express';
 import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import { DataStore } from '../../../datastore/common';
+import { has0xPrefix } from '../../../helpers';
+import { parseLimitQuery, parsePagingQueryInput } from '../../pagination';
+import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
+import {
+  RosettaMempoolResponse,
+  RosettaTransaction,
+} from '@blockstack/stacks-blockchain-api-types';
+import { getOperations } from '../../../rosetta-helpers';
+import { RosettaErrors } from './../../rosetta-constants';
+
+const MAX_MEMPOOL_TXS_PER_REQUEST = 200;
+const parseMempoolTxQueryLimit = parseLimitQuery({
+  maxItems: MAX_MEMPOOL_TXS_PER_REQUEST,
+  errorMsg: `'limit' must be equal to or less than ${MAX_MEMPOOL_TXS_PER_REQUEST}`,
+});
 
 export function createRosettaMempoolRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
+  router.use(express.json());
 
-  router.post('/', (req, res) => {
-    res.json({ status: 'ready' });
+  router.postAsync('/', async (req, res) => {
+    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body);
+    if (!valid.valid) {
+      res.status(400).json(makeRosettaError(valid));
+      return;
+    }
+
+    const limit = req.body.metadata
+      ? parseMempoolTxQueryLimit(req.body.metadata.limit ?? 100)
+      : 100;
+    const offset = req.body.metadata ? parsePagingQueryInput(req.body.metadata.offset ?? 0) : 0;
+    const { results: txResults, total } = await db.getMempoolTxIdList({ offset, limit });
+
+    const transaction_identifiers = txResults.map(tx => {
+      return { hash: tx.tx_id };
+    });
+    const metadata = {
+      limit: limit,
+      total: total,
+      offset: offset,
+    };
+    const response: RosettaMempoolResponse = {
+      transaction_identifiers,
+      metadata,
+    };
+    res.json(response);
   });
 
-  router.post('/transaction', (req, res) => {
-    res.json({ status: 'ready' });
+  router.postAsync('/transaction', async (req, res) => {
+    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body);
+    if (!valid.valid) {
+      res.status(400).json(makeRosettaError(valid));
+      return;
+    }
+
+    let tx_id = req.body.transaction_identifier.hash;
+
+    if (!has0xPrefix(tx_id)) {
+      tx_id = '0x' + tx_id;
+    }
+    const mempoolTxQuery = await db.getMempoolTx(tx_id);
+
+    if (!mempoolTxQuery.found) {
+      return res.status(400).json(RosettaErrors.transactionNotFound);
+    }
+
+    const operations = getOperations(mempoolTxQuery.result);
+    const result: RosettaTransaction = {
+      transaction_identifier: { hash: tx_id },
+      operations: operations,
+    };
+    res.json(result);
   });
 
   return router;

--- a/src/api/routes/rosetta/network.ts
+++ b/src/api/routes/rosetta/network.ts
@@ -1,6 +1,9 @@
 import * as express from 'express';
 import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import { DataStore } from '../../../datastore/common';
+import { logger } from '../../../helpers';
+import { getRosettaBlockFromDataStore } from '../../controllers/db-controller';
+import { StacksCoreRpcClient, Neighbor } from '../../../core-rpc/client';
 import {
   RosettaConstants,
   RosettaOperationTypes,
@@ -8,12 +11,20 @@ import {
   RosettaErrors,
 } from '../../rosetta-constants';
 const middleware_version = require('../../../../package.json').version;
+import {
+  RosettaNetworkListResponse,
+  RosettaNetworkOptionsResponse,
+  RosettaNetworkStatusResponse,
+  RosettaPeers,
+} from '@blockstack/stacks-blockchain-api-types';
+import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
 
 export function createRosettaNetworkRouter(db: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
+  router.use(express.json());
 
   router.post('/list', (_req, res) => {
-    const response = {
+    const response: RosettaNetworkListResponse = {
       network_identifiers: [
         {
           blockchain: RosettaConstants.blockchain,
@@ -25,12 +36,63 @@ export function createRosettaNetworkRouter(db: DataStore): RouterWithAsync {
     res.json(response);
   });
 
-  router.post('/status', (req, res) => {
-    res.json({ status: 'ready' });
+  router.postAsync('/status', async (req, res) => {
+    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body);
+    if (!valid.valid) {
+      res.status(400).json(makeRosettaError(valid));
+      return;
+    }
+
+    const block = await getRosettaBlockFromDataStore(db);
+    if (!block.found) {
+      res.status(404).json(RosettaErrors.blockNotFound);
+      return;
+    }
+
+    const genesis = await getRosettaBlockFromDataStore(db, undefined, 1);
+    if (!genesis.found) {
+      res.status(404).json(RosettaErrors.blockNotFound);
+      return;
+    }
+
+    const stacksCoreRpcClient = new StacksCoreRpcClient();
+    const neighborsResp = await stacksCoreRpcClient.getNeighbors();
+
+    const neighbors: Neighbor[] = [...neighborsResp.inbound, ...neighborsResp.outbound];
+
+    const set_of_peer_ids = new Set(
+      neighbors.map(neighbor => {
+        return neighbor.public_key_hash;
+      })
+    );
+
+    const peers = [...set_of_peer_ids].map(peerId => {
+      return { peer_id: peerId };
+    });
+
+    const response: RosettaNetworkStatusResponse = {
+      current_block_identifier: {
+        index: block.result.block_identifier.index,
+        hash: block.result.block_identifier.hash,
+      },
+      current_block_timestamp: block.result.timestamp,
+      genesis_block_identifier: {
+        index: genesis.result.block_identifier.index,
+        hash: genesis.result.block_identifier.hash,
+      },
+      peers,
+    };
+    res.json(response);
   });
 
-  router.post('/options', (_req, res) => {
-    const response = {
+  router.postAsync('/options', async (req, res) => {
+    const valid: ValidSchema = await rosettaValidateRequest(req.originalUrl, req.body);
+    if (!valid.valid) {
+      res.status(400).json(makeRosettaError(valid));
+      return;
+    }
+
+    const response: RosettaNetworkOptionsResponse = {
       version: {
         rosetta_version: RosettaConstants.rosettaVersion,
         node_version: process.version,

--- a/src/api/routes/rosetta/network.ts
+++ b/src/api/routes/rosetta/network.ts
@@ -51,7 +51,7 @@ export function createRosettaNetworkRouter(db: DataStore): RouterWithAsync {
 
     const genesis = await getRosettaBlockFromDataStore(db, undefined, 1);
     if (!genesis.found) {
-      res.status(404).json(RosettaErrors.blockNotFound);
+      res.status(400).json(RosettaErrors.blockNotFound);
       return;
     }
 

--- a/src/api/validate.ts
+++ b/src/api/validate.ts
@@ -1,11 +1,18 @@
 import * as Ajv from 'ajv';
 import * as RefParser from '@apidevtools/json-schema-ref-parser';
-import { logger } from '../helpers';
+import { logger, getOrAdd, getOrAddAsync } from '../helpers';
+
+const derefSchemaCache: Map<string, RefParser.JSONSchema> = new Map();
+export async function dereferenceSchema(schemaFilePath: string): Promise<RefParser.JSONSchema> {
+  return getOrAddAsync(derefSchemaCache, schemaFilePath, () =>
+    RefParser.dereference(schemaFilePath)
+  );
+}
 
 export async function validate(schemaFilePath: string, data: any) {
   if (process.env.NODE_ENV !== 'development') return;
 
-  const schemaDef = await RefParser.dereference(schemaFilePath);
+  const schemaDef = await dereferenceSchema(schemaFilePath);
   const ajv = new Ajv({ schemaId: 'auto' });
   const valid = await ajv.validate(schemaDef, data);
   if (!valid) {

--- a/src/core-rpc/client.ts
+++ b/src/core-rpc/client.ts
@@ -26,6 +26,21 @@ export interface CoreRpcInfo {
   stacks_tip_height: number;
 }
 
+export interface Neighbor {
+  network_id: number;
+  peer_version: number;
+  ip: string;
+  port: number;
+  public_key_hash: string;
+  authenticated: boolean;
+}
+
+export interface CoreRpcNeighbors {
+  sample: Neighbor[];
+  inbound: Neighbor[];
+  outbound: Neighbor[];
+}
+
 export function getCoreNodeEndpoint(opts?: { host?: string; port?: number | string }) {
   const host = opts?.host ?? process.env['STACKS_CORE_RPC_HOST'];
   if (!host) {
@@ -138,5 +153,12 @@ export class StacksCoreRpcClient {
     return {
       txId: '0x' + result,
     };
+  }
+
+  async getNeighbors(): Promise<CoreRpcNeighbors> {
+    const result = await this.fetchJson<CoreRpcNeighbors>(`v2/neighbors`, {
+      method: 'GET',
+    });
+    return result;
   }
 }

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -135,7 +135,7 @@ export interface DbMempoolTx {
   coinbase_payload?: Buffer;
 
   /** Added for consistency. */
-  raw_result?: string
+  raw_result?: string;
 }
 
 export interface DbSmartContract {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -248,11 +248,14 @@ export interface DbSearchResult {
 
 export interface DataStore extends DataStoreEventEmitter {
   getBlock(blockHash: string): Promise<FoundOrNot<DbBlock>>;
+  getBlockByHeight(block_height: number): Promise<FoundOrNot<DbBlock>>;
+  getCurrentBlock(): Promise<FoundOrNot<DbBlock>>;
   getBlocks(args: {
     limit: number;
     offset: number;
   }): Promise<{ results: DbBlock[]; total: number }>;
   getBlockTxs(indexBlockHash: string): Promise<{ results: string[] }>;
+  getBlockTxsRows(indexBlockHash: string): Promise<FoundOrNot<DbTx[]>>;
 
   getMempoolTx(txId: string): Promise<FoundOrNot<DbMempoolTx>>;
   getMempoolTxList(args: {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -138,6 +138,10 @@ export interface DbMempoolTx {
   raw_result?: string;
 }
 
+export interface DbMempoolTxId {
+  tx_id: string;
+}
+
 export interface DbSmartContract {
   tx_id: string;
   canonical: boolean;
@@ -265,6 +269,10 @@ export interface DataStore extends DataStoreEventEmitter {
     limit: number;
     offset: number;
   }): Promise<{ results: DbMempoolTx[]; total: number }>;
+  getMempoolTxIdList(args: {
+    limit: number;
+    offset: number;
+  }): Promise<{ results: DbMempoolTxId[]; total: number }>;
   getTx(txId: string): Promise<FoundOrNot<DbTx>>;
   getTxList(args: {
     limit: number;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -133,6 +133,9 @@ export interface DbMempoolTx {
 
   /** Only valid for `coinbase` tx types. Hex encoded 32-bytes. */
   coinbase_payload?: Buffer;
+
+  /** Added for consistency. */
+  raw_result?: string
 }
 
 export interface DbSmartContract {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -253,6 +253,12 @@ export interface DbSearchResult {
   entity_data?: DbBlock | DbMempoolTx | DbTx;
 }
 
+export interface DbStxBalance {
+  balance: bigint;
+  totalSent: bigint;
+  totalReceived: bigint;
+}
+
 export interface DataStore extends DataStoreEventEmitter {
   getBlock(blockHash: string): Promise<FoundOrNot<DbBlock>>;
   getBlockByHeight(block_height: number): Promise<FoundOrNot<DbBlock>>;
@@ -294,16 +300,9 @@ export interface DataStore extends DataStoreEventEmitter {
 
   updateMempoolTx(args: { mempoolTx: DbMempoolTx }): Promise<void>;
 
-  getStxBalance(
-    stxAddress: string
-  ): Promise<{ balance: bigint; totalSent: bigint; totalReceived: bigint }>;
-  getStxBalanceAtBlock(
-    stxAddress: string,
-    blockHeight: number
-  ): Promise<{ balance: bigint; totalSent: bigint; totalReceived: bigint }>;
-  getFungibleTokenBalances(
-    stxAddress: string
-  ): Promise<Map<string, { balance: bigint; totalSent: bigint; totalReceived: bigint }>>;
+  getStxBalance(stxAddress: string): Promise<DbStxBalance>;
+  getStxBalanceAtBlock(stxAddress: string, blockHeight: number): Promise<DbStxBalance>;
+  getFungibleTokenBalances(stxAddress: string): Promise<Map<string, DbStxBalance>>;
   getNonFungibleTokenCounts(
     stxAddress: string
   ): Promise<Map<string, { count: bigint; totalSent: bigint; totalReceived: bigint }>>;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -268,7 +268,7 @@ export interface DataStore extends DataStoreEventEmitter {
     offset: number;
   }): Promise<{ results: DbBlock[]; total: number }>;
   getBlockTxs(indexBlockHash: string): Promise<{ results: string[] }>;
-  getBlockTxsRows(indexBlockHash: string): Promise<FoundOrNot<DbTx[]>>;
+  getBlockTxsRows(blockHash: string): Promise<FoundOrNot<DbTx[]>>;
 
   getMempoolTx(txId: string): Promise<FoundOrNot<DbMempoolTx>>;
   getMempoolTxList(args: {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -297,6 +297,10 @@ export interface DataStore extends DataStoreEventEmitter {
   getStxBalance(
     stxAddress: string
   ): Promise<{ balance: bigint; totalSent: bigint; totalReceived: bigint }>;
+  getStxBalanceAtBlock(
+    stxAddress: string,
+    blockHeight: number
+  ): Promise<{ balance: bigint; totalSent: bigint; totalReceived: bigint }>;
   getFungibleTokenBalances(
     stxAddress: string
   ): Promise<Map<string, { balance: bigint; totalSent: bigint; totalReceived: bigint }>>;

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -177,6 +177,13 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     throw new Error('not yet implemented');
   }
 
+  getMempoolTxIdList(args: {
+    limit: number;
+    offset: number;
+  }): Promise<{ results: DbMempoolTx[]; total: number }> {
+    throw new Error('not yet implemented');
+  }
+
   getTx(txId: string) {
     const tx = this.txs.get(txId);
     if (tx === undefined) {

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -121,6 +121,14 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     return Promise.resolve({ found: true, result: block.entry });
   }
 
+  getBlockByHeight(block_height: number): Promise<FoundOrNot<DbBlock>> {
+    throw new Error('not yet implemented');
+  }
+
+  getCurrentBlock(): Promise<FoundOrNot<DbBlock>> {
+    throw new Error('not yet implemented');
+  }
+
   getBlocks({ limit, offset }: { limit: number; offset: number }) {
     const blockList = [...this.blocks.values()].filter(b => b.entry.canonical);
     const results = blockList
@@ -129,6 +137,10 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
       .slice(0, limit)
       .map(b => b.entry);
     return Promise.resolve({ results, total: blockList.length });
+  }
+
+  getBlockTxsRows(indexBlockHash: string): Promise<FoundOrNot<DbTx[]>> {
+    throw new Error('not yet implemented');
   }
 
   getBlockTxs(indexBlockHash: string) {

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -345,15 +345,11 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     throw new Error('not yet implemented');
   }
 
-  searchHash(args: {
-    hash: string;
-  }): Promise<{ found: false } | { found: true; result: DbSearchResult }> {
+  searchHash(args: { hash: string }): Promise<FoundOrNot<DbSearchResult>> {
     throw new Error('not yet implemented');
   }
 
-  searchPrincipal(args: {
-    principal: string;
-  }): Promise<{ found: false } | { found: true; result: DbSearchResult }> {
+  searchPrincipal(args: { principal: string }): Promise<FoundOrNot<DbSearchResult>> {
     throw new Error('not yet implemented');
   }
 

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -140,7 +140,7 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     return Promise.resolve({ results, total: blockList.length });
   }
 
-  getBlockTxsRows(indexBlockHash: string): Promise<FoundOrNot<DbTx[]>> {
+  getBlockTxsRows(blockHash: string): Promise<FoundOrNot<DbTx[]>> {
     throw new Error('not yet implemented');
   }
 

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -15,6 +15,7 @@ import {
   DbFaucetRequestCurrency,
   DbMempoolTx,
   DbSearchResult,
+  DbStxBalance,
 } from './common';
 import { logger, FoundOrNot } from '../helpers';
 import { TransactionType } from '@blockstack/stacks-blockchain-api-types';
@@ -296,22 +297,15 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     throw new Error('not yet implemented');
   }
 
-  getStxBalance(
-    stxAddress: string
-  ): Promise<{ balance: bigint; totalSent: bigint; totalReceived: bigint }> {
+  getStxBalance(stxAddress: string): Promise<DbStxBalance> {
     throw new Error('not yet implemented');
   }
 
-  getStxBalanceAtBlock(
-    stxAddress: string,
-    blockHeight: number
-  ): Promise<{ balance: bigint; totalSent: bigint; totalReceived: bigint }> {
+  getStxBalanceAtBlock(stxAddress: string, blockHeight: number): Promise<DbStxBalance> {
     throw new Error('not yet implemented');
   }
 
-  getFungibleTokenBalances(
-    stxAddress: string
-  ): Promise<Map<string, { balance: bigint; totalSent: bigint; totalReceived: bigint }>> {
+  getFungibleTokenBalances(stxAddress: string): Promise<Map<string, DbStxBalance>> {
     throw new Error('not yet implemented');
   }
 

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -302,6 +302,13 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     throw new Error('not yet implemented');
   }
 
+  getStxBalanceAtBlock(
+    stxAddress: string,
+    blockHeight: number
+  ): Promise<{ balance: bigint; totalSent: bigint; totalReceived: bigint }> {
+    throw new Error('not yet implemented');
+  }
+
   getFungibleTokenBalances(
     stxAddress: string
   ): Promise<Map<string, { balance: bigint; totalSent: bigint; totalReceived: bigint }>> {

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -34,6 +34,7 @@ import {
   DataStoreUpdateData,
   DbFaucetRequestCurrency,
   DbMempoolTx,
+  DbMempoolTxId,
   DbSearchResult,
 } from './common';
 import { TransactionType } from '@blockstack/stacks-blockchain-api-types';
@@ -143,6 +144,11 @@ const MEMPOOL_TX_COLUMNS = `
   coinbase_payload
 `;
 
+const MEMPOOL_TX_ID_COLUMNS = `
+  -- required columns
+  tx_id
+`;
+
 const BLOCK_COLUMNS = `
   block_hash, index_block_hash, parent_index_block_hash, parent_block_hash, parent_microblock, block_height, burn_block_time, canonical
 `;
@@ -238,6 +244,9 @@ interface TxQueryResult {
   coinbase_payload?: Buffer;
 }
 
+interface MempoolTxIdQueryResult {
+  tx_id: Buffer;
+}
 interface FaucetRequestQueryResult {
   currency: string;
   ip: string;
@@ -1136,6 +1145,38 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     );
 
     const parsed = resultQuery.rows.map(r => this.parseMempoolTxQueryResult(r));
+    return { results: parsed, total: totalQuery.rows[0].count };
+  }
+
+  async getMempoolTxIdList({
+    limit,
+    offset,
+  }: {
+    limit: number;
+    offset: number;
+  }): Promise<{ results: DbMempoolTxId[]; total: number }> {
+    const totalQuery = await this.pool.query<{ count: number }>(
+      `
+      SELECT COUNT(*)::integer
+      FROM mempool_txs
+      `
+    );
+    const resultQuery = await this.pool.query<MempoolTxIdQueryResult>(
+      `
+      SELECT ${MEMPOOL_TX_ID_COLUMNS}
+      FROM mempool_txs
+      ORDER BY receipt_time DESC
+      LIMIT $1
+      OFFSET $2
+      `,
+      [limit, offset]
+    );
+    const parsed = resultQuery.rows.map(r => {
+      const tx: DbMempoolTxId = {
+        tx_id: bufferToHexPrefixString(r.tx_id),
+      };
+      return tx;
+    });
     return { results: parsed, total: totalQuery.rows[0].count };
   }
 

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -842,7 +842,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       `
       SELECT ${BLOCK_COLUMNS}
       FROM blocks
-      WHERE block_height = $1
+      WHERE block_height = $1 AND canonical = true
       `,
       [block_height]
     );
@@ -859,6 +859,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       `
       SELECT ${BLOCK_COLUMNS}
       FROM blocks
+      WHERE canonical = true
       ORDER BY  block_height DESC
       LIMIT 1
       `
@@ -911,7 +912,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       `
       SELECT ${TX_COLUMNS}
       FROM txs
-      WHERE block_hash = $1
+      WHERE block_hash = $1 AND canonical = true
       `,
       [hexToBuffer(indexBlockHash)]
     );

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -36,6 +36,7 @@ import {
   DbMempoolTx,
   DbMempoolTxId,
   DbSearchResult,
+  DbStxBalance,
 } from './common';
 import { TransactionType } from '@blockstack/stacks-blockchain-api-types';
 import { getTxTypeId } from '../api/controllers/db-controller';
@@ -1596,9 +1597,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     return { found: true, result };
   }
 
-  async getStxBalance(
-    stxAddress: string
-  ): Promise<{ balance: bigint; totalSent: bigint; totalReceived: bigint }> {
+  async getStxBalance(stxAddress: string): Promise<DbStxBalance> {
     const result = await this.pool.query<{
       credit_total: string | null;
       debit_total: string | null;
@@ -1641,10 +1640,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     };
   }
 
-  async getStxBalanceAtBlock(
-    stxAddress: string,
-    blockHeight: number
-  ): Promise<{ balance: bigint; totalSent: bigint; totalReceived: bigint }> {
+  async getStxBalanceAtBlock(stxAddress: string, blockHeight: number): Promise<DbStxBalance> {
     const result = await this.pool.query<{
       credit_total: string | null;
       debit_total: string | null;
@@ -1789,9 +1785,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     };
   }
 
-  async getFungibleTokenBalances(
-    stxAddress: string
-  ): Promise<Map<string, { balance: bigint; totalSent: bigint; totalReceived: bigint }>> {
+  async getFungibleTokenBalances(stxAddress: string): Promise<Map<string, DbStxBalance>> {
     const result = await this.pool.query<{
       asset_identifier: string;
       credit_total: string | null;

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -907,14 +907,14 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     return { results: txIds };
   }
 
-  async getBlockTxsRows(indexBlockHash: string) {
+  async getBlockTxsRows(blockHash: string) {
     const result = await this.pool.query<TxQueryResult>(
       `
       SELECT ${TX_COLUMNS}
       FROM txs
       WHERE block_hash = $1 AND canonical = true
       `,
-      [hexToBuffer(indexBlockHash)]
+      [hexToBuffer(blockHash)]
     );
     if (result.rowCount === 0) {
       return { found: false } as const;

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1911,11 +1911,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     return { results: parsed, total: count };
   }
 
-  async searchHash({
-    hash,
-  }: {
-    hash: string;
-  }): Promise<{ found: false } | { found: true; result: DbSearchResult }> {
+  async searchHash({ hash }: { hash: string }): Promise<FoundOrNot<DbSearchResult>> {
     const txQuery = await this.pool.query<TxQueryResult>(
       `SELECT ${TX_COLUMNS} FROM txs WHERE tx_id = $1 LIMIT 1`,
       [hexToBuffer(hash)]
@@ -1966,11 +1962,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     return { found: false };
   }
 
-  async searchPrincipal({
-    principal,
-  }: {
-    principal: string;
-  }): Promise<{ found: false } | { found: true; result: DbSearchResult }> {
+  async searchPrincipal({ principal }: { principal: string }): Promise<FoundOrNot<DbSearchResult>> {
     const isContract = principal.includes('.');
     const entityType = isContract ? 'contract_address' : 'standard_address';
     const successResponse = {

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -730,7 +730,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     logger.verbose(`Entities marked as non-canonical: ${markedNonCanonical}`);
   }
 
-  static async connect(): Promise<PgDataStore> {
+  static async connect(skipMigrations = false): Promise<PgDataStore> {
     const clientConfig = getPgClientConfig();
 
     const initTimer = stopwatch();
@@ -762,7 +762,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       throw connectionError;
     }
 
-    await runMigrations(clientConfig);
+    if (!skipMigrations) {
+      await runMigrations(clientConfig);
+    }
     const pool = new Pool({
       ...clientConfig,
     });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,8 +4,6 @@ import * as dotenv from 'dotenv';
 import * as path from 'path';
 import * as winston from 'winston';
 import { c32addressDecode } from 'c32check';
-import * as WebSocket from 'ws';
-import { TransactionStatus } from '@blockstack/stacks-blockchain-api-types';
 
 export const isDevEnv = process.env.NODE_ENV === 'development';
 export const isTestEnv = process.env.NODE_ENV === 'test';
@@ -304,6 +302,19 @@ export function getOrAdd<K, V>(map: Map<K, V>, key: K, create: () => V): V {
   let val = map.get(key);
   if (val === undefined) {
     val = create();
+    map.set(key, val);
+  }
+  return val;
+}
+
+export async function getOrAddAsync<K, V>(
+  map: Map<K, V>,
+  key: K,
+  create: () => PromiseLike<V>
+): Promise<V> {
+  let val = map.get(key);
+  if (val === undefined) {
+    val = await create();
     map.set(key, val);
   }
   return val;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -159,7 +159,7 @@ export function digestSha512_256(input: Buffer): Buffer {
   return digest;
 }
 
-function isValidC32Address(stxAddress: string): boolean {
+export function isValidC32Address(stxAddress: string): boolean {
   try {
     c32addressDecode(stxAddress);
     return true;

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -1,0 +1,171 @@
+import { DbMempoolTx, DbTx } from './datastore/common';
+import { getTxTypeString, getTxStatusString } from './api/controllers/db-controller';
+
+import { assertNotNullish as unwrapOptional, bufferToHexPrefixString } from './helpers';
+import { RosettaOperation } from '@blockstack/stacks-blockchain-api-types';
+
+enum CoinAction {
+  CoinSpent = 'coin_spent',
+  CoinCreated = 'coin_created',
+}
+
+export function getOperations(tx: DbMempoolTx | DbTx): RosettaOperation[] {
+  const operations: RosettaOperation[] = [];
+  const txType = getTxTypeString(tx.type_id);
+  switch (txType) {
+    case 'token_transfer':
+      operations.push(makeFeeOperation(tx));
+      operations.push(makeSenderOperation(tx, operations.length));
+      operations.push(makeRecieverOperation(tx, operations.length));
+      break;
+    case 'contract_call':
+      operations.push(makeFeeOperation(tx));
+      operations.push(makeCallContractOperation(tx, operations.length));
+      break;
+    case 'smart_contract':
+      operations.push(makeFeeOperation(tx));
+      operations.push(makeDeployContractOperation(tx, operations.length));
+      break;
+    case 'coinbase':
+      operations.push(makeCoinbaseOperation(tx, 0));
+      break;
+    case 'poison_microblock':
+      operations.push(makePoisonMicroblockOperation(tx, 0));
+      break;
+    default:
+      throw new Error(`Unexpected tx type: ${JSON.stringify(txType)}`);
+  }
+  return operations;
+}
+
+function makeFeeOperation(tx: DbMempoolTx | DbTx): RosettaOperation {
+  const fee: RosettaOperation = {
+    operation_identifier: { index: 0 },
+    type: 'fee',
+    status: getTxStatusString(tx.status),
+    account: { address: tx.sender_address },
+    amount: {
+      value: (BigInt(0) - tx.fee_rate).toString(10),
+      currency: { symbol: 'STX', decimals: 6 },
+    },
+  };
+
+  return fee;
+}
+
+function makeSenderOperation(tx: DbMempoolTx | DbTx, index: number): RosettaOperation {
+  const sender: RosettaOperation = {
+    operation_identifier: { index: index },
+    type: getTxTypeString(tx.type_id),
+    status: getTxStatusString(tx.status),
+    account: {
+      address: unwrapOptional(tx.sender_address, () => 'Unexpected nullish sender_address'),
+    },
+    amount: {
+      value:
+        '-' +
+        unwrapOptional(
+          tx.token_transfer_amount,
+          () => 'Unexpected nullish token_transfer_amount'
+        ).toString(10),
+      currency: { symbol: 'STX', decimals: 6 },
+    },
+    coin_change: {
+      coin_action: CoinAction.CoinSpent,
+      coin_identifier: { identifier: tx.tx_id + ':' + index },
+    },
+  };
+
+  return sender;
+}
+
+function makeRecieverOperation(tx: DbMempoolTx | DbTx, index: number): RosettaOperation {
+  const reciever: RosettaOperation = {
+    operation_identifier: { index: index },
+    related_operations: [{ index: 0, operation_identifier: { index: 1 } }],
+    type: getTxTypeString(tx.type_id),
+    status: getTxStatusString(tx.status),
+    account: {
+      address: unwrapOptional(
+        tx.token_transfer_recipient_address,
+        () => 'Unexpected nullish token_transfer_recipient_address'
+      ),
+    },
+    amount: {
+      value: unwrapOptional(
+        tx.token_transfer_amount,
+        () => 'Unexpected nullish token_transfer_amount'
+      ).toString(10),
+      currency: { symbol: 'STX', decimals: 6 },
+    },
+    coin_change: {
+      coin_action: CoinAction.CoinCreated,
+      coin_identifier: { identifier: tx.tx_id + ':' + index },
+    },
+  };
+
+  return reciever;
+}
+
+function makeDeployContractOperation(tx: DbMempoolTx | DbTx, index: number): RosettaOperation {
+  const deployer: RosettaOperation = {
+    operation_identifier: { index: index },
+    type: getTxTypeString(tx.type_id),
+    status: getTxStatusString(tx.status),
+    account: {
+      address: unwrapOptional(tx.sender_address, () => 'Unexpected nullish sender_address'),
+    },
+  };
+
+  return deployer;
+}
+
+function makeCallContractOperation(tx: DbMempoolTx | DbTx, index: number): RosettaOperation {
+  const caller: RosettaOperation = {
+    operation_identifier: { index: index },
+    type: getTxTypeString(tx.type_id),
+    status: getTxStatusString(tx.status),
+    account: {
+      address: unwrapOptional(tx.sender_address, () => 'Unexpected nullish sender_address'),
+      sub_account: {
+        address: tx.contract_call_contract_id ? tx.contract_call_contract_id : '',
+        metadata: {
+          contract_call_function_name: tx.contract_call_function_name,
+          contract_call_function_args: bufferToHexPrefixString(
+            unwrapOptional(tx.contract_call_function_args, () => '')
+          ),
+          raw_result: tx.raw_result,
+        },
+      },
+    },
+  };
+
+  return caller;
+}
+function makeCoinbaseOperation(tx: DbMempoolTx | DbTx, index: number): RosettaOperation {
+  // TODO : Add more mappings in operations for coinbase
+  const sender: RosettaOperation = {
+    operation_identifier: { index: index },
+    type: getTxTypeString(tx.type_id),
+    status: getTxStatusString(tx.status),
+    account: {
+      address: unwrapOptional(tx.sender_address, () => 'Unexpected nullish sender_address'),
+    },
+  };
+
+  return sender;
+}
+
+function makePoisonMicroblockOperation(tx: DbMempoolTx | DbTx, index: number): RosettaOperation {
+  // TODO : add more mappings in operations for poison-microblock
+  const sender: RosettaOperation = {
+    operation_identifier: { index: index },
+    type: getTxTypeString(tx.type_id),
+    status: getTxStatusString(tx.status),
+    account: {
+      address: unwrapOptional(tx.sender_address, () => 'Unexpected nullish sender_address'),
+    },
+  };
+
+  return sender;
+}

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -16,7 +16,7 @@ export function getOperations(tx: DbMempoolTx | DbTx): RosettaOperation[] {
     case 'token_transfer':
       operations.push(makeFeeOperation(tx));
       operations.push(makeSenderOperation(tx, operations.length));
-      operations.push(makeRecieverOperation(tx, operations.length));
+      operations.push(makeReceiverOperation(tx, operations.length));
       break;
     case 'contract_call':
       operations.push(makeFeeOperation(tx));
@@ -79,8 +79,8 @@ function makeSenderOperation(tx: DbMempoolTx | DbTx, index: number): RosettaOper
   return sender;
 }
 
-function makeRecieverOperation(tx: DbMempoolTx | DbTx, index: number): RosettaOperation {
-  const reciever: RosettaOperation = {
+function makeReceiverOperation(tx: DbMempoolTx | DbTx, index: number): RosettaOperation {
+  const receiver: RosettaOperation = {
     operation_identifier: { index: index },
     related_operations: [{ index: 0, operation_identifier: { index: 1 } }],
     type: getTxTypeString(tx.type_id),
@@ -104,7 +104,7 @@ function makeRecieverOperation(tx: DbMempoolTx | DbTx, index: number): RosettaOp
     },
   };
 
-  return reciever;
+  return receiver;
 }
 
 function makeDeployContractOperation(tx: DbMempoolTx | DbTx, index: number): RosettaOperation {

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -1,0 +1,395 @@
+import { PgDataStore, cycleMigrations, runMigrations } from '../datastore/postgres-store';
+import { PoolClient } from 'pg';
+import { ApiServer, startApiServer } from '../api/init';
+import * as supertest from 'supertest';
+import { startEventServer } from '../event-stream/event-server';
+import { Server } from 'net';
+import { DbBlock, DbTx, DbMempoolTx, DbTxStatus } from '../datastore/common';
+import * as assert from 'assert';
+import { makeSTXTokenTransfer, StacksTestnet } from '@blockstack/stacks-transactions';
+import * as BN from 'bn.js';
+import { getCoreNodeEndpoint, StacksCoreRpcClient } from '../core-rpc/client';
+import { timeout } from '../helpers';
+
+describe('Rosetta API', () => {
+  let db: PgDataStore;
+  let client: PoolClient;
+  let eventServer: Server;
+  let api: ApiServer;
+
+  function getStacksTestnetNetwork() {
+    const stacksNetwork = new StacksTestnet();
+    stacksNetwork.coreApiUrl = `http://${getCoreNodeEndpoint()}`;
+    return stacksNetwork;
+  }
+
+  beforeAll(async () => {
+    process.env.PG_DATABASE = 'postgres';
+    await cycleMigrations();
+    db = await PgDataStore.connect();
+    client = await db.pool.connect();
+    eventServer = await startEventServer(db);
+    api = await startApiServer(db);
+  });
+
+  test('network/list', async () => {
+    const query1 = await supertest(api.server).post(`/rosetta/v1/network/list`);
+    expect(query1.status).toBe(200);
+    expect(query1.type).toBe('application/json');
+    expect(JSON.parse(query1.text)).toEqual({
+      network_identifiers: [{ blockchain: 'stacks', network: 'testnet' }],
+    });
+  });
+
+  test('network/options', async () => {
+    const nodeVersion = process.version;
+    const middlewareVersion = require('../../package.json').version;
+    const query1 = await supertest(api.server)
+      .post(`/rosetta/v1/network/options`)
+      .send({ network_identifier: { blockchain: 'stacks', network: 'testnet' } });
+    expect(query1.status).toBe(200);
+    expect(query1.type).toBe('application/json');
+    expect(JSON.parse(query1.text)).toEqual({
+      version: {
+        rosetta_version: '1.4.2',
+        node_version: nodeVersion,
+        middleware_version: middlewareVersion,
+      },
+      allow: {
+        operation_statuses: [
+          { status: 'success', successful: true },
+          { status: 'pending', successful: true },
+          { status: 'abort_by_response', successful: false },
+          { status: 'abort_by_post_condition', successful: false },
+        ],
+        operation_types: [
+          'token_transfer',
+          'contract_call',
+          'smart_contract',
+          'coinbase',
+          'poison_microblock',
+          'fee',
+        ],
+        errors: [
+          { code: 601, message: 'Invalid Account.', retriable: true },
+          { code: 602, message: 'Insufficient Funds.', retriable: true },
+          { code: 603, message: 'Account is empty.', retriable: true },
+          { code: 604, message: 'Invalid block index.', retriable: true },
+          { code: 605, message: 'Block not found.', retriable: true },
+          { code: 606, message: 'Invalid block hash.', retriable: true },
+          { code: 607, message: 'Transaction not found.', retriable: true },
+          { code: 608, message: 'Invalid transaction hash.', retriable: true },
+          { code: 609, message: 'Invalid params.', retriable: true },
+          { code: 610, message: 'Invalid network.', retriable: true },
+          { code: 611, message: 'Invalid blockchain.', retriable: true },
+          { code: 612, message: 'Unknown error.', retriable: false },
+          { code: 613, message: 'Network identifier object is null.', retriable: true },
+          { code: 614, message: 'Account identifier object is null.', retriable: true },
+          { code: 615, message: 'Block identifier is null.', retriable: true },
+          { code: 616, message: 'Transaction identifier is null.', retriable: true },
+          { code: 617, message: 'Blockchain name is null.', retriable: true },
+          { code: 618, message: 'Network name is null.', retriable: true },
+        ],
+        historical_balance_lookup: true,
+      },
+    });
+  });
+
+  test('network/options - bad request', async () => {
+    const query1 = await supertest(api.server).post(`/rosetta/v1/network/options`).send({});
+    expect(query1.status).toBe(400);
+    expect(query1.type).toBe('application/json');
+    expect(JSON.parse(query1.text)).toEqual({
+      code: 613,
+      message: 'Network identifier object is null.',
+      retriable: true,
+      details: { message: "should have required property 'network_identifier'" },
+    });
+  });
+
+  test('network/status - invalid blockchain', async () => {
+    const query1 = await supertest(api.server)
+      .post(`/rosetta/v1/network/status`)
+      .send({ network_identifier: { blockchain: 'bitcoin', network: 'testnet' } });
+    expect(query1.status).toBe(400);
+    expect(query1.type).toBe('application/json');
+    expect(JSON.parse(query1.text)).toEqual({
+      code: 611,
+      message: 'Invalid blockchain.',
+      retriable: true,
+    });
+  });
+
+  test('network/status - invalid network', async () => {
+    const query1 = await supertest(api.server)
+      .post(`/rosetta/v1/network/status`)
+      .send({ network_identifier: { blockchain: 'stacks', network: 'mainnet' } });
+    expect(query1.status).toBe(400);
+    expect(query1.type).toBe('application/json');
+    expect(JSON.parse(query1.text)).toEqual({
+      code: 610,
+      message: 'Invalid network.',
+      retriable: true,
+    });
+  });
+
+  test('network/status', async () => {
+    // skip first a block (so we are at least N+1 blocks)
+    await new Promise<DbBlock>(resolve =>
+      api.datastore.once('blockUpdate', block => resolve(block))
+    );
+    const block = await new Promise<DbBlock>(resolve =>
+      api.datastore.once('blockUpdate', block => resolve(block))
+    );
+    const genesisBlock = await api.datastore.getBlockByHeight(1);
+    assert(genesisBlock.found);
+    const query1 = await supertest(api.address)
+      .post(`/rosetta/v1/network/status`)
+      .send({ network_identifier: { blockchain: 'stacks', network: 'testnet' } });
+    expect(query1.status).toBe(200);
+    expect(query1.type).toBe('application/json');
+    expect(JSON.parse(query1.text)).toEqual({
+      current_block_identifier: {
+        index: block.block_height,
+        hash: block.block_hash,
+      },
+      current_block_timestamp: block.burn_block_time * 1000,
+      genesis_block_identifier: {
+        index: genesisBlock.result.block_height,
+        hash: genesisBlock.result.block_hash,
+      },
+      peers: [],
+    });
+  });
+
+  test('block - by index', async () => {
+    const blockHeight = 2;
+    const block = await api.datastore.getBlockByHeight(blockHeight);
+    assert(block.found);
+    const txs = await api.datastore.getBlockTxsRows(block.result.block_hash);
+    assert(txs.found);
+    const query1 = await supertest(api.address)
+      .post(`/rosetta/v1/block`)
+      .send({
+        network_identifier: { blockchain: 'stacks', network: 'testnet' },
+        block_identifier: { index: blockHeight },
+      });
+    expect(query1.status).toBe(200);
+    expect(query1.type).toBe('application/json');
+    expect(JSON.parse(query1.text)).toEqual({
+      block: {
+        block_identifier: {
+          index: blockHeight,
+          hash: block.result.block_hash,
+        },
+        parent_block_identifier: {
+          index: blockHeight - 1,
+          hash: block.result.parent_block_hash,
+        },
+        timestamp: block.result.burn_block_time * 1000,
+        transactions: [
+          {
+            transaction_identifier: {
+              hash: txs.result[0].tx_id,
+            },
+            operations: [
+              {
+                operation_identifier: { index: 0 },
+                type: 'coinbase',
+                status: 'success',
+                account: { address: txs.result[0].sender_address },
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  test('block - by hash', async () => {
+    const blockHeight = 2;
+    const block = await api.datastore.getBlockByHeight(blockHeight);
+    assert(block.found);
+    const txs = await api.datastore.getBlockTxsRows(block.result.block_hash);
+    assert(txs.found);
+    const query1 = await supertest(api.address)
+      .post(`/rosetta/v1/block`)
+      .send({
+        network_identifier: { blockchain: 'stacks', network: 'testnet' },
+        block_identifier: { hash: block.result.block_hash },
+      });
+    expect(query1.status).toBe(200);
+    expect(query1.type).toBe('application/json');
+    expect(JSON.parse(query1.text)).toEqual({
+      block: {
+        block_identifier: {
+          index: blockHeight,
+          hash: block.result.block_hash,
+        },
+        parent_block_identifier: {
+          index: blockHeight - 1,
+          hash: block.result.parent_block_hash,
+        },
+        timestamp: block.result.burn_block_time * 1000,
+        transactions: [
+          {
+            transaction_identifier: {
+              hash: txs.result[0].tx_id,
+            },
+            operations: [
+              {
+                operation_identifier: { index: 0 },
+                type: 'coinbase',
+                status: 'success',
+                account: { address: txs.result[0].sender_address },
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  test('block - get latest', async () => {
+    const block = await api.datastore.getCurrentBlock();
+    assert(block.found);
+    const txs = await api.datastore.getBlockTxsRows(block.result.block_hash);
+    assert(txs.found);
+    const query1 = await supertest(api.address)
+      .post(`/rosetta/v1/block`)
+      .send({
+        network_identifier: { blockchain: 'stacks', network: 'testnet' },
+      });
+    expect(query1.status).toBe(200);
+    expect(query1.type).toBe('application/json');
+    expect(JSON.parse(query1.text)).toEqual({
+      block: {
+        block_identifier: {
+          index: block.result.block_height,
+          hash: block.result.block_hash,
+        },
+        parent_block_identifier: {
+          index: block.result.block_height - 1,
+          hash: block.result.parent_block_hash,
+        },
+        timestamp: block.result.burn_block_time * 1000,
+        transactions: [
+          {
+            transaction_identifier: {
+              hash: txs.result[0].tx_id,
+            },
+            operations: [
+              {
+                operation_identifier: { index: 0 },
+                type: 'coinbase',
+                status: 'success',
+                account: { address: txs.result[0].sender_address },
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  test('block/transaction', async () => {
+    let expectedTxId: string = '';
+    const broadcastTx = new Promise<DbTx>(resolve => {
+      const listener: (info: DbTx | DbMempoolTx) => void = info => {
+        if (info.tx_id === expectedTxId && info.status === DbTxStatus.Success) {
+          api.datastore.removeListener('txUpdate', listener);
+          resolve(info as DbTx);
+        }
+      };
+      api.datastore.addListener('txUpdate', listener);
+    });
+    const transferTx = await makeSTXTokenTransfer({
+      recipient: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
+      amount: new BN(3852),
+      senderKey: 'c71700b07d520a8c9731e4d0f095aa6efb91e16e25fb27ce2b72e7b698f8127a01',
+      network: getStacksTestnetNetwork(),
+      memo: 'test1234',
+    });
+    expectedTxId = '0x' + transferTx.txid();
+    const submitResult = await new StacksCoreRpcClient().sendTransaction(transferTx.serialize());
+    expect(submitResult.txId).toBe(expectedTxId);
+    await broadcastTx;
+    const txDb = await api.datastore.getTx(expectedTxId);
+    assert(txDb.found);
+    const query1 = await supertest(api.server)
+      .post(`/rosetta/v1/block/transaction`)
+      .send({
+        network_identifier: { blockchain: 'stacks', network: 'testnet' },
+        block_identifier: { index: txDb.result.block_height, hash: txDb.result.block_hash },
+        transaction_identifier: { hash: txDb.result.tx_id },
+      });
+    expect(query1.status).toBe(200);
+    expect(query1.type).toBe('application/json');
+    expect(JSON.parse(query1.text)).toEqual({
+      transaction_identifier: {
+        hash: txDb.result.tx_id,
+      },
+      operations: [
+        {
+          operation_identifier: { index: 0 },
+          type: 'fee',
+          status: 'success',
+          account: { address: 'ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR' },
+          amount: { value: '-180', currency: { symbol: 'STX', decimals: 6 } },
+        },
+        {
+          operation_identifier: { index: 1 },
+          type: 'token_transfer',
+          status: 'success',
+          account: { address: 'ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR' },
+          amount: { value: '-3852', currency: { symbol: 'STX', decimals: 6 } },
+          coin_change: {
+            coin_action: 'coin_spent',
+            coin_identifier: {
+              identifier: `${txDb.result.tx_id}:1`,
+            },
+          },
+        },
+        {
+          operation_identifier: { index: 2 },
+          related_operations: [{ index: 0, operation_identifier: { index: 1 } }],
+          type: 'token_transfer',
+          status: 'success',
+          account: { address: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP' },
+          amount: { value: '3852', currency: { symbol: 'STX', decimals: 6 } },
+          coin_change: {
+            coin_action: 'coin_created',
+            coin_identifier: {
+              identifier: `${txDb.result.tx_id}:2`,
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  test('block/transaction - invalid transaction hash', async () => {
+    const query1 = await supertest(api.server)
+      .post(`/rosetta/v1/block/transaction`)
+      .send({
+        network_identifier: { blockchain: 'stacks', network: 'testnet' },
+        block_identifier: { index: 3, hash: '0x3a' },
+        transaction_identifier: { hash: '3' },
+      });
+    expect(query1.status).toBe(400);
+    expect(query1.type).toBe('application/json');
+    expect(JSON.parse(query1.text)).toEqual({
+      code: 608,
+      message: 'Invalid transaction hash.',
+      retriable: true,
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise(resolve => eventServer.close(() => resolve()));
+    await api.terminate();
+    client.release();
+    await db?.close();
+    await runMigrations(undefined, 'down');
+  });
+});

--- a/src/tests-rosetta/setup.ts
+++ b/src/tests-rosetta/setup.ts
@@ -1,0 +1,23 @@
+import { loadDotEnv } from '../helpers';
+import { StacksCoreRpcClient } from '../core-rpc/client';
+import { PgDataStore } from '../datastore/postgres-store';
+
+export interface GlobalServices {
+  db: PgDataStore;
+}
+
+export default async (): Promise<void> => {
+  console.log('Jest - setup..');
+  if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV = 'test';
+  }
+  loadDotEnv();
+  const db = await PgDataStore.connect(true);
+  console.log('Waiting for RPC connection to core node..');
+  await new StacksCoreRpcClient().waitForConnection(60000);
+  const globalServices: GlobalServices = {
+    db: db,
+  };
+  Object.assign(global, globalServices);
+  console.log('Jest - setup done');
+};

--- a/src/tests-rosetta/teardown.ts
+++ b/src/tests-rosetta/teardown.ts
@@ -1,0 +1,8 @@
+import type { GlobalServices } from './setup';
+
+export default async (): Promise<void> => {
+  console.log('Jest - teardown..');
+  const globalServices = (global as unknown) as GlobalServices;
+  await globalServices.db.close();
+  console.log('Jest - teardown done');
+};

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -16,7 +16,7 @@ import {
 import { PgDataStore, cycleMigrations, runMigrations } from '../datastore/postgres-store';
 import { PoolClient } from 'pg';
 import { parseDbEvent } from '../api/controllers/db-controller';
-import { assert } from 'assert';
+import * as assert from 'assert';
 
 describe('in-memory datastore', () => {
   let db: MemoryDataStore;

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -16,14 +16,7 @@ import {
 import { PgDataStore, cycleMigrations, runMigrations } from '../datastore/postgres-store';
 import { PoolClient } from 'pg';
 import { parseDbEvent } from '../api/controllers/db-controller';
-
-// This can be removed once typing bug is sorted https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42786
-function assert(condition: any, msg?: string): asserts condition {
-  if (!condition) {
-    expect(condition).toBe(true);
-    throw new Error(msg ?? 'Assertion failed');
-  }
-}
+import { assert } from 'assert';
 
 describe('in-memory datastore', () => {
   let db: MemoryDataStore;

--- a/stacks-blockchain/docker/Dockerfile
+++ b/stacks-blockchain/docker/Dockerfile
@@ -14,6 +14,10 @@ FROM debian:stretch
 COPY wait-for-it.sh /bin/wait-for-it.sh
 RUN chmod +x /bin/wait-for-it.sh
 
+COPY docker-entrypoint.sh /bin/
+RUN chmod +x /bin/docker-entrypoint.sh
+
 COPY --from=build /bin/stacks-node /bin/
 
+ENTRYPOINT ["/bin/docker-entrypoint.sh"]
 CMD ["stacks-node"]

--- a/stacks-blockchain/docker/docker-entrypoint.sh
+++ b/stacks-blockchain/docker/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Use this script to enable host.docker.internal on Docker for linux.
+# See https://github.com/bufferings/docker-access-host
+
+HOST_DOMAIN="host.docker.internal"
+ping -q -c1 $HOST_DOMAIN > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  HOST_IP=$(ip route | awk 'NR==1 {print $3}')
+  echo -e "$HOST_IP\t$HOST_DOMAIN" >> /etc/hosts
+fi
+
+cat /etc/hosts
+echo "patched host.docker.internal"
+
+exec "$@"


### PR DESCRIPTION
Implemented calls:

[X] `/rosetta/v1/network/list`
[X] `/rosetta/v1/network/options`
[X] `/rosetta/v1/network/status`
[X] `/rosetta/v1/block`
[X] `/rosetta/v1/block/transaction`
[X ] `/rosetta/v1/mempool`
[X] `/rosetta/v1/mempool/transaction`
[X] `/rosetta/v1/account/balance`

The calls can be tested:

`/network/list`:
```
curl -s -d '' http://localhost:3999/rosetta/v1/network/list | jq .
```
`/network/options`:
```
curl -s -H 'content-type: application/json' \
    -d '{"network_identifier": {"blockchain": "stacks", "network": "testnet"}}' \
    http://localhost:3999/rosetta/v1/network/options  | jq .
```
`/network/status`:
```
curl -s -H 'content-type: application/json' \
    -d '{"network_identifier": {"blockchain": "stacks", "network": "testnet"}}' \
    http://localhost:3999/rosetta/v1/network/status  | jq .
```
`/network/status` currently returns an empty peers array when run against the offline docker image (using `stacks-blockchain/Stacks-dev.toml`)

The validation code checks requests against the schema files, and performs some further tests:
```
curl -s -H 'content-type: application/json' \
    -d '{}}' \
    http://localhost:3999/rosetta/v1/network/options  | jq .
```
=>
```
{
  "code": 613,
  "message": "Network identifier object is null",
  "retriable": true,
  "details": {
    "message": "should have required property 'network_identifier'"
  }
}
```
```
curl -s -H 'content-type: application/json' \
    -d '{"network_identifier": {"blockchain": "bitcoin", "network": "testnet"}}' \
    http://localhost:3999/rosetta/v1/network/status  | jq .
```
=> 
```
{
  "code": 611,
  "message": "Invalid blockchain.",
  "retriable": true
}
```
```
curl -s -H 'content-type: application/json' \
    -d '{"network_identifier": {"blockchain": "stacks", "network": "mainnet"}}' \
    http://localhost:3999/rosetta/v1/network/status  | jq .
```
=> 
```
{
  "code": 610,
  "message": "Invalid network.",
  "retriable": true
}
```
```
curl -s -H 'content-type: application/json' \
    -d '{"network_identifier": {"blockchain": "stacks", "network": "testnet"}, "block_identifier": {"index": 3}, "transaction_identifier": {"hash": "3"}}' \
    http://localhost:3999/rosetta/v1/block/transaction  | jq .
```
=>
```
{
  "code": 608,
  "message": "Invalid transaction hash.",
  "retriable": true
}
```