### PR TITLE
Stub response for `/new_burn_block`

### DIFF
--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -172,3 +172,17 @@ export interface CoreNodeParsedTxMessage {
   block_height: number;
   burn_block_time: number;
 }
+
+export interface CoreNodeNewBurnBlockMessage {
+  burn_block_hash: string;
+  /** Amount in BTC satoshis. */
+  burn_amount: number;
+  reward_recipients: [
+    {
+      /** Bitcoin address (b58 encoded). */
+      recipient: string;
+      /** Amount in BTC satoshis. */
+      amount: number;
+    }
+  ];
+}

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -6,8 +6,12 @@ import * as bodyParser from 'body-parser';
 import { addAsync } from '@awaitjs/express';
 import PQueue from 'p-queue';
 
-import { hexToBuffer, logError, logger, digestSha512_256, assertNotNullish } from '../helpers';
-import { CoreNodeMessage, CoreNodeEventType, StxLockEvent } from './core-node-message';
+import { hexToBuffer, logError, logger, digestSha512_256 } from '../helpers';
+import {
+  CoreNodeMessage,
+  CoreNodeEventType,
+  CoreNodeNewBurnBlockMessage,
+} from './core-node-message';
 import {
   DataStore,
   createDbTxFromCoreMsg,
@@ -304,7 +308,22 @@ export async function startEventServer(opts: {
       await messageHandler.handleBlockMessage(msg, db);
       res.status(200).json({ result: 'ok' });
     } catch (error) {
-      logError(`error processing core-node message: ${error}`, error);
+      logError(`error processing core-node /new_block: ${error}`, error);
+      res.status(500).json({ error: error });
+    }
+  });
+
+  app.postAsync('/new_burn_block', async (req, res) => {
+    try {
+      const msg: CoreNodeNewBurnBlockMessage = req.body;
+      if (msg.reward_recipients.length > 0) {
+        // TODO: integrate into event handler and db
+        // console.log(msg);
+      }
+      await Promise.resolve();
+      res.status(200).json({ result: 'ok' });
+    } catch (error) {
+      logError(`error processing core-node /new_burn_block: ${error}`, error);
       res.status(500).json({ error: error });
     }
   });
@@ -316,7 +335,7 @@ export async function startEventServer(opts: {
       res.status(200).json({ result: 'ok' });
       await Promise.resolve();
     } catch (error) {
-      logError(`error processing core-node mempool tx: ${error}`, error);
+      logError(`error processing core-node /new_mempool_tx: ${error}`, error);
       res.status(500).json({ error: error });
     }
   });


### PR DESCRIPTION
Stub response for the `/new_burn_block` event. Allows the sidecar to run with latest core-node (v23.0.0.11-krypton).