### PR TITLE
chore(openapi): use contract_address only #258

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "build": "rimraf ./lib && npm run generate-openapi && npm run build:node && npm run build:browser",
     "build:node": "tsc",
     "build:browser": "microbundle -i src/index.ts -o lib/index.umd.js --no-pkg-main -f umd --external none --globals none --tsconfig tsconfig.browser.json --name StacksBlockchainApiClient",
-    "test": "ts-node src/test.ts",
+    "test": "ts-node test/test.ts",
     "lint": "eslint . --ext .ts -f codeframe",
     "lint:prettier": "prettier --check ./src/**/*.{ts}",
     "open": "http-server -o 9222 -o index.html",

--- a/client/src/generated/apis/SmartContractsApi.ts
+++ b/client/src/generated/apis/SmartContractsApi.ts
@@ -30,7 +30,7 @@ import {
 } from '../models';
 
 export interface CallReadOnlyFunctionRequest {
-    stacksAddress: string;
+    contractAddress: string;
     contractName: string;
     functionName: string;
     readOnlyFunctionArgs: ReadOnlyFunctionArgs;
@@ -41,7 +41,7 @@ export interface GetContractByIdRequest {
 }
 
 export interface GetContractDataMapEntryRequest {
-    stacksAddress: string;
+    contractAddress: string;
     contractName: string;
     mapName: string;
     key: string;
@@ -55,12 +55,12 @@ export interface GetContractEventsByIdRequest {
 }
 
 export interface GetContractInterfaceRequest {
-    stacksAddress: string;
+    contractAddress: string;
     contractName: string;
 }
 
 export interface GetContractSourceRequest {
-    stacksAddress: string;
+    contractAddress: string;
     contractName: string;
     proof?: number;
 }
@@ -75,8 +75,8 @@ export class SmartContractsApi extends runtime.BaseAPI {
      * Call read-only function
      */
     async callReadOnlyFunctionRaw(requestParameters: CallReadOnlyFunctionRequest): Promise<runtime.ApiResponse<ReadOnlyFunctionSuccessResponse>> {
-        if (requestParameters.stacksAddress === null || requestParameters.stacksAddress === undefined) {
-            throw new runtime.RequiredError('stacksAddress','Required parameter requestParameters.stacksAddress was null or undefined when calling callReadOnlyFunction.');
+        if (requestParameters.contractAddress === null || requestParameters.contractAddress === undefined) {
+            throw new runtime.RequiredError('contractAddress','Required parameter requestParameters.contractAddress was null or undefined when calling callReadOnlyFunction.');
         }
 
         if (requestParameters.contractName === null || requestParameters.contractName === undefined) {
@@ -98,7 +98,7 @@ export class SmartContractsApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
         const response = await this.request({
-            path: `/v2/contracts/call-read/{stacks_address}/{contract_name}/{function_name}`.replace(`{${"stacks_address"}}`, encodeURIComponent(String(requestParameters.stacksAddress))).replace(`{${"contract_name"}}`, encodeURIComponent(String(requestParameters.contractName))).replace(`{${"function_name"}}`, encodeURIComponent(String(requestParameters.functionName))),
+            path: `/v2/contracts/call-read/{contract_address}/{contract_name}/{function_name}`.replace(`{${"contract_address"}}`, encodeURIComponent(String(requestParameters.contractAddress))).replace(`{${"contract_name"}}`, encodeURIComponent(String(requestParameters.contractName))).replace(`{${"function_name"}}`, encodeURIComponent(String(requestParameters.functionName))),
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
@@ -154,8 +154,8 @@ export class SmartContractsApi extends runtime.BaseAPI {
      * Get specific data-map inside a contract
      */
     async getContractDataMapEntryRaw(requestParameters: GetContractDataMapEntryRequest): Promise<runtime.ApiResponse<void>> {
-        if (requestParameters.stacksAddress === null || requestParameters.stacksAddress === undefined) {
-            throw new runtime.RequiredError('stacksAddress','Required parameter requestParameters.stacksAddress was null or undefined when calling getContractDataMapEntry.');
+        if (requestParameters.contractAddress === null || requestParameters.contractAddress === undefined) {
+            throw new runtime.RequiredError('contractAddress','Required parameter requestParameters.contractAddress was null or undefined when calling getContractDataMapEntry.');
         }
 
         if (requestParameters.contractName === null || requestParameters.contractName === undefined) {
@@ -181,7 +181,7 @@ export class SmartContractsApi extends runtime.BaseAPI {
         headerParameters['Content-Type'] = 'application/json';
 
         const response = await this.request({
-            path: `/v2/map_entry/{stacks_address}/{contract_name}/{map_name}`.replace(`{${"stacks_address"}}`, encodeURIComponent(String(requestParameters.stacksAddress))).replace(`{${"contract_name"}}`, encodeURIComponent(String(requestParameters.contractName))).replace(`{${"map_name"}}`, encodeURIComponent(String(requestParameters.mapName))),
+            path: `/v2/map_entry/{contract_address}/{contract_name}/{map_name}`.replace(`{${"contract_address"}}`, encodeURIComponent(String(requestParameters.contractAddress))).replace(`{${"contract_name"}}`, encodeURIComponent(String(requestParameters.contractName))).replace(`{${"map_name"}}`, encodeURIComponent(String(requestParameters.mapName))),
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
@@ -240,12 +240,12 @@ export class SmartContractsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Get contract interface using a `stacks_address` and contract name
+     * Get contract interface using a `contract_address` and `contract name`
      * Get contract interface
      */
     async getContractInterfaceRaw(requestParameters: GetContractInterfaceRequest): Promise<runtime.ApiResponse<ContractInterfaceResponse>> {
-        if (requestParameters.stacksAddress === null || requestParameters.stacksAddress === undefined) {
-            throw new runtime.RequiredError('stacksAddress','Required parameter requestParameters.stacksAddress was null or undefined when calling getContractInterface.');
+        if (requestParameters.contractAddress === null || requestParameters.contractAddress === undefined) {
+            throw new runtime.RequiredError('contractAddress','Required parameter requestParameters.contractAddress was null or undefined when calling getContractInterface.');
         }
 
         if (requestParameters.contractName === null || requestParameters.contractName === undefined) {
@@ -257,7 +257,7 @@ export class SmartContractsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
         const response = await this.request({
-            path: `/v2/contracts/interface/{stacks_address}/{contract_name}`.replace(`{${"stacks_address"}}`, encodeURIComponent(String(requestParameters.stacksAddress))).replace(`{${"contract_name"}}`, encodeURIComponent(String(requestParameters.contractName))),
+            path: `/v2/contracts/interface/{contract_address}/{contract_name}`.replace(`{${"contract_address"}}`, encodeURIComponent(String(requestParameters.contractAddress))).replace(`{${"contract_name"}}`, encodeURIComponent(String(requestParameters.contractName))),
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
@@ -267,7 +267,7 @@ export class SmartContractsApi extends runtime.BaseAPI {
     }
 
     /**
-     * Get contract interface using a `stacks_address` and contract name
+     * Get contract interface using a `contract_address` and `contract name`
      * Get contract interface
      */
     async getContractInterface(requestParameters: GetContractInterfaceRequest): Promise<ContractInterfaceResponse> {
@@ -280,8 +280,8 @@ export class SmartContractsApi extends runtime.BaseAPI {
      * Get contract source
      */
     async getContractSourceRaw(requestParameters: GetContractSourceRequest): Promise<runtime.ApiResponse<ContractSourceResponse>> {
-        if (requestParameters.stacksAddress === null || requestParameters.stacksAddress === undefined) {
-            throw new runtime.RequiredError('stacksAddress','Required parameter requestParameters.stacksAddress was null or undefined when calling getContractSource.');
+        if (requestParameters.contractAddress === null || requestParameters.contractAddress === undefined) {
+            throw new runtime.RequiredError('contractAddress','Required parameter requestParameters.contractAddress was null or undefined when calling getContractSource.');
         }
 
         if (requestParameters.contractName === null || requestParameters.contractName === undefined) {
@@ -297,7 +297,7 @@ export class SmartContractsApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
         const response = await this.request({
-            path: `/v2/contracts/source/{stacks_address}/{contract_name}`.replace(`{${"stacks_address"}}`, encodeURIComponent(String(requestParameters.stacksAddress))).replace(`{${"contract_name"}}`, encodeURIComponent(String(requestParameters.contractName))),
+            path: `/v2/contracts/source/{contract_address}/{contract_name}`.replace(`{${"contract_address"}}`, encodeURIComponent(String(requestParameters.contractAddress))).replace(`{${"contract_name"}}`, encodeURIComponent(String(requestParameters.contractName))),
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,

--- a/client/test/test.ts
+++ b/client/test/test.ts
@@ -15,7 +15,7 @@ import { Configuration, BlocksApi, SmartContractsApi } from '../src/index';
 
   const smartContractsApi = new SmartContractsApi(apiConfig);
   const readOnly = await smartContractsApi.callReadOnlyFunction({
-    stacksAddress: 'ST12EY99GS4YKP0CP2CFW6SEPWQ2CGVRWK5GHKDRV',
+    contractAddress: 'ST12EY99GS4YKP0CP2CFW6SEPWQ2CGVRWK5GHKDRV',
     contractName: 'flip-coin-jackpot',
     functionName: 'get-optional-winner-at',
     readOnlyFunctionArgs: {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -291,7 +291,7 @@ paths:
     parameters:
       - name: contract_id
         in: path
-        description: Contract identifier formatted as `<principal_address>.<contract_name>`
+        description: Contract identifier formatted as `<contract_address>.<contract_name>`
         required: true
         schema:
           type: string
@@ -318,7 +318,7 @@ paths:
             type: integer
         - name: contract_id
           in: path
-          description: Contract identifier formatted as `<principal_address>.<contract_name>`
+          description: Contract identifier formatted as `<contract_address>.<contract_name>`
           required: true
           schema:
             type: string
@@ -332,10 +332,10 @@ paths:
               example:
                 $ref: ./entities/transaction-events/transaction-event-smart-contract-log.example.json
 
-  /v2/contracts/interface/{stacks_address}/{contract_name}:
+  /v2/contracts/interface/{contract_address}/{contract_name}:
     get:
       summary: Get contract interface
-      description: Get contract interface using a `stacks_address` and contract name
+      description: Get contract interface using a `contract_address` and `contract name`
       tags:
         - Smart Contracts
       operationId: get_contract_interface
@@ -349,7 +349,7 @@ paths:
               example:
                 $ref: ./api/core-node/get-contract-interface.example.json
     parameters:
-      - name: stacks_address
+      - name: contract_address
         in: path
         required: true
         description: Stacks address
@@ -362,7 +362,7 @@ paths:
         schema:
           type: string
 
-  /v2/map_entry/{stacks_address}/{contract_name}/{map_name}:
+  /v2/map_entry/{contract_address}/{contract_name}/{map_name}:
     post:
       summary: Get specific data-map inside a contract
       tags:
@@ -383,7 +383,7 @@ paths:
         400:
           description: Failed loading data map
       parameters:
-        - name: stacks_address
+        - name: contract_address
           in: path
           required: true
           description: Stacks address
@@ -415,7 +415,7 @@ paths:
             schema:
               type: string
 
-  /v2/contracts/source/{stacks_address}/{contract_name}:
+  /v2/contracts/source/{contract_address}/{contract_name}:
     get:
       summary: Get contract source
       tags:
@@ -432,7 +432,7 @@ paths:
               example:
                 $ref: ./api/core-node/get-contract-source.example.json
     parameters:
-      - name: stacks_address
+      - name: contract_address
         in: path
         required: true
         description: Stacks address
@@ -450,7 +450,7 @@ paths:
         schema:
           type: integer
 
-  /v2/contracts/call-read/{stacks_address}/{contract_name}/{function_name}:
+  /v2/contracts/call-read/{contract_address}/{contract_name}/{function_name}:
     post:
       summary: Call read-only function
       tags:
@@ -473,7 +473,7 @@ paths:
                 fail:
                   $ref: ./api/contract/post-call-read-only-fn-fail.example.json
       parameters:
-        - name: stacks_address
+        - name: contract_address
           in: path
           required: true
           description: Stacks address


### PR DESCRIPTION
This PR
* renames `stacks_address` to `contract_address` in contract related rpc calls
* renames `principal_address` to `contract_address` in the documentation
* fixes #258 