### PR TITLE
Feat/genesis ingest speed

### DIFF
--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -362,7 +362,7 @@ export async function startEventServer(opts: {
     app.use(opts.promMiddleware);
   }
 
-  app.use(bodyParser.json({ type: 'application/json', limit: '25MB' }));
+  app.use(bodyParser.json({ type: 'application/json', limit: '500MB' }));
   app.getAsync('/', (req, res) => {
     res
       .status(200)


### PR DESCRIPTION
Using a full Stacks 1.0 dataset with the core node results in ~30 minutes of genesis block event ingest time, mostly spent on sql inserts. 

This PR implements batched postgres inserts using prepared statements. Local benchmarks have the STX balance imports taking ~15 seconds with this PR, vs the previous ~30 minutes.