### PR TITLE
Temporary limit of 200 stx asset events

### DIFF
--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1600,6 +1600,8 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
           event_index, tx_id, tx_index, block_height, canonical, asset_event_type_id, sender, recipient, amount
         FROM stx_events
         WHERE tx_id = $1 AND index_block_hash = $2
+        ORDER BY event_index DESC
+        LIMIT 200
         `,
         [txIdBuffer, blockHashBuffer]
       );


### PR DESCRIPTION
A couple endpoints that return the stx-mint events for the genesis transaction are currently extremely resource intensive due to loading in ~330k at once. This is a temporary fix by adding a 200 limit to the amount of stx-asset events returned for a given transaction.

A permanent fix is could be to simply not return events for these special massive genesis transactions, as I don't think there's a real need to display them. Alternatively, we can implement per-transaction event pagination. This will require some discussion.