### PR TITLE
feat: hacks to get started with pox

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 PG_HOST=127.0.0.1
-PG_PORT=5490
+PG_PORT=5432
 PG_USER=postgres
 PG_PASSWORD=postgres
-PG_DATABASE=stacks_blockchain_api
+PG_DATABASE=stacks_core_sidecar_dev
 
 STACKS_CORE_EVENT_PORT=3700
 STACKS_CORE_EVENT_HOST=127.0.0.1

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -529,34 +529,36 @@ export async function getTxFromDataStore(
         () => 'Unexpected nullish contract_call_function_name'
       );
       apiTx.post_conditions = postConditions.map(pc => serializePostCondition(pc));
+      // TODO: Sidecar does not know about contracts created in boot code
       const contract = await db.getSmartContract(contractId);
       if (!contract.found) {
-        throw new Error(`Failed to lookup smart contract by ID ${contractId}`);
+        // throw new Error(`Failed to lookup smart contract by ID ${contractId}`);
       }
-      const contractAbi: ClarityAbi = JSON.parse(contract.result.abi);
-      const functionAbi = contractAbi.functions.find(fn => fn.name === functionName);
-      if (!functionAbi) {
-        throw new Error(`Could not find function name "${functionName}" in ABI for ${contractId}`);
-      }
+      // const contractAbi: ClarityAbi = JSON.parse(contract.result.abi);
+      // const functionAbi = contractAbi.functions.find(fn => fn.name === functionName);
+      // if (!functionAbi) {
+      //   throw new Error(`Could not find function name "${functionName}" in ABI for ${contractId}`);
+      // }
       apiTx.contract_call = {
         contract_id: contractId,
         function_name: functionName,
-        function_signature: abiFunctionToString(functionAbi),
+        function_signature: '',
+        // function_signature: abiFunctionToString(functionAbi),
       };
-      if (dbTx.contract_call_function_args) {
-        let fnArgIndex = 0;
-        apiTx.contract_call.function_args = readClarityValueArray(
-          dbTx.contract_call_function_args
-        ).map(c => {
-          const functionArgAbi = functionAbi.args[fnArgIndex++];
-          return {
-            hex: bufferToHexPrefixString(serializeCV(c)),
-            repr: cvToString(c),
-            name: functionArgAbi.name,
-            type: getTypeString(functionArgAbi.type),
-          };
-        });
-      }
+      // if (dbTx.contract_call_function_args) {
+      //   let fnArgIndex = 0;
+      //   apiTx.contract_call.function_args = readClarityValueArray(
+      //     dbTx.contract_call_function_args
+      //   ).map(c => {
+      //     const functionArgAbi = functionAbi.args[fnArgIndex++];
+      //     return {
+      //       hex: bufferToHexPrefixString(serializeCV(c)),
+      //       repr: cvToString(c),
+      //       name: functionArgAbi.name,
+      //       type: getTypeString(functionArgAbi.type),
+      //     };
+      //   });
+      // }
       break;
     }
     case 'poison_microblock': {

--- a/src/api/routes/faucets.ts
+++ b/src/api/routes/faucets.ts
@@ -88,7 +88,8 @@ export function createFaucetRouter(db: DataStore): RouterWithAsync {
         return;
       }
 
-      const stxAmount = 500_000; // 0.5 STX
+      // const stxAmount = 500_000; // 0.5 STX
+      const stxAmount = 50500000010000 + 50000;
       const tx = await makeSTXTokenTransfer({
         recipient: address,
         amount: new BN(stxAmount),

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -10,6 +10,7 @@ export enum CoreNodeEventType {
   NftMintEvent = 'nft_mint_event',
   FtTransferEvent = 'ft_transfer_event',
   FtMintEvent = 'ft_mint_event',
+  LockEvent = 'stx_lock_event',
 }
 
 // TODO: core-node should use a better encoding for this structure;
@@ -102,6 +103,10 @@ export interface FtMintEvent extends CoreNodeEventBase {
   };
 }
 
+export interface StxLockEvent extends CoreNodeEventBase {
+  type: CoreNodeEventType.LockEvent;
+}
+
 export type CoreNodeEvent =
   | SmartContractEvent
   | StxTransferEvent
@@ -110,7 +115,8 @@ export type CoreNodeEvent =
   | FtTransferEvent
   | FtMintEvent
   | NftTransferEvent
-  | NftMintEvent;
+  | NftMintEvent
+  | StxLockEvent;
 
 export type CoreNodeTxStatus = 'success' | 'abort_by_response' | 'abort_by_post_condition';
 

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -222,6 +222,10 @@ async function handleClientMessage(msg: CoreNodeMessage, db: DataStore): Promise
         dbTx.nftEvents.push(entry);
         break;
       }
+      case CoreNodeEventType.LockEvent: {
+        console.log(event);
+        break;
+      }
       default: {
         throw new Error(`Unexpected CoreNodeEventType: ${inspect(event)}`);
       }


### PR DESCRIPTION
This is just some hacky code that I used to get PoX working with the sidecar. Main issues:

- Faucet needed to send more STX
- Server would abort when it saw an unrecognized event. In this case we have a new event `stx_lock_event`
- The server doesn't know about smart contracts that were created during boot. So, if you tried to fetch a TX for a contract call to `pox.clar`, it'd throw, since that contract is not in the DB

This code should be considered all hacky workarounds, do not merge, only use if you need to use some PoX features locally today.