### PR TITLE
Add locked height and locked txid to balance endpoints

### DIFF
--- a/client/src/generated/models/AddressBalanceResponseStx.ts
+++ b/client/src/generated/models/AddressBalanceResponseStx.ts
@@ -30,18 +30,6 @@ export interface AddressBalanceResponseStx {
      * @type {string}
      * @memberof AddressBalanceResponseStx
      */
-    locked: string;
-    /**
-     * 
-     * @type {number}
-     * @memberof AddressBalanceResponseStx
-     */
-    unlock_height: number;
-    /**
-     * 
-     * @type {string}
-     * @memberof AddressBalanceResponseStx
-     */
     total_sent: string;
     /**
      * 
@@ -61,6 +49,36 @@ export interface AddressBalanceResponseStx {
      * @memberof AddressBalanceResponseStx
      */
     total_miner_rewards_received: string;
+    /**
+     * The transaction where the lock event occurred. Empty if no tokens are locked.
+     * @type {string}
+     * @memberof AddressBalanceResponseStx
+     */
+    lock_tx_id: string;
+    /**
+     * The amount of locked STX, as string quoted micro-STX. Zero if no tokens are locked.
+     * @type {string}
+     * @memberof AddressBalanceResponseStx
+     */
+    locked: string;
+    /**
+     * The STX chain block height of when the lock event occurred. Zero if no tokens are locked.
+     * @type {number}
+     * @memberof AddressBalanceResponseStx
+     */
+    lock_height: number;
+    /**
+     * The burnchain block height of when the lock event occurred. Zero if no tokens are locked.
+     * @type {number}
+     * @memberof AddressBalanceResponseStx
+     */
+    burnchain_lock_height: number;
+    /**
+     * The burnchain block height of when the tokens unlock. Zero if no tokens are locked.
+     * @type {number}
+     * @memberof AddressBalanceResponseStx
+     */
+    burnchain_unlock_height: number;
 }
 
 export function AddressBalanceResponseStxFromJSON(json: any): AddressBalanceResponseStx {
@@ -74,12 +92,15 @@ export function AddressBalanceResponseStxFromJSONTyped(json: any, ignoreDiscrimi
     return {
         
         'balance': json['balance'],
-        'locked': json['locked'],
-        'unlock_height': json['unlock_height'],
         'total_sent': json['total_sent'],
         'total_received': json['total_received'],
         'total_fees_sent': json['total_fees_sent'],
         'total_miner_rewards_received': json['total_miner_rewards_received'],
+        'lock_tx_id': json['lock_tx_id'],
+        'locked': json['locked'],
+        'lock_height': json['lock_height'],
+        'burnchain_lock_height': json['burnchain_lock_height'],
+        'burnchain_unlock_height': json['burnchain_unlock_height'],
     };
 }
 
@@ -93,12 +114,15 @@ export function AddressBalanceResponseStxToJSON(value?: AddressBalanceResponseSt
     return {
         
         'balance': value.balance,
-        'locked': value.locked,
-        'unlock_height': value.unlock_height,
         'total_sent': value.total_sent,
         'total_received': value.total_received,
         'total_fees_sent': value.total_fees_sent,
         'total_miner_rewards_received': value.total_miner_rewards_received,
+        'lock_tx_id': value.lock_tx_id,
+        'locked': value.locked,
+        'lock_height': value.lock_height,
+        'burnchain_lock_height': value.burnchain_lock_height,
+        'burnchain_unlock_height': value.burnchain_unlock_height,
     };
 }
 

--- a/client/src/generated/models/AddressStxBalanceResponse.ts
+++ b/client/src/generated/models/AddressStxBalanceResponse.ts
@@ -30,18 +30,6 @@ export interface AddressStxBalanceResponse {
      * @type {string}
      * @memberof AddressStxBalanceResponse
      */
-    locked: string;
-    /**
-     * 
-     * @type {number}
-     * @memberof AddressStxBalanceResponse
-     */
-    unlock_height: number;
-    /**
-     * 
-     * @type {string}
-     * @memberof AddressStxBalanceResponse
-     */
     total_sent: string;
     /**
      * 
@@ -61,6 +49,36 @@ export interface AddressStxBalanceResponse {
      * @memberof AddressStxBalanceResponse
      */
     total_miner_rewards_received: string;
+    /**
+     * The transaction where the lock event occurred. Empty if no tokens are locked.
+     * @type {string}
+     * @memberof AddressStxBalanceResponse
+     */
+    lock_tx_id: string;
+    /**
+     * The amount of locked STX, as string quoted micro-STX. Zero if no tokens are locked.
+     * @type {string}
+     * @memberof AddressStxBalanceResponse
+     */
+    locked: string;
+    /**
+     * The STX chain block height of when the lock event occurred. Zero if no tokens are locked.
+     * @type {number}
+     * @memberof AddressStxBalanceResponse
+     */
+    lock_height: number;
+    /**
+     * The burnchain block height of when the lock event occurred. Zero if no tokens are locked.
+     * @type {number}
+     * @memberof AddressStxBalanceResponse
+     */
+    burnchain_lock_height: number;
+    /**
+     * The burnchain block height of when the tokens unlock. Zero if no tokens are locked.
+     * @type {number}
+     * @memberof AddressStxBalanceResponse
+     */
+    burnchain_unlock_height: number;
 }
 
 export function AddressStxBalanceResponseFromJSON(json: any): AddressStxBalanceResponse {
@@ -74,12 +92,15 @@ export function AddressStxBalanceResponseFromJSONTyped(json: any, ignoreDiscrimi
     return {
         
         'balance': json['balance'],
-        'locked': json['locked'],
-        'unlock_height': json['unlock_height'],
         'total_sent': json['total_sent'],
         'total_received': json['total_received'],
         'total_fees_sent': json['total_fees_sent'],
         'total_miner_rewards_received': json['total_miner_rewards_received'],
+        'lock_tx_id': json['lock_tx_id'],
+        'locked': json['locked'],
+        'lock_height': json['lock_height'],
+        'burnchain_lock_height': json['burnchain_lock_height'],
+        'burnchain_unlock_height': json['burnchain_unlock_height'],
     };
 }
 
@@ -93,12 +114,15 @@ export function AddressStxBalanceResponseToJSON(value?: AddressStxBalanceRespons
     return {
         
         'balance': value.balance,
-        'locked': value.locked,
-        'unlock_height': value.unlock_height,
         'total_sent': value.total_sent,
         'total_received': value.total_received,
         'total_fees_sent': value.total_fees_sent,
         'total_miner_rewards_received': value.total_miner_rewards_received,
+        'lock_tx_id': value.lock_tx_id,
+        'locked': value.locked,
+        'lock_height': value.lock_height,
+        'burnchain_lock_height': value.burnchain_lock_height,
+        'burnchain_unlock_height': value.burnchain_unlock_height,
     };
 }
 

--- a/docs/api/address/get-address-balances.example.json
+++ b/docs/api/address/get-address-balances.example.json
@@ -1,10 +1,13 @@
 {
   "stx": {
     "balance": "1000000",
-    "locked": "50000",
-    "unlock_height": "256",
     "total_sent": "0",
-    "total_received": "1000000"
+    "total_received": "1000000",
+    "lock_tx_id": "0xec94e7d20af8979b44d17a0520c126bf742b999a0fc7ddbcbe0ab21b228ecc8c",
+    "locked": "50000",
+    "lock_height": 100,
+    "burnchain_lock_height": 100,
+    "burnchain_unlock_height": 200
   },
   "fungible_tokens": {},
   "non_fungible_tokens": {}

--- a/docs/api/address/get-address-stx-balance.example.json
+++ b/docs/api/address/get-address-stx-balance.example.json
@@ -1,7 +1,10 @@
 {
   "balance": "1000000",
-  "locked": "50000",
-  "unlock_height": "256",
   "total_sent": "0",
-  "total_received": "1000000"
+  "total_received": "1000000",
+  "lock_tx_id": "0xec94e7d20af8979b44d17a0520c126bf742b999a0fc7ddbcbe0ab21b228ecc8c",
+  "locked": "50000",
+  "lock_height": 100,
+  "burnchain_lock_height": 100,
+  "burnchain_unlock_height": 200
 }

--- a/docs/entities/balance/stx-balance.schema.json
+++ b/docs/entities/balance/stx-balance.schema.json
@@ -3,16 +3,10 @@
   "description": "StxBalance",
   "type": "object",
   "additionalProperties": false,
-  "required": ["balance", "locked", "unlock_height", "total_sent", "total_received", "total_fees_sent", "total_miner_rewards_received"],
+  "required": ["balance", "total_sent", "total_received", "total_fees_sent", "total_miner_rewards_received", "lock_tx_id", "locked", "lock_height", "burnchain_lock_height", "burnchain_unlock_height"],
   "properties": {
     "balance": {
       "type": "string"
-    },
-    "locked": {
-      "type": "string"
-    },
-    "unlock_height": {
-      "type": "integer"
     },
     "total_sent": {
       "type": "string"
@@ -25,6 +19,26 @@
     },
     "total_miner_rewards_received": {
       "type": "string"
+    },
+    "lock_tx_id": {
+      "type": [ "string", "null" ],
+      "description": "The transaction where the lock event occurred. Null if no tokens are locked."
+    },
+    "locked": {
+      "type": "string",
+      "description": "The amount of locked STX, as string quoted micro-STX. Zero if no tokens are locked."
+    },
+    "lock_height": {
+      "type": "integer",
+      "description": "The STX chain block height of when the lock event occurred. Zero if no tokens are locked."
+    },
+    "burnchain_lock_height": {
+      "type": "integer",
+      "description": "The burnchain block height of when the lock event occurred. Zero if no tokens are locked."
+    },
+    "burnchain_unlock_height": {
+      "type": "integer",
+      "description": "The burnchain block height of when the tokens unlock. Zero if no tokens are locked."
     }
   }
 }

--- a/docs/entities/balance/stx-balance.schema.json
+++ b/docs/entities/balance/stx-balance.schema.json
@@ -3,7 +3,18 @@
   "description": "StxBalance",
   "type": "object",
   "additionalProperties": false,
-  "required": ["balance", "total_sent", "total_received", "total_fees_sent", "total_miner_rewards_received", "lock_tx_id", "locked", "lock_height", "burnchain_lock_height", "burnchain_unlock_height"],
+  "required": [
+    "balance",
+    "total_sent",
+    "total_received",
+    "total_fees_sent",
+    "total_miner_rewards_received",
+    "lock_tx_id",
+    "locked",
+    "lock_height",
+    "burnchain_lock_height",
+    "burnchain_unlock_height"
+  ],
   "properties": {
     "balance": {
       "type": "string"
@@ -21,8 +32,8 @@
       "type": "string"
     },
     "lock_tx_id": {
-      "type": [ "string", "null" ],
-      "description": "The transaction where the lock event occurred. Null if no tokens are locked."
+      "type": "string",
+      "description": "The transaction where the lock event occurred. Empty if no tokens are locked."
     },
     "locked": {
       "type": "string",

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -23,12 +23,30 @@ export interface AddressBalanceResponse {
    */
   stx: {
     balance: string;
-    locked: string;
-    unlock_height: number;
     total_sent: string;
     total_received: string;
     total_fees_sent: string;
     total_miner_rewards_received: string;
+    /**
+     * The transaction where the lock event occurred. Null if no tokens are locked.
+     */
+    lock_tx_id: string | null;
+    /**
+     * The amount of locked STX, as string quoted micro-STX. Zero if no tokens are locked.
+     */
+    locked: string;
+    /**
+     * The STX chain block height of when the lock event occurred. Zero if no tokens are locked.
+     */
+    lock_height: number;
+    /**
+     * The burnchain block height of when the lock event occurred. Zero if no tokens are locked.
+     */
+    burnchain_lock_height: number;
+    /**
+     * The burnchain block height of when the tokens unlock. Zero if no tokens are locked.
+     */
+    burnchain_unlock_height: number;
   };
   fungible_tokens: {
     /**
@@ -63,12 +81,30 @@ export interface AddressBalanceResponse {
  */
 export interface AddressStxBalanceResponse {
   balance: string;
-  locked: string;
-  unlock_height: number;
   total_sent: string;
   total_received: string;
   total_fees_sent: string;
   total_miner_rewards_received: string;
+  /**
+   * The transaction where the lock event occurred. Null if no tokens are locked.
+   */
+  lock_tx_id: string | null;
+  /**
+   * The amount of locked STX, as string quoted micro-STX. Zero if no tokens are locked.
+   */
+  locked: string;
+  /**
+   * The STX chain block height of when the lock event occurred. Zero if no tokens are locked.
+   */
+  lock_height: number;
+  /**
+   * The burnchain block height of when the lock event occurred. Zero if no tokens are locked.
+   */
+  burnchain_lock_height: number;
+  /**
+   * The burnchain block height of when the tokens unlock. Zero if no tokens are locked.
+   */
+  burnchain_unlock_height: number;
 }
 
 /**

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -28,9 +28,9 @@ export interface AddressBalanceResponse {
     total_fees_sent: string;
     total_miner_rewards_received: string;
     /**
-     * The transaction where the lock event occurred. Null if no tokens are locked.
+     * The transaction where the lock event occurred. Empty if no tokens are locked.
      */
-    lock_tx_id: string | null;
+    lock_tx_id: string;
     /**
      * The amount of locked STX, as string quoted micro-STX. Zero if no tokens are locked.
      */
@@ -86,9 +86,9 @@ export interface AddressStxBalanceResponse {
   total_fees_sent: string;
   total_miner_rewards_received: string;
   /**
-   * The transaction where the lock event occurred. Null if no tokens are locked.
+   * The transaction where the lock event occurred. Empty if no tokens are locked.
    */
-  lock_tx_id: string | null;
+  lock_tx_id: string;
   /**
    * The amount of locked STX, as string quoted micro-STX. Zero if no tokens are locked.
    */

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -44,12 +44,15 @@ export function createAddressRouter(db: DataStore): RouterWithAsync {
     const stxBalanceResult = await db.getStxBalance(stxAddress);
     const result: AddressStxBalanceResponse = {
       balance: stxBalanceResult.balance.toString(),
-      locked: stxBalanceResult.locked.toString(),
-      unlock_height: Number(stxBalanceResult.unlockHeight),
       total_sent: stxBalanceResult.totalSent.toString(),
       total_received: stxBalanceResult.totalReceived.toString(),
       total_fees_sent: stxBalanceResult.totalFeesSent.toString(),
       total_miner_rewards_received: stxBalanceResult.totalMinerRewardsReceived.toString(),
+      lock_tx_id: stxBalanceResult.lockTxId,
+      locked: stxBalanceResult.locked.toString(),
+      lock_height: stxBalanceResult.lockHeight,
+      burnchain_lock_height: stxBalanceResult.burnchainLockHeight,
+      burnchain_unlock_height: stxBalanceResult.burnchainUnlockHeight,
     };
     res.json(result);
   });
@@ -86,12 +89,15 @@ export function createAddressRouter(db: DataStore): RouterWithAsync {
     const result: AddressBalanceResponse = {
       stx: {
         balance: stxBalanceResult.balance.toString(),
-        locked: stxBalanceResult.locked.toString(),
-        unlock_height: Number(stxBalanceResult.unlockHeight),
         total_sent: stxBalanceResult.totalSent.toString(),
         total_received: stxBalanceResult.totalReceived.toString(),
         total_fees_sent: stxBalanceResult.totalFeesSent.toString(),
         total_miner_rewards_received: stxBalanceResult.totalMinerRewardsReceived.toString(),
+        lock_tx_id: stxBalanceResult.lockTxId,
+        locked: stxBalanceResult.locked.toString(),
+        lock_height: stxBalanceResult.lockHeight,
+        burnchain_lock_height: stxBalanceResult.burnchainLockHeight,
+        burnchain_unlock_height: stxBalanceResult.burnchainUnlockHeight,
       },
       fungible_tokens: ftBalances,
       non_fungible_tokens: nftBalances,

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -277,7 +277,7 @@ export interface DbStxBalance {
   totalReceived: bigint;
   totalFeesSent: bigint;
   totalMinerRewardsReceived: bigint;
-  lockTxId: string | null;
+  lockTxId: string;
   locked: bigint;
   lockHeight: number;
   burnchainLockHeight: number;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -273,12 +273,15 @@ export interface DbFtBalance {
 
 export interface DbStxBalance {
   balance: bigint;
-  locked: bigint;
-  unlockHeight: number;
   totalSent: bigint;
   totalReceived: bigint;
   totalFeesSent: bigint;
   totalMinerRewardsReceived: bigint;
+  lockTxId: string | null;
+  locked: bigint;
+  lockHeight: number;
+  burnchainLockHeight: number;
+  burnchainUnlockHeight: number;
 }
 
 export interface DataStore extends DataStoreEventEmitter {

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -2023,7 +2023,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         `,
         [stxAddress, currentBlockHeight, currentBurnBlockHeight]
       );
-      let lockTxId: string | null = null;
+      let lockTxId: string = '';
       let locked: bigint = 0n;
       let lockHeight = 0;
       let burnchainLockHeight = 0;
@@ -2126,7 +2126,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         `,
         [stxAddress, blockHeight, burnchainBlockHeight]
       );
-      let lockTxId: string | null = null;
+      let lockTxId: string = '';
       let locked: bigint = 0n;
       let lockHeight = 0;
       let burnchainLockHeight = 0;

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -1236,12 +1236,15 @@ describe('api tests', () => {
     const expectedResp1 = {
       stx: {
         balance: '94913',
-        locked: '0',
-        unlock_height: 0,
         total_sent: '1385',
         total_received: '100000',
         total_fees_sent: '3702',
         total_miner_rewards_received: '0',
+        burnchain_lock_height: 0,
+        burnchain_unlock_height: 0,
+        lock_height: 0,
+        lock_tx_id: null,
+        locked: '0',
       },
       fungible_tokens: {
         bux: { balance: '99615', total_sent: '385', total_received: '100000' },
@@ -1266,12 +1269,15 @@ describe('api tests', () => {
     const expectedResp2 = {
       stx: {
         balance: '101',
-        locked: '0',
-        unlock_height: 0,
         total_sent: '15',
         total_received: '1350',
         total_fees_sent: '1234',
         total_miner_rewards_received: '0',
+        burnchain_lock_height: 0,
+        burnchain_unlock_height: 0,
+        lock_height: 0,
+        lock_tx_id: null,
+        locked: '0',
       },
       fungible_tokens: {
         bux: { balance: '335', total_sent: '15', total_received: '350' },
@@ -1291,12 +1297,15 @@ describe('api tests', () => {
     expect(fetchAddrStxBalance1.type).toBe('application/json');
     const expectedStxResp1 = {
       balance: '101',
-      locked: '0',
-      unlock_height: 0,
       total_sent: '15',
       total_received: '1350',
       total_fees_sent: '1234',
       total_miner_rewards_received: '0',
+      burnchain_lock_height: 0,
+      burnchain_unlock_height: 0,
+      lock_height: 0,
+      lock_tx_id: null,
+      locked: '0',
     };
     expect(JSON.parse(fetchAddrStxBalance1.text)).toEqual(expectedStxResp1);
 

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -1046,6 +1046,21 @@ describe('api tests', () => {
     const testContractAddr = 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world';
     const testAddr4 = 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C';
 
+    const block: DbBlock = {
+      block_hash: '0x1234',
+      index_block_hash: '0x1234',
+      parent_index_block_hash: '0x2345',
+      parent_block_hash: '0x5678',
+      parent_microblock: '0x9876',
+      block_height: 100123123,
+      burn_block_time: 39486,
+      burn_block_hash: '0x1234',
+      burn_block_height: 100123123,
+      miner_txid: '0x4321',
+      canonical: true,
+    };
+    await db.updateBlock(client, block);
+
     let indexIdIndex = 0;
     const createStxTx = (
       sender: string,

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -1243,7 +1243,7 @@ describe('api tests', () => {
         burnchain_lock_height: 0,
         burnchain_unlock_height: 0,
         lock_height: 0,
-        lock_tx_id: null,
+        lock_tx_id: '',
         locked: '0',
       },
       fungible_tokens: {
@@ -1276,7 +1276,7 @@ describe('api tests', () => {
         burnchain_lock_height: 0,
         burnchain_unlock_height: 0,
         lock_height: 0,
-        lock_tx_id: null,
+        lock_tx_id: '',
         locked: '0',
       },
       fungible_tokens: {
@@ -1304,7 +1304,7 @@ describe('api tests', () => {
       burnchain_lock_height: 0,
       burnchain_unlock_height: 0,
       lock_height: 0,
-      lock_tx_id: null,
+      lock_tx_id: '',
       locked: '0',
     };
     expect(JSON.parse(fetchAddrStxBalance1.text)).toEqual(expectedStxResp1);

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -220,7 +220,7 @@ describe('postgres datastore', () => {
       burnchainLockHeight: 0,
       burnchainUnlockHeight: 0,
       lockHeight: 0,
-      lockTxId: null,
+      lockTxId: '',
       locked: 0n,
     });
     expect(addrCResult).toEqual({
@@ -232,7 +232,7 @@ describe('postgres datastore', () => {
       burnchainLockHeight: 0,
       burnchainUnlockHeight: 0,
       lockHeight: 0,
-      lockTxId: null,
+      lockTxId: '',
       locked: 0n,
     });
     expect(addrDResult).toEqual({
@@ -244,7 +244,7 @@ describe('postgres datastore', () => {
       burnchainLockHeight: 0,
       burnchainUnlockHeight: 0,
       lockHeight: 0,
-      lockTxId: null,
+      lockTxId: '',
       locked: 0n,
     });
   });

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -201,39 +201,51 @@ describe('postgres datastore', () => {
 
     expect(addrAResult).toEqual({
       balance: 198287n,
-      locked: 400n,
-      unlockHeight: 68656,
       totalReceived: 100000n,
       totalSent: 385n,
       totalFeesSent: 1334n,
       totalMinerRewardsReceived: 100006n,
+      burnchainLockHeight: 123,
+      burnchainUnlockHeight: 68656,
+      lockHeight: 68456,
+      lockTxId: '0x1234',
+      locked: 400n,
     });
     expect(addrBResult).toEqual({
       balance: 565n,
-      locked: 0n,
-      unlockHeight: 0,
       totalReceived: 350n,
       totalSent: 15n,
       totalFeesSent: 0n,
       totalMinerRewardsReceived: 230n,
+      burnchainLockHeight: 0,
+      burnchainUnlockHeight: 0,
+      lockHeight: 0,
+      lockTxId: null,
+      locked: 0n,
     });
     expect(addrCResult).toEqual({
       balance: 50n,
-      locked: 0n,
-      unlockHeight: 0,
       totalReceived: 50n,
       totalSent: 0n,
       totalFeesSent: 0n,
       totalMinerRewardsReceived: 0n,
+      burnchainLockHeight: 0,
+      burnchainUnlockHeight: 0,
+      lockHeight: 0,
+      lockTxId: null,
+      locked: 0n,
     });
     expect(addrDResult).toEqual({
       balance: 0n,
-      locked: 0n,
-      unlockHeight: 0,
       totalReceived: 0n,
       totalSent: 0n,
       totalFeesSent: 0n,
       totalMinerRewardsReceived: 0n,
+      burnchainLockHeight: 0,
+      burnchainUnlockHeight: 0,
+      lockHeight: 0,
+      lockTxId: null,
+      locked: 0n,
     });
   });
 

--- a/src/tests/websocket-tests.ts
+++ b/src/tests/websocket-tests.ts
@@ -306,16 +306,16 @@ describe('websocket notifications', () => {
   test('websocket rpc - address balance subscription updates', async () => {
     // build the db block, tx, and event
     const block: DbBlock = {
-      block_hash: '0x1234',
-      index_block_hash: '0xdeadbeef',
-      parent_index_block_hash: '0x00',
-      parent_block_hash: '0xff0011',
-      parent_microblock: '0x9876',
+      block_hash: '0x001234',
+      index_block_hash: '0x001234',
+      parent_index_block_hash: '0x002345',
+      parent_block_hash: '0x005678',
+      parent_microblock: '0x009876',
       block_height: 1,
-      burn_block_time: 94869286,
-      burn_block_hash: '0x1234',
-      burn_block_height: 123,
-      miner_txid: '0x4321',
+      burn_block_time: 39486,
+      burn_block_hash: '0x001234',
+      burn_block_height: 1,
+      miner_txid: '0x004321',
       canonical: true,
     };
 
@@ -325,7 +325,7 @@ describe('websocket notifications', () => {
       raw_tx: Buffer.from('raw-tx-test'),
       index_block_hash: '0x5432',
       block_hash: '0x9876',
-      block_height: 68456,
+      block_height: block.block_height,
       burn_block_time: 2837565,
       type_id: DbTxTypeId.TokenTransfer,
       status: DbTxStatus.Success,


### PR DESCRIPTION
Closes #340

Adds both lock height (for both burnchain and Stacks chain), as well as the associated lockup txid.

Also clarifies that the unlock height refers to the burnchain by renaming to `burnchain_unlock_height`.

The new response interface:
```ts
interface Balance {
    balance: string;
    total_sent: string;
    total_received: string;
    total_fees_sent: string;
    total_miner_rewards_received: string;
    /**
     * The transaction where the lock event occurred. Empty if no tokens are locked.
     */
    lock_tx_id: string;
    /**
     * The amount of locked STX, as string quoted micro-STX. Zero if no tokens are locked.
     */
    locked: string;
    /**
     * The STX chain block height of when the lock event occurred. Zero if no tokens are locked.
     */
    lock_height: number;
    /**
     * The burnchain block height of when the lock event occurred. Zero if no tokens are locked.
     */
    burnchain_lock_height: number;
    /**
     * The burnchain block height of when the tokens unlock. Zero if no tokens are locked.
     */
    burnchain_unlock_height: number;
}
```

Example response:
```json
{
  "balance": "1000000",
  "total_sent": "0",
  "total_received": "1000000",
  "lock_tx_id": "0xec94e7d20af8979b44d17a0520c126bf742b999a0fc7ddbcbe0ab21b228ecc8c",
  "locked": "50000",
  "lock_height": 100,
  "burnchain_lock_height": 100,
  "burnchain_unlock_height": 200
}
```