### PR TITLE
three rosetta fixes: API_TAG in stx-rosetta, contract function args, and fees calculation.

### DIFF
--- a/rosetta-cli-config/bootstrap_balances.json
+++ b/rosetta-cli-config/bootstrap_balances.json
@@ -1,6 +1,16 @@
 [
   {
     "account_identifier": {
+      "address": "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
+    },
+    "currency": {
+      "symbol": "STX",
+      "decimals": 6
+    },
+    "value": "10000000000000000"
+  },
+  {
+    "account_identifier": {
       "address": "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
     },
     "currency": {

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1667,9 +1667,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       `
       SELECT sum(fee_rate) as fee_sum
       FROM txs
-      WHERE canonical = true AND sender_address = $1
+      WHERE canonical = true AND sender_address = $1 AND block_height <= $2
       `,
-      [stxAddress]
+      [stxAddress, blockHeight]
     );
     const totalFees = BigInt(feeQuery.rows[0].fee_sum ?? 0);
     const totalSent = BigInt(result.rows[0].debit_total ?? 0);

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -171,7 +171,7 @@ function makeCallContractOperation(tx: BaseTx, index: number): RosettaOperation 
         metadata: {
           contract_call_function_name: tx.contract_call_function_name,
           contract_call_function_args: bufferToHexPrefixString(
-            unwrapOptional(tx.contract_call_function_args, () => '')
+            tx.contract_call_function_args ? tx.contract_call_function_args : Buffer.from('')
           ),
           raw_result: tx.raw_result,
         },

--- a/stx-rosetta.Dockerfile
+++ b/stx-rosetta.Dockerfile
@@ -1,7 +1,7 @@
 ### Build blockstack-core-sidecar API
 FROM node:lts-buster as build
 
-ARG API_TAG=v0.29.2
+ARG API_TAG=v0.29.4
 
 RUN apt-get -y update && apt-get -y install openjdk-11-jre-headless
 


### PR DESCRIPTION
* A few transactions on the testnet have contract function calls without arguments.  The code to handle this for rosetta's `/block` endpoint didn't expect that case, and handled it incorrectly by throwing an exception.  This is a one-line fix, and probably a **high priority** one (breaks `rosetta-cli`'s `check:data`).

This can be seen by trying
```
curl -s -H 'content-type: application/json' \
-d '{"network_identifier": {"blockchain": "stacks", "network": "testnet"}, "block_identifier": {"index": 1209}}' \
https://stacks-node-api.blockstack.org/rosetta/v1/block

# this one fails
curl -s -H 'content-type: application/json' \
-d '{"network_identifier": {"blockchain": "stacks", "network": "testnet"}, "block_identifier": {"index": 1210}}' \
https://stacks-node-api.blockstack.org/rosetta/v1/block

curl -s -H 'content-type: application/json' \
-d '{"network_identifier": {"blockchain": "stacks", "network": "testnet"}, "block_identifier": {"index": 1211}}' \
https://stacks-node-api.blockstack.org/rosetta/v1/block
```

* The code to calculate an account's balance at a given block height for the rosetta `/account/balance` endpoint calculated the tokens sent/received properly, but didn't take the block height into account.

This can be seen by trying
```
curl -s -H 'content-type: application/json' \
-d '{"network_identifier": {"blockchain": "stacks", "network": "testnet"}, "block_identifier": {"index": 1}, "account_identifier": {"address": "ST3BGS3XT2613ZQBQHG9R4G2FRHWRF8XBMGT8J920"}}' \
https://stacks-node-api.blockstack.org/rosetta/v1/account/balance
```

The account makes three contract calls in blocks 1632, 1634, and 1636, with a `fee_rate` of 260 each.  The balance should be zero until it receives STX prior to those blocks.

* Lastly, bumped the version of `API_TAG` in `stx-rosetta.Dockerfile` to `v0.29.4`, which is what it should be after this PR is merged.

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?

No.

## Are documentation updates required?

No.


## Checklist
- [ ] Code is commented where needed
- [X] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [X] `npm run test:rosetta` passes
- [ ] Changelog is updated
- [X] tagging @zone117x
