### PR TITLE
fix: contract names can be less than 5 chars

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -174,7 +174,7 @@ export function isValidC32Address(stxAddress: string): boolean {
 }
 
 function isValidContractName(contractName: string): boolean {
-  const CONTRACT_MIN_NAME_LENGTH = 5;
+  const CONTRACT_MIN_NAME_LENGTH = 1;
   const CONTRACT_MAX_NAME_LENGTH = 128;
   if (
     contractName.length > CONTRACT_MAX_NAME_LENGTH ||


### PR DESCRIPTION
Closes #322 - Search endpoint not recognizing short contract names

Contract names were previously required to be at least 5 chars long. This is not the case with the `pox` contract, and perhaps no longer the case at all in core. Either way, the restriction was unnecessary. 