### PR TITLE
STX faucet Stacking differentiation

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -52,6 +52,7 @@ paths:
         required: false
         schema:
           type: boolean
+          default: false
     post:
       summary: Get STX tokens
       description: Get STX tokens for the testnet

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -46,6 +46,12 @@ paths:
         required: true
         schema:
           type: string
+      - name: stacking
+        in: query
+        description: Request the amount of STX needed for stacking
+        required: false
+        schema:
+          type: boolean
     post:
       summary: Get STX tokens
       description: Get STX tokens for the testnet

--- a/src/api/routes/faucets.ts
+++ b/src/api/routes/faucets.ts
@@ -103,10 +103,11 @@ export function createFaucetRouter(db: DataStore): RouterWithAsync {
       // Only based on address for now, but we're keeping the IP in case
       // we want to escalate and implement a per IP policy
       const now = Date.now();
-      const window = isStackingReq ? FAUCET_STACKING_WINDOW : FAUCET_DEFAULT_WINDOW;
-      const triggerCount = isStackingReq
-        ? FAUCET_STACKING_TRIGGER_COUNT
-        : FAUCET_DEFAULT_TRIGGER_COUNT;
+
+      const [window, triggerCount, stxAmount] = isStackingReq
+        ? [FAUCET_STACKING_WINDOW, FAUCET_STACKING_TRIGGER_COUNT, FAUCET_STACKING_STX_AMOUNT]
+        : [FAUCET_DEFAULT_WINDOW, FAUCET_DEFAULT_TRIGGER_COUNT, FAUCET_DEFAULT_STX_AMOUNT];
+
       const requestsInWindow = lastRequests.results
         .map(r => now - r.occurred_at)
         .filter(r => r <= window);
@@ -119,7 +120,6 @@ export function createFaucetRouter(db: DataStore): RouterWithAsync {
         return;
       }
 
-      const stxAmount = isStackingReq ? FAUCET_STACKING_STX_AMOUNT : FAUCET_DEFAULT_STX_AMOUNT;
       const tx = await makeSTXTokenTransfer({
         recipient: address,
         amount: new BN(stxAmount.toString()),

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -151,6 +151,13 @@ export function formatMapToObject<TKey extends string, TValue, TFormatted>(
   return obj;
 }
 
+export const MICROSTACKS_IN_STACKS = BigInt(1_000_000);
+
+export function stxToMicroStx(microStx: bigint | number): bigint {
+  const input = typeof microStx === 'bigint' ? microStx : BigInt(microStx);
+  return input * MICROSTACKS_IN_STACKS;
+}
+
 export function digestSha512_256(input: Buffer): Buffer {
   const hash = crypto.createHash('sha512-256');
   const digest = hash.update(input).digest();


### PR DESCRIPTION
Closes #247

* Update the STX faucet endpoint default amount to 500 stx, and the original 5 requests with 5 minute cooldown.
* Added an optional param `stacking=true` to the endpoint which sends the Stacking amount, and has a 48 hour cooldown.

The default behavior is the non-stacking amount.

## Testing

Regular STX amount request, several can be made within rolling 5 minute window:
```shell
curl -L -d POST \
 "http://localhost:3999/extended/v1/faucets/stx?address=STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP"
```

Stacking STX amount request, 1 per 48 hours:
```shell
curl -L -d POST \
 "http://localhost:3999/extended/v1/faucets/stx?address=STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP&stacking=true"
```