### PR TITLE
chore: rename block_hash to hash

### DIFF
--- a/client/src/generated/apis/BlocksApi.ts
+++ b/client/src/generated/apis/BlocksApi.ts
@@ -24,7 +24,7 @@ import {
 } from '../models';
 
 export interface GetBlockByHashRequest {
-    blockHash: string;
+    hash: string;
 }
 
 export interface GetBlockListRequest {
@@ -42,8 +42,8 @@ export class BlocksApi extends runtime.BaseAPI {
      * Get block
      */
     async getBlockByHashRaw(requestParameters: GetBlockByHashRequest): Promise<runtime.ApiResponse<Block>> {
-        if (requestParameters.blockHash === null || requestParameters.blockHash === undefined) {
-            throw new runtime.RequiredError('blockHash','Required parameter requestParameters.blockHash was null or undefined when calling getBlockByHash.');
+        if (requestParameters.hash === null || requestParameters.hash === undefined) {
+            throw new runtime.RequiredError('hash','Required parameter requestParameters.hash was null or undefined when calling getBlockByHash.');
         }
 
         const queryParameters: runtime.HTTPQuery = {};
@@ -51,7 +51,7 @@ export class BlocksApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
         const response = await this.request({
-            path: `/extended/v1/block/{block_hash}`.replace(`{${"block_hash"}}`, encodeURIComponent(String(requestParameters.blockHash))),
+            path: `/extended/v1/block/{hash}`.replace(`{${"hash"}}`, encodeURIComponent(String(requestParameters.hash))),
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -247,9 +247,9 @@ paths:
                 $ref: ./api/blocks/get-blocks.schema.json
               example:
                 $ref: ./api/blocks/get-blocks.example.json
-  /extended/v1/block/{block_hash}:
+  /extended/v1/block/{hash}:
     parameters:
-      - name: block_hash
+      - name: hash
         in: path
         description: Hash of the block
         required: true

--- a/src/api/routes/block.ts
+++ b/src/api/routes/block.ts
@@ -36,16 +36,16 @@ export function createBlockRouter(db: DataStore): RouterWithAsync {
     res.json(response);
   });
 
-  router.getAsync('/:block_hash', async (req, res) => {
-    const { block_hash } = req.params;
+  router.getAsync('/:hash', async (req, res) => {
+    const { hash } = req.params;
 
-    if (!has0xPrefix(block_hash)) {
-      return res.redirect('/extended/v1/block/0x' + block_hash);
+    if (!has0xPrefix(hash)) {
+      return res.redirect('/extended/v1/block/0x' + hash);
     }
 
-    const block = await getBlockFromDataStore(block_hash, db);
+    const block = await getBlockFromDataStore(hash, db);
     if (!block.found) {
-      res.status(404).json({ error: `cannot find block by hash ${block_hash}` });
+      res.status(404).json({ error: `cannot find block by hash ${hash}` });
       return;
     }
     // TODO: block schema validation


### PR DESCRIPTION
## Description
As a developer, I don't want to relearn the API for different clients (RPC vs js lib)

This PR
* renames the block hash parameter in the RPC API from `block_hash` to `hash`
* fixes issue #262 


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
no

## Are documentation updates required?
new client docs 

## Testing information

Provide context on how tests should be performed.

1. Is testing required for this change?
2. If it’s a bug fix, list steps to reproduce the bug
3. Briefly mention affected code paths
4. List other affected projects if possible
5. Things to watch out for when testing

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review
