### PR TITLE
Miner STX reward event handling

### DIFF
--- a/client/src/generated/models/AddressBalanceResponseStx.ts
+++ b/client/src/generated/models/AddressBalanceResponseStx.ts
@@ -49,6 +49,18 @@ export interface AddressBalanceResponseStx {
      * @memberof AddressBalanceResponseStx
      */
     total_received: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AddressBalanceResponseStx
+     */
+    total_fees_sent: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AddressBalanceResponseStx
+     */
+    total_miner_rewards_received: string;
 }
 
 export function AddressBalanceResponseStxFromJSON(json: any): AddressBalanceResponseStx {
@@ -66,6 +78,8 @@ export function AddressBalanceResponseStxFromJSONTyped(json: any, ignoreDiscrimi
         'unlock_height': json['unlock_height'],
         'total_sent': json['total_sent'],
         'total_received': json['total_received'],
+        'total_fees_sent': json['total_fees_sent'],
+        'total_miner_rewards_received': json['total_miner_rewards_received'],
     };
 }
 
@@ -83,6 +97,8 @@ export function AddressBalanceResponseStxToJSON(value?: AddressBalanceResponseSt
         'unlock_height': value.unlock_height,
         'total_sent': value.total_sent,
         'total_received': value.total_received,
+        'total_fees_sent': value.total_fees_sent,
+        'total_miner_rewards_received': value.total_miner_rewards_received,
     };
 }
 

--- a/client/src/generated/models/AddressStxBalanceResponse.ts
+++ b/client/src/generated/models/AddressStxBalanceResponse.ts
@@ -49,6 +49,18 @@ export interface AddressStxBalanceResponse {
      * @memberof AddressStxBalanceResponse
      */
     total_received: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AddressStxBalanceResponse
+     */
+    total_fees_sent: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof AddressStxBalanceResponse
+     */
+    total_miner_rewards_received: string;
 }
 
 export function AddressStxBalanceResponseFromJSON(json: any): AddressStxBalanceResponse {
@@ -66,6 +78,8 @@ export function AddressStxBalanceResponseFromJSONTyped(json: any, ignoreDiscrimi
         'unlock_height': json['unlock_height'],
         'total_sent': json['total_sent'],
         'total_received': json['total_received'],
+        'total_fees_sent': json['total_fees_sent'],
+        'total_miner_rewards_received': json['total_miner_rewards_received'],
     };
 }
 
@@ -83,6 +97,8 @@ export function AddressStxBalanceResponseToJSON(value?: AddressStxBalanceRespons
         'unlock_height': value.unlock_height,
         'total_sent': value.total_sent,
         'total_received': value.total_received,
+        'total_fees_sent': value.total_fees_sent,
+        'total_miner_rewards_received': value.total_miner_rewards_received,
     };
 }
 

--- a/docs/entities/balance/stx-balance.schema.json
+++ b/docs/entities/balance/stx-balance.schema.json
@@ -3,7 +3,7 @@
   "description": "StxBalance",
   "type": "object",
   "additionalProperties": false,
-  "required": ["balance", "locked", "unlock_height", "total_sent", "total_received"],
+  "required": ["balance", "locked", "unlock_height", "total_sent", "total_received", "total_fees_sent", "total_miner_rewards_received"],
   "properties": {
     "balance": {
       "type": "string"
@@ -18,6 +18,12 @@
       "type": "string"
     },
     "total_received": {
+      "type": "string"
+    },
+    "total_fees_sent": {
+      "type": "string"
+    },
+    "total_miner_rewards_received": {
       "type": "string"
     }
   }

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -27,6 +27,8 @@ export interface AddressBalanceResponse {
     unlock_height: number;
     total_sent: string;
     total_received: string;
+    total_fees_sent: string;
+    total_miner_rewards_received: string;
   };
   fungible_tokens: {
     /**
@@ -65,6 +67,8 @@ export interface AddressStxBalanceResponse {
   unlock_height: number;
   total_sent: string;
   total_received: string;
+  total_fees_sent: string;
+  total_miner_rewards_received: string;
 }
 
 /**

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -48,6 +48,8 @@ export function createAddressRouter(db: DataStore): RouterWithAsync {
       unlock_height: Number(stxBalanceResult.unlockHeight),
       total_sent: stxBalanceResult.totalSent.toString(),
       total_received: stxBalanceResult.totalReceived.toString(),
+      total_fees_sent: stxBalanceResult.totalFeesSent.toString(),
+      total_miner_rewards_received: stxBalanceResult.totalMinerRewardsReceived.toString(),
     };
     res.json(result);
   });
@@ -88,6 +90,8 @@ export function createAddressRouter(db: DataStore): RouterWithAsync {
         unlock_height: Number(stxBalanceResult.unlockHeight),
         total_sent: stxBalanceResult.totalSent.toString(),
         total_received: stxBalanceResult.totalReceived.toString(),
+        total_fees_sent: stxBalanceResult.totalFeesSent.toString(),
+        total_miner_rewards_received: stxBalanceResult.totalMinerRewardsReceived.toString(),
       },
       fungible_tokens: ftBalances,
       non_fungible_tokens: nftBalances,

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -28,6 +28,20 @@ export interface DbBlock {
   canonical: boolean;
 }
 
+export interface DbMinerReward {
+  block_hash: string;
+  index_block_hash: string;
+  mature_block_height: number;
+  /** Set to `true` if entry corresponds to the canonical chain tip */
+  canonical: boolean;
+  /** STX principal */
+  recipient: string;
+  coinbase_amount: bigint;
+  tx_fees_anchored_shared: bigint;
+  tx_fees_anchored_exclusive: bigint;
+  tx_fees_streamed_confirmed: bigint;
+}
+
 export enum DbTxTypeId {
   TokenTransfer = 0x00,
   SmartContract = 0x01,
@@ -222,6 +236,7 @@ export type DataStoreEventEmitter = StrictEventEmitter<
 
 export interface DataStoreUpdateData {
   block: DbBlock;
+  minerRewards: DbMinerReward[];
   txs: {
     tx: DbTx;
     stxEvents: DbStxEvent[];
@@ -251,6 +266,8 @@ export interface DbStxBalance {
   unlockHeight: number;
   totalSent: bigint;
   totalReceived: bigint;
+  totalFeesSent: bigint;
+  totalMinerRewardsReceived: bigint;
 }
 
 export interface DataStore extends DataStoreEventEmitter {

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -852,9 +852,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       `
       INSERT INTO miner_rewards(
         block_hash, index_block_hash, mature_block_height, canonical, recipient, coinbase_amount, tx_fees_anchored_shared, tx_fees_anchored_exclusive, tx_fees_streamed_confirmed
-      ) values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-      ON CONFLICT (index_block_hash)
-      DO NOTHING
+      ) values($1, $2, $3, $4, $5, $6, $7, $8, $9)
       `,
       [
         hexToBuffer(minerReward.block_hash),

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -155,6 +155,20 @@ export interface CoreNodeMessage {
   parent_microblock: string;
   events: CoreNodeEvent[];
   transactions: CoreNodeTxMessage[];
+  matured_miner_rewards: {
+    from_index_consensus_hash: string;
+    from_stacks_block_hash: string;
+    /** STX principal */
+    recipient: string;
+    /** String quoted micro-STX amount. */
+    coinbase_amount: string;
+    /** String quoted micro-STX amount. */
+    tx_fees_anchored_shared: string;
+    /** String quoted micro-STX amount. */
+    tx_fees_anchored_exclusive: string;
+    /** String quoted micro-STX amount. */
+    tx_fees_streamed_confirmed: string;
+  }[];
 }
 
 export interface CoreNodeMessageParsed extends CoreNodeMessage {

--- a/src/migrations/1605184662317_miner_rewards.ts
+++ b/src/migrations/1605184662317_miner_rewards.ts
@@ -1,0 +1,53 @@
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+// block_hash, index_block_hash, canonical, recipient, coinbase_amount, tx_fees_anchored_shared, tx_fees_anchored_exclusive, tx_fees_streamed_confirmed
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('miner_rewards', {
+    id: {
+      type: 'serial',
+      primaryKey: true,
+    },
+    block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    index_block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    mature_block_height: {
+      type: 'integer',
+      notNull: true,
+    },
+    canonical: {
+      type: 'boolean',
+      notNull: true,
+    },
+    recipient: {
+      type: 'string',
+      notNull: true,
+    },
+    coinbase_amount: {
+      type: 'numeric',
+      notNull: true,
+    },
+    tx_fees_anchored_shared: {
+      type: 'numeric',
+      notNull: true,
+    },
+    tx_fees_anchored_exclusive: {
+      type: 'numeric',
+      notNull: true,
+    },
+    tx_fees_streamed_confirmed: {
+      type: 'numeric',
+      notNull: true,
+    },
+  });
+
+  pgm.createIndex('miner_rewards', 'block_hash');
+  pgm.createIndex('miner_rewards', 'index_block_hash');
+  pgm.createIndex('miner_rewards', 'mature_block_height');
+  pgm.createIndex('miner_rewards', 'canonical');
+  pgm.createIndex('miner_rewards', 'recipient');
+
+}

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -965,6 +965,8 @@ describe('api tests', () => {
         unlock_height: 0,
         total_sent: '1385',
         total_received: '100000',
+        total_fees_sent: '3702',
+        total_miner_rewards_received: '0',
       },
       fungible_tokens: {
         bux: { balance: '99615', total_sent: '385', total_received: '100000' },
@@ -993,6 +995,8 @@ describe('api tests', () => {
         unlock_height: 0,
         total_sent: '15',
         total_received: '1350',
+        total_fees_sent: '1234',
+        total_miner_rewards_received: '0',
       },
       fungible_tokens: {
         bux: { balance: '335', total_sent: '15', total_received: '350' },
@@ -1016,6 +1020,8 @@ describe('api tests', () => {
       unlock_height: 0,
       total_sent: '15',
       total_received: '1350',
+      total_fees_sent: '1234',
+      total_miner_rewards_received: '0',
     };
     expect(JSON.parse(fetchAddrStxBalance1.text)).toEqual(expectedStxResp1);
 
@@ -1269,6 +1275,7 @@ describe('api tests', () => {
     };
     await db.update({
       block: block1,
+      minerRewards: [],
       txs: [
         {
           tx: tx1,

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -2173,6 +2173,26 @@ describe('postgres datastore', () => {
       canonical: true,
     };
 
+    const minerReward1: DbMinerReward = {
+      ...block1,
+      mature_block_height: 3,
+      recipient: 'miner-addr1',
+      coinbase_amount: 1000n,
+      tx_fees_anchored_shared: 1n,
+      tx_fees_anchored_exclusive: 2n,
+      tx_fees_streamed_confirmed: 3n,
+    };
+
+    const minerReward2: DbMinerReward = {
+      ...block2,
+      mature_block_height: 4,
+      recipient: 'miner-addr2',
+      coinbase_amount: 1000n,
+      tx_fees_anchored_shared: 1n,
+      tx_fees_anchored_exclusive: 2n,
+      tx_fees_streamed_confirmed: 3n,
+    };
+
     const tx1: DbTx = {
       tx_id: '0x01',
       tx_index: 0,
@@ -2215,7 +2235,7 @@ describe('postgres datastore', () => {
 
     await db.update({
       block: block1,
-      minerRewards: [],
+      minerRewards: [minerReward1],
       txs: [
         {
           tx: tx1,
@@ -2230,7 +2250,7 @@ describe('postgres datastore', () => {
     });
     await db.update({
       block: block2,
-      minerRewards: [],
+      minerRewards: [minerReward2],
       txs: [
         {
           tx: tx2,
@@ -2355,6 +2375,11 @@ describe('postgres datastore', () => {
     expect(b3.result?.canonical).toBe(false);
     expect(b3b.result?.canonical).toBe(true);
     expect(b4.result?.canonical).toBe(true);
+
+    const r1 = await db.getStxBalance(minerReward1.recipient);
+    const r2 = await db.getStxBalance(minerReward2.recipient);
+    expect(r1.totalMinerRewardsReceived).toBe(1006n);
+    expect(r2.totalMinerRewardsReceived).toBe(0n);
 
     const t1 = await db.getTx(tx1.tx_id);
     const t2 = await db.getTx(tx2.tx_id);

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -2032,6 +2032,16 @@ describe('postgres datastore', () => {
       canonical: false,
     };
 
+    const minerReward1: DbMinerReward = {
+      ...block1,
+      mature_block_height: 3,
+      recipient: 'miner-addr1',
+      coinbase_amount: 1000n,
+      tx_fees_anchored_shared: 1n,
+      tx_fees_anchored_exclusive: 2n,
+      tx_fees_streamed_confirmed: 3n,
+    };
+
     const tx1: DbTx = {
       tx_id: '0x01',
       tx_index: 0,
@@ -2077,6 +2087,11 @@ describe('postgres datastore', () => {
       await db.updateBlock(client, block);
     }
 
+    // insert miner rewards directly
+    for (const minerReward of [minerReward1]) {
+      await db.updateMinerReward(client, minerReward);
+    }
+
     // insert txs directly
     for (const tx of [tx1, tx2]) {
       await db.updateTx(client, tx);
@@ -2100,7 +2115,7 @@ describe('postgres datastore', () => {
     expect(reorgResult).toEqual({
       markedCanonical: {
         blocks: 4,
-        minerRewards: 0,
+        minerRewards: 1,
         txs: 2,
         stxLockEvents: 0,
         stxEvents: 0,

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -127,6 +127,8 @@ describe('postgres datastore', () => {
       unlockHeight: 0,
       totalReceived: 100000n,
       totalSent: 385n,
+      totalFeesSent: 1334n,
+      totalMinerRewardsReceived: 0n,
     });
     expect(addrBResult).toEqual({
       balance: 335n,
@@ -134,6 +136,8 @@ describe('postgres datastore', () => {
       unlockHeight: 0,
       totalReceived: 350n,
       totalSent: 15n,
+      totalFeesSent: 0n,
+      totalMinerRewardsReceived: 0n,
     });
     expect(addrCResult).toEqual({
       balance: 50n,
@@ -141,6 +145,8 @@ describe('postgres datastore', () => {
       unlockHeight: 0,
       totalReceived: 50n,
       totalSent: 0n,
+      totalFeesSent: 0n,
+      totalMinerRewardsReceived: 0n,
     });
     expect(addrDResult).toEqual({
       balance: 0n,
@@ -148,6 +154,8 @@ describe('postgres datastore', () => {
       unlockHeight: 0,
       totalReceived: 0n,
       totalSent: 0n,
+      totalFeesSent: 0n,
+      totalMinerRewardsReceived: 0n,
     });
   });
 
@@ -1624,6 +1632,7 @@ describe('postgres datastore', () => {
     };
     await db.update({
       block: block1,
+      minerRewards: [],
       txs: [
         {
           tx: tx1,
@@ -1818,12 +1827,14 @@ describe('postgres datastore', () => {
     for (const block of [block1, block2, block3]) {
       await db.update({
         block: block,
+        minerRewards: [],
         txs: [],
       });
     }
 
     await db.update({
       block: block3B,
+      minerRewards: [],
       txs: [
         {
           tx: tx1,
@@ -1844,6 +1855,7 @@ describe('postgres datastore', () => {
 
     await db.update({
       block: block4B,
+      minerRewards: [],
       txs: [],
     });
 
@@ -1864,6 +1876,7 @@ describe('postgres datastore', () => {
     for (const block of [block4, block5]) {
       await db.update({
         block: block,
+        minerRewards: [],
         txs: [],
       });
     }
@@ -1885,6 +1898,7 @@ describe('postgres datastore', () => {
     // mine the same tx in the latest canonical block
     await db.update({
       block: block6,
+      minerRewards: [],
       txs: [
         {
           tx: tx1b,
@@ -2038,6 +2052,7 @@ describe('postgres datastore', () => {
     expect(reorgResult).toEqual({
       markedCanonical: {
         blocks: 4,
+        minerRewards: 0,
         txs: 2,
         stxLockEvents: 0,
         stxEvents: 0,
@@ -2048,6 +2063,7 @@ describe('postgres datastore', () => {
       },
       markedNonCanonical: {
         blocks: 1,
+        minerRewards: 0,
         txs: 0,
         stxLockEvents: 0,
         stxEvents: 0,
@@ -2151,6 +2167,7 @@ describe('postgres datastore', () => {
 
     await db.update({
       block: block1,
+      minerRewards: [],
       txs: [
         {
           tx: tx1,
@@ -2165,6 +2182,7 @@ describe('postgres datastore', () => {
     });
     await db.update({
       block: block2,
+      minerRewards: [],
       txs: [
         {
           tx: tx2,
@@ -2177,7 +2195,7 @@ describe('postgres datastore', () => {
         },
       ],
     });
-    await db.update({ block: block3, txs: [] });
+    await db.update({ block: block3, minerRewards: [], txs: [] });
 
     const block2b: DbBlock = {
       block_hash: '0x22bb',
@@ -2221,6 +2239,7 @@ describe('postgres datastore', () => {
     };
     await db.update({
       block: block2b,
+      minerRewards: [],
       txs: [
         {
           tx: tx3,
@@ -2251,7 +2270,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
     };
-    await db.update({ block: block3b, txs: [] });
+    await db.update({ block: block3b, minerRewards: [], txs: [] });
     const blockQuery2 = await db.getBlock(block3b.block_hash);
     expect(blockQuery2.result?.canonical).toBe(false);
     const chainTip2 = await db.getChainTipHeight(client);
@@ -2270,7 +2289,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
     };
-    await db.update({ block: block4b, txs: [] });
+    await db.update({ block: block4b, minerRewards: [], txs: [] });
     const blockQuery3 = await db.getBlock(block3b.block_hash);
     expect(blockQuery3.result?.canonical).toBe(true);
     const chainTip3 = await db.getChainTipHeight(client);

--- a/src/tests/websocket-tests.ts
+++ b/src/tests/websocket-tests.ts
@@ -101,6 +101,7 @@ describe('websocket notifications', () => {
 
     const dbUpdate: DataStoreUpdateData = {
       block,
+      minerRewards: [],
       txs: [
         {
           tx,
@@ -233,6 +234,7 @@ describe('websocket notifications', () => {
 
     const dbUpdate: DataStoreUpdateData = {
       block,
+      minerRewards: [],
       txs: [
         {
           tx,
@@ -352,6 +354,7 @@ describe('websocket notifications', () => {
 
     const dbUpdate: DataStoreUpdateData = {
       block,
+      minerRewards: [],
       txs: [
         {
           tx,
@@ -465,6 +468,7 @@ describe('websocket notifications', () => {
 
     const dbUpdate: DataStoreUpdateData = {
       block,
+      minerRewards: [],
       txs: [
         {
           tx,
@@ -561,6 +565,7 @@ describe('websocket notifications', () => {
 
     const dbUpdate: DataStoreUpdateData = {
       block,
+      minerRewards: [],
       txs: [
         {
           tx,


### PR DESCRIPTION
Closes #314 - Balance reported by API does not match balance reported by miner/follower

The various STX balance endpoints now return the structure:
```ts
type StxBalance = {
    locked: string;
    unlock_height: number;
    total_sent: string;
    total_received: string;
    total_fees_sent: string; // NEW
    total_miner_rewards_received: string; // NEW
    balance: string; // Now returns an accurate balance with rewards factored in
}
```