### PR TITLE
Fix mempool transaction disappear during re-orgs

### DIFF
--- a/docker-compose.dev.postgres.yml
+++ b/docker-compose.dev.postgres.yml
@@ -9,8 +9,3 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: stacks_blockchain_api
       POSTGRES_PORT: 5432
-    volumes:
-      - database-data:/var/lib/postgresql/data/ # persist data even if container shuts down
-
-volumes:
-  database-data:

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -119,6 +119,7 @@ export interface DbTx extends BaseTx {
 }
 
 export interface DbMempoolTx extends BaseTx {
+  pruned: boolean;
   raw_tx: Buffer;
 
   receipt_time: number;
@@ -442,6 +443,7 @@ export function createDbMempoolTxFromCoreMsg(msg: {
   receiptDate: number;
 }): DbMempoolTx {
   const dbTx: DbMempoolTx = {
+    pruned: false,
     tx_id: msg.txId,
     raw_tx: msg.rawTx,
     type_id: parseEnum(DbTxTypeId, msg.txData.payload.typeId as number),

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -447,8 +447,8 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
   }
 
   /**
-   * Restore transactions in the mempool table. This should be called when transactions are
-   * marked from non-canonical to canonical.
+   * Restore transactions in the mempool table. This should be called when mined transactions are
+   * marked from canonical to non-canonical.
    * @param txIds - List of transactions to update in the mempool
    */
   async restoreMempoolTxs(client: ClientBase, txIds: string[]): Promise<{ restoredTxs: string[] }> {

--- a/src/migrations/1591291822107_mempool_txs.ts
+++ b/src/migrations/1591291822107_mempool_txs.ts
@@ -6,6 +6,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       type: 'serial',
       primaryKey: true,
     },
+    pruned: {
+      type: 'boolean',
+      notNull: true,
+    },
     tx_id: {
       type: 'bytea',
       notNull: true,
@@ -62,6 +66,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 
   });
 
+  pgm.createIndex('mempool_txs', 'pruned');
   pgm.createIndex('mempool_txs', 'tx_id');
   pgm.createIndex('mempool_txs', 'type_id');
   pgm.createIndex('mempool_txs', 'sender_address');

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -451,6 +451,7 @@ describe('Rosetta API', () => {
   test('rosetta/mempool list', async () => {
     for (let i = 0; i < 10; i++) {
       const mempoolTx: DbMempoolTx = {
+        pruned: false,
         tx_id: `0x891200000000000000000000000000000000000000000000000000000000000${i}`,
         raw_tx: Buffer.from('test-raw-tx'),
         type_id: DbTxTypeId.Coinbase,
@@ -501,6 +502,7 @@ describe('Rosetta API', () => {
 
   test('rosetta/mempool/transaction', async () => {
     const mempoolTx: DbMempoolTx = {
+      pruned: false,
       tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
       raw_tx: Buffer.from('test-raw-tx'),
       type_id: DbTxTypeId.Coinbase,

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -350,6 +350,7 @@ describe('api tests', () => {
 
   test('fetch mempool-tx', async () => {
     const mempoolTx: DbMempoolTx = {
+      pruned: false,
       tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
       raw_tx: Buffer.from('test-raw-tx'),
       type_id: DbTxTypeId.Coinbase,
@@ -385,6 +386,7 @@ describe('api tests', () => {
 
   test('fetch mempool-tx - sponsored', async () => {
     const mempoolTx: DbMempoolTx = {
+      pruned: false,
       tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
       raw_tx: Buffer.from('test-raw-tx'),
       type_id: DbTxTypeId.Coinbase,
@@ -423,6 +425,7 @@ describe('api tests', () => {
   test('fetch mempool-tx list', async () => {
     for (let i = 0; i < 10; i++) {
       const mempoolTx: DbMempoolTx = {
+        pruned: false,
         tx_id: `0x891200000000000000000000000000000000000000000000000000000000000${i}`,
         raw_tx: Buffer.from('test-raw-tx'),
         type_id: DbTxTypeId.Coinbase,
@@ -525,6 +528,7 @@ describe('api tests', () => {
     await db.updateTx(client, tx);
 
     const mempoolTx: DbMempoolTx = {
+      pruned: false,
       tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
       raw_tx: Buffer.from('test-raw-tx'),
       type_id: DbTxTypeId.Coinbase,
@@ -969,6 +973,7 @@ describe('api tests', () => {
     expect(JSON.parse(searchResult9.text)).toEqual(expectedResp9);
 
     const smartContractMempoolTx: DbMempoolTx = {
+      pruned: false,
       type_id: DbTxTypeId.SmartContract,
       tx_id: '0x1111882200000000000000000000000000000000000000000000000000000000',
       raw_tx: Buffer.from('test-raw-tx'),

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -2121,11 +2121,8 @@ describe('postgres datastore', () => {
     expect(txQuery5?.result?.status).toBe(DbTxStatus.Success);
     expect(txQuery5?.result?.canonical).toBe(false);
 
-    // "rebroadcast" the same tx, ensure it's in the mempool again
-    await db.updateMempoolTx({
-      mempoolTx: { ...tx1b, pruned: false, status: DbTxStatus.Pending, receipt_time: 123456 },
-    });
-    const txQuery6 = await db.getMempoolTx(tx1b.tx_id);
+    // the fork containing this tx was made canonical again, it should now in the mempool
+    const txQuery6 = await db.getMempoolTx(tx1Mempool.tx_id);
     expect(txQuery6.found).toBe(true);
     expect(txQuery6?.result?.status).toBe(DbTxStatus.Pending);
 

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -2012,6 +2012,7 @@ describe('postgres datastore', () => {
     };
 
     const tx1Mempool: DbMempoolTx = {
+      pruned: false,
       tx_id: '0x01',
       raw_tx: Buffer.from('test-raw-tx'),
       type_id: DbTxTypeId.TokenTransfer,
@@ -2122,7 +2123,7 @@ describe('postgres datastore', () => {
 
     // "rebroadcast" the same tx, ensure it's in the mempool again
     await db.updateMempoolTx({
-      mempoolTx: { ...tx1b, status: DbTxStatus.Pending, receipt_time: 123456 },
+      mempoolTx: { ...tx1b, pruned: false, status: DbTxStatus.Pending, receipt_time: 123456 },
     });
     const txQuery6 = await db.getMempoolTx(tx1b.tx_id);
     expect(txQuery6.found).toBe(true);

--- a/src/tests/websocket-tests.ts
+++ b/src/tests/websocket-tests.ts
@@ -82,6 +82,7 @@ describe('websocket notifications', () => {
 
     const mempoolTx: DbMempoolTx = {
       ...tx,
+      pruned: false,
       status: DbTxStatus.Pending,
       receipt_time: 123456,
     };
@@ -215,6 +216,7 @@ describe('websocket notifications', () => {
 
     const mempoolTx: DbMempoolTx = {
       ...tx,
+      pruned: false,
       status: DbTxStatus.Pending,
       receipt_time: 123456,
     };
@@ -547,6 +549,7 @@ describe('websocket notifications', () => {
 
     const mempoolTx: DbMempoolTx = {
       ...tx,
+      pruned: false,
       receipt_time: 123456,
     };
 


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/333 - Disappearing Mempool TX

This was a bug in the sidecar's handling of mempool transactions. Transactions were not "re-inserted" into the mempool in the event that the block they were mined in became non-canonical.
