### PR TITLE
Expose btc info

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/blockchain-api-client",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/client/src/generated/models/Block.ts
+++ b/client/src/generated/models/Block.ts
@@ -38,7 +38,7 @@ export interface Block {
      */
     hash: string;
     /**
-     * Hash of the prant block
+     * Hash of the parent block
      * @type {string}
      * @memberof Block
      */
@@ -55,6 +55,24 @@ export interface Block {
      * @memberof Block
      */
     burn_block_time_iso: string;
+    /**
+     * Hash of the anchor chain block
+     * @type {string}
+     * @memberof Block
+     */
+    burn_block_hash: string;
+    /**
+     * Height of the anchor chain block
+     * @type {number}
+     * @memberof Block
+     */
+    burn_block_height: number;
+    /**
+     * Anchor chain transaction ID
+     * @type {string}
+     * @memberof Block
+     */
+    miner_txid: string;
     /**
      * List of transactions included in the block
      * @type {Array<string>}
@@ -79,6 +97,9 @@ export function BlockFromJSONTyped(json: any, ignoreDiscriminator: boolean): Blo
         'parent_block_hash': json['parent_block_hash'],
         'burn_block_time': json['burn_block_time'],
         'burn_block_time_iso': json['burn_block_time_iso'],
+        'burn_block_hash': json['burn_block_hash'],
+        'burn_block_height': json['burn_block_height'],
+        'miner_txid': json['miner_txid'],
         'txs': json['txs'],
     };
 }
@@ -98,6 +119,9 @@ export function BlockToJSON(value?: Block | null): any {
         'parent_block_hash': value.parent_block_hash,
         'burn_block_time': value.burn_block_time,
         'burn_block_time_iso': value.burn_block_time_iso,
+        'burn_block_hash': value.burn_block_hash,
+        'burn_block_height': value.burn_block_height,
+        'miner_txid': value.miner_txid,
         'txs': value.txs,
     };
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: stacks_blockchain_api
       POSTGRES_PORT: 5432
-    volumes:
-      - database-data:/var/lib/postgresql/data/ # persist data even if container shuts down
     networks:
       - backend
   stacks-blockchain:
@@ -60,6 +58,3 @@ services:
 
 networks:
   backend:
-
-volumes:
-  database-data:

--- a/docs/entities/blocks/block.example.json
+++ b/docs/entities/blocks/block.example.json
@@ -5,5 +5,8 @@
   "parent_block_hash": "0x75ab21ef25cbff2caa14c27d830ed7886a4d1522e1b6f9e5dc3b59ccf73ed49f",
   "burn_block_time": 1594233639,
   "burn_block_time_iso": "2020-08-27T16:41:26.000Z",
+  "burn_block_hash": "0xb154c008df2101023a6d0d54986b3964cee58119eed14f5bed98e15678e18fe2",
+  "burn_block_height": 654439,
+  "miner_txid": "0xd7d56070277ccd87b42acf0c91f915dd181f9db4cf878a4e95518bc397c240cc",
   "txs": ["0x66557c219c6b0cdb40681ecf79a69f03654d88ef1910651a7db0b078f58af5ca"]
 }

--- a/docs/entities/blocks/block.schema.json
+++ b/docs/entities/blocks/block.schema.json
@@ -3,7 +3,7 @@
   "title": "Block",
   "description": "A block",
   "type": "object",
-  "required": ["canonical", "height", "hash", "parent_block_hash", "txs", "burn_block_time", "burn_block_time_iso"],
+  "required": ["canonical", "height", "hash", "parent_block_hash", "txs", "burn_block_time", "burn_block_time_iso", "burn_block_hash", "burn_block_height", "miner_txid"],
   "properties": {
     "canonical": {
       "type": "boolean",
@@ -19,7 +19,7 @@
     },
     "parent_block_hash": {
       "type": "string",
-      "description": "Hash of the prant block"
+      "description": "Hash of the parent block"
     },
     "burn_block_time": {
       "type": "number",
@@ -28,6 +28,18 @@
     "burn_block_time_iso": {
       "type": "string",
       "description": "An ISO 8601 (YYYY-MM-DDTHH:mm:ss.sssZ) indicating when this block was mined."
+    },
+    "burn_block_hash": {
+      "type": "string",
+      "description": "Hash of the anchor chain block"
+    },
+    "burn_block_height": {
+      "type": "integer",
+      "description": "Height of the anchor chain block"
+    },
+    "miner_txid": {
+      "type": "string",
+      "description": "Anchor chain transaction ID"
     },
     "txs": {
       "type": "array",

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -696,7 +696,7 @@ export interface Block {
    */
   hash: string;
   /**
-   * Hash of the prant block
+   * Hash of the parent block
    */
   parent_block_hash: string;
   /**
@@ -707,6 +707,18 @@ export interface Block {
    * An ISO 8601 (YYYY-MM-DDTHH:mm:ss.sssZ) indicating when this block was mined.
    */
   burn_block_time_iso: string;
+  /**
+   * Hash of the anchor chain block
+   */
+  burn_block_hash: string;
+  /**
+   * Height of the anchor chain block
+   */
+  burn_block_height: number;
+  /**
+   * Anchor chain transaction ID
+   */
+  miner_txid: string;
   /**
    * List of transactions included in the block
    */

--- a/follower.Dockerfile
+++ b/follower.Dockerfile
@@ -8,17 +8,8 @@ RUN npm install
 RUN npm run build
 RUN npm prune --production
 
-
 ### Fetch stacks-node binary
-FROM everpeace/curl-jq as stacks-node-build
-ENV ARTIFACTS "http://blockstack-stacks-blockchain_artifacts.storage.googleapis.com/index.json"
-RUN curl -s "$ARTIFACTS" --output ./artifacts-resp.json \
-  && cat ./artifacts-resp.json | jq -r '."stacks-node-krypton"."linux-x64".latest.url' > ./url \
-  && mkdir -p /app \
-  && echo "Fetching $(cat ./url)" \
-  && curl --compressed $(cat ./url) --output /stacks-node \
-  && chmod +x /stacks-node
-
+FROM blockstack/stacks-blockchain:v23.0.0.10-krypton-stretch as stacks-node-build
 
 ### Begin building base image
 FROM ubuntu:focal
@@ -53,7 +44,7 @@ ENV PATH=$PATH:/home/stacky/.nvm/versions/node/v${NODE_VERSION}/bin
 RUN node -e 'console.log("Node.js runs")'
 
 ### Setup stacks-node
-COPY --from=stacks-node-build /stacks-node stacks-node/
+COPY --from=stacks-node-build /bin/stacks-node stacks-node/
 ENV PATH="$PATH:$HOME/stacks-node"
 
 #### Copy stacks-node mocknet config

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "devenv:follower": "docker-compose -f docker-compose.dev.postgres.yml -f docker-compose.dev.stacks-blockchain-follower.yml up",
     "devenv:stop": "docker-compose -f docker-compose.dev.postgres.yml -f docker-compose.dev.stacks-blockchain.yml -f docker-compose.dev.bitcoind.yml down -v -t 0",
     "devenv:logs": "docker-compose -f docker-compose.dev.postgres.yml -f docker-compose.dev.stacks-blockchain.yml -f docker-compose.dev.bitcoind.yml logs -t -f",
-    "docs:generate": "cd docs && npm run generate:types && npm run generate:docs && cd ../client && typedoc",
+    "docs:generate": "cd docs && npm run generate:types && npm run generate:docs && cd ../client && npm run generate:docs",
     "docs:deploy": "npm run docs:generate && cd docs && gulp deployDocs"
   },
   "repository": {

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -293,6 +293,9 @@ export async function getBlockFromDataStore(
     parent_block_hash: dbBlock.parent_block_hash,
     burn_block_time: dbBlock.burn_block_time,
     burn_block_time_iso: unixEpochToIso(dbBlock.burn_block_time),
+    burn_block_hash: dbBlock.burn_block_hash,
+    burn_block_height: dbBlock.burn_block_height,
+    miner_txid: dbBlock.miner_txid,
     txs: txIds.results,
   };
   return { found: true, result: apiBlock };

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -16,6 +16,9 @@ import { getTxSenderAddress } from '../event-stream/reader';
 export interface DbBlock {
   block_hash: string;
   burn_block_time: number;
+  burn_block_hash: string;
+  burn_block_height: number;
+  miner_txid: string;
   index_block_hash: string;
   parent_index_block_hash: string;
   parent_block_hash: string;

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -151,7 +151,8 @@ const MEMPOOL_TX_ID_COLUMNS = `
 `;
 
 const BLOCK_COLUMNS = `
-  block_hash, index_block_hash, parent_index_block_hash, parent_block_hash, parent_microblock, block_height, burn_block_time, canonical
+  block_hash, index_block_hash, parent_index_block_hash, parent_block_hash, parent_microblock, block_height, 
+  burn_block_time, burn_block_hash, burn_block_height, miner_txid, canonical
 `;
 
 interface BlockQueryResult {
@@ -162,6 +163,9 @@ interface BlockQueryResult {
   parent_microblock: Buffer;
   block_height: number;
   burn_block_time: number;
+  burn_block_hash: Buffer;
+  burn_block_height: number;
+  miner_txid: Buffer;
   canonical: boolean;
 }
 
@@ -787,8 +791,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     const result = await client.query(
       `
       INSERT INTO blocks(
-        block_hash, index_block_hash, parent_index_block_hash, parent_block_hash, parent_microblock, block_height, burn_block_time, canonical
-      ) values($1, $2, $3, $4, $5, $6, $7, $8)
+        block_hash, index_block_hash, parent_index_block_hash, parent_block_hash, parent_microblock, block_height, 
+        burn_block_time, burn_block_hash, burn_block_height, miner_txid, canonical
+      ) values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
       ON CONFLICT (index_block_hash)
       DO NOTHING
       `,
@@ -800,6 +805,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         hexToBuffer(block.parent_microblock),
         block.block_height,
         block.burn_block_time,
+        hexToBuffer(block.burn_block_hash),
+        block.burn_block_height,
+        hexToBuffer(block.miner_txid),
         block.canonical,
       ]
     );
@@ -815,6 +823,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       parent_microblock: bufferToHexPrefixString(row.parent_microblock),
       block_height: row.block_height,
       burn_block_time: row.burn_block_time,
+      burn_block_hash: bufferToHexPrefixString(row.burn_block_hash),
+      burn_block_height: row.burn_block_height,
+      miner_txid: bufferToHexPrefixString(row.miner_txid),
       canonical: row.canonical,
     };
     return block;

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -135,6 +135,9 @@ export interface CoreNodeMessage {
   block_hash: string;
   block_height: number;
   burn_block_time: number;
+  burn_block_hash: string;
+  burn_block_height: number;
+  miner_txid: string;
   index_block_hash: string;
   parent_index_block_hash: string;
   parent_block_hash: string;

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -71,6 +71,9 @@ async function handleClientMessage(msg: CoreNodeMessage, db: DataStore): Promise
     parent_microblock: parsedMsg.parent_microblock,
     block_height: parsedMsg.block_height,
     burn_block_time: parsedMsg.burn_block_time,
+    burn_block_hash: parsedMsg.burn_block_hash,
+    burn_block_height: parsedMsg.burn_block_height,
+    miner_txid: parsedMsg.miner_txid,
   };
 
   logger.verbose(

--- a/src/migrations/1584604583726_blocks.ts
+++ b/src/migrations/1584604583726_blocks.ts
@@ -20,6 +20,18 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       type: 'integer',
       notNull: true,
     },
+    burn_block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    burn_block_height: {
+      type: 'integer',
+      notNull: true,
+    },
+    miner_txid: {
+      type: 'bytea',
+      notNull: true,
+    },
     parent_index_block_hash: {
       type: 'bytea',
       notNull: true,

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -227,6 +227,9 @@ describe('api tests', () => {
       parent_microblock: '0x9876',
       block_height: 1235,
       burn_block_time: 94869286,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     await db.updateBlock(client, block);
@@ -1198,6 +1201,9 @@ describe('api tests', () => {
       parent_microblock: '0x9876',
       block_height: 1,
       burn_block_time: 1594647996,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     const tx1: DbTx = {
@@ -1309,6 +1315,9 @@ describe('api tests', () => {
       parent_microblock: '0x9876',
       block_height: 1235,
       burn_block_time: 1594647996,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     await db.updateBlock(client, block);
@@ -1341,6 +1350,9 @@ describe('api tests', () => {
     const expectedResp = {
       burn_block_time: 1594647996,
       burn_block_time_iso: '2020-07-13T13:46:36.000Z',
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
       hash: '0x1234',
       height: 1235,

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -34,6 +34,9 @@ describe('in-memory datastore', () => {
       parent_microblock: '987',
       block_height: 123,
       burn_block_time: 39486,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: false,
     };
     await db.updateBlock(block);
@@ -324,6 +327,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0x9876',
       block_height: 1235,
       burn_block_time: 94869286,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     await db.updateBlock(client, block);
@@ -1525,6 +1531,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0x9876',
       block_height: 1,
       burn_block_time: 94869286,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     const tx1: DbTx = {
@@ -1663,6 +1672,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 1,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     const block2: DbBlock = {
@@ -1673,6 +1685,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 2,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     const block3: DbBlock = {
@@ -1683,6 +1698,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 3,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     const block3B: DbBlock = {
@@ -1699,6 +1717,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 4,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     const block4: DbBlock = {
@@ -1709,6 +1730,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 4,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     const block5: DbBlock = {
@@ -1719,6 +1743,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 5,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     const block6: DbBlock = {
@@ -1729,6 +1756,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 6,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
 
@@ -1880,6 +1910,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 1,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: false,
     };
     const block2: DbBlock = {
@@ -1890,6 +1923,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 2,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: false,
     };
     const block3: DbBlock = {
@@ -1900,6 +1936,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 3,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: false,
     };
     const block3B: DbBlock = {
@@ -1916,6 +1955,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 4,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: false,
     };
 
@@ -1977,6 +2019,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 5,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
 
@@ -2021,6 +2066,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 1,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     const block2: DbBlock = {
@@ -2031,6 +2079,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 2,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     const block3: DbBlock = {
@@ -2041,6 +2092,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 3,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
 
@@ -2120,6 +2174,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 2,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     const tx3: DbTx = {
@@ -2175,6 +2232,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 3,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     await db.update({ block: block3b, txs: [] });
@@ -2191,6 +2251,9 @@ describe('postgres datastore', () => {
       parent_microblock: '0xbeef',
       block_height: 4,
       burn_block_time: 1234,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
     await db.update({ block: block4b, txs: [] });

--- a/src/tests/websocket-tests.ts
+++ b/src/tests/websocket-tests.ts
@@ -52,6 +52,9 @@ describe('websocket notifications', () => {
       parent_microblock: '0x9876',
       block_height: 1,
       burn_block_time: 94869286,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
 
@@ -180,6 +183,9 @@ describe('websocket notifications', () => {
       parent_microblock: '0x9876',
       block_height: 1,
       burn_block_time: 94869286,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
 
@@ -301,6 +307,9 @@ describe('websocket notifications', () => {
       parent_microblock: '0x9876',
       block_height: 1,
       burn_block_time: 94869286,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
 
@@ -410,6 +419,9 @@ describe('websocket notifications', () => {
       parent_microblock: '0x9876',
       block_height: 1,
       burn_block_time: 94869286,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
 
@@ -497,6 +509,9 @@ describe('websocket notifications', () => {
       parent_microblock: '0x9876',
       block_height: 1,
       burn_block_time: 94869286,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
       canonical: true,
     };
 

--- a/stacks-blockchain/docker/Dockerfile
+++ b/stacks-blockchain/docker/Dockerfile
@@ -1,13 +1,4 @@
-FROM everpeace/curl-jq as build
-
-ENV ARTIFACTS "http://blockstack-stacks-blockchain_artifacts.storage.googleapis.com/index.json"
-
-RUN curl -s "$ARTIFACTS" --output ./artifacts-resp.json \
-  && cat ./artifacts-resp.json | jq -r '."stacks-node-krypton"."linux-x64".latest.url' > ./url \
-  && mkdir -p /app \
-  && echo "Fetching $(cat ./url)" \
-  && curl --compressed $(cat ./url) --output /bin/stacks-node \
-  && chmod +x /bin/stacks-node
+FROM blockstack/stacks-blockchain:v23.0.0.10-krypton-stretch as build
 
 FROM debian:stretch
 


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/302

Adds the new bitcoin fields to the block API: `burn_block_hash`, `burn_block_height`, `miner_txid`

Also switch the docker setup to pull the `stacks-node` binary from the official docker hub images. Updated to the latest build which closes https://github.com/blockstack/stacks-blockchain-api/issues/301