### PR TITLE
Add pagination for tx events #365

### DIFF
--- a/client/src/generated/apis/TransactionsApi.ts
+++ b/client/src/generated/apis/TransactionsApi.ts
@@ -33,6 +33,8 @@ export interface GetMempoolTransactionListRequest {
 
 export interface GetTransactionByIdRequest {
     txId: string;
+    eventOffset?: number;
+    eventLimit?: number;
 }
 
 export interface GetTransactionListRequest {
@@ -73,6 +75,8 @@ export interface TransactionsApiInterface {
      * Get a specific transaction by ID  `import type { Transaction } from \'@blockstack/stacks-blockchain-api-types\';` 
      * @summary Get transaction
      * @param {string} txId Hash of transaction
+     * @param {number} [eventOffset] The number of events to skip
+     * @param {number} [eventLimit] The numbers of events to return
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TransactionsApiInterface
@@ -172,6 +176,14 @@ export class TransactionsApi extends runtime.BaseAPI implements TransactionsApiI
         }
 
         const queryParameters: runtime.HTTPQuery = {};
+
+        if (requestParameters.eventOffset !== undefined) {
+            queryParameters['event_offset'] = requestParameters.eventOffset;
+        }
+
+        if (requestParameters.eventLimit !== undefined) {
+            queryParameters['event_limit'] = requestParameters.eventLimit;
+        }
 
         const headerParameters: runtime.HTTPHeaders = {};
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -155,6 +155,18 @@ paths:
         required: true
         schema:
           type: string
+      - name: event_offset
+        in: query
+        schema:
+          type: integer
+          default: 0
+        description: The number of events to skip
+      - name: event_limit
+        in: query
+        schema:
+          type: integer
+          default: 96
+        description: The numbers of events to return
     get:
       summary: Get transaction
       tags:

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -120,7 +120,7 @@ export function createAddressRouter(db: DataStore): RouterWithAsync {
       offset,
     });
     const results = await Bluebird.mapSeries(txResults, async tx => {
-      const txQuery = await getTxFromDataStore(tx.tx_id, db);
+      const txQuery = await getTxFromDataStore(db, { txId: tx.tx_id });
       if (!txQuery.found) {
         throw new Error('unexpected tx not found -- fix tx enumeration query');
       }

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -308,7 +308,12 @@ export interface DataStore extends DataStoreEventEmitter {
     txTypeFilter: TransactionType[];
   }): Promise<{ results: DbTx[]; total: number }>;
 
-  getTxEvents(txId: string, indexBlockHash: string): Promise<{ results: DbEvent[] }>;
+  getTxEvents(args: {
+    txId: string;
+    indexBlockHash: string;
+    limit: number;
+    offset: number;
+  }): Promise<{ results: DbEvent[] }>;
 
   getSmartContract(contractId: string): Promise<FoundOrNot<DbSmartContract>>;
 

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -251,21 +251,21 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     return Promise.resolve({ results, total: transactionsList.length });
   }
 
-  getTxEvents(txId: string, indexBlockHash: string) {
+  getTxEvents(args: { txId: string; indexBlockHash: string; limit: number; offset: number }) {
     const stxLockEvents = [...this.stxLockEvents.values()].filter(
-      e => e.indexBlockHash === indexBlockHash && e.entry.tx_id === txId
+      e => e.indexBlockHash === args.indexBlockHash && e.entry.tx_id === args.txId
     );
     const stxEvents = [...this.stxTokenEvents.values()].filter(
-      e => e.indexBlockHash === indexBlockHash && e.entry.tx_id === txId
+      e => e.indexBlockHash === args.indexBlockHash && e.entry.tx_id === args.txId
     );
     const ftEvents = [...this.fungibleTokenEvents.values()].filter(
-      e => e.indexBlockHash === indexBlockHash && e.entry.tx_id === txId
+      e => e.indexBlockHash === args.indexBlockHash && e.entry.tx_id === args.txId
     );
     const nftEvents = [...this.nonFungibleTokenEvents.values()].filter(
-      e => e.indexBlockHash === indexBlockHash && e.entry.tx_id === txId
+      e => e.indexBlockHash === args.indexBlockHash && e.entry.tx_id === args.txId
     );
     const smartContractEvents = [...this.smartContractEvents.values()].filter(
-      e => e.indexBlockHash === indexBlockHash && e.entry.tx_id === txId
+      e => e.indexBlockHash === args.indexBlockHash && e.entry.tx_id === args.txId
     );
     const allEvents = [
       ...stxLockEvents,

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1560,12 +1560,14 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     }
   }
 
-  async getTxEvents(txId: string, indexBlockHash: string) {
+  async getTxEvents(args: { txId: string; indexBlockHash: string; limit: number; offset: number }) {
     const client = await this.pool.connect();
     try {
       await client.query('BEGIN');
-      const txIdBuffer = hexToBuffer(txId);
-      const blockHashBuffer = hexToBuffer(indexBlockHash);
+      const eventIndexStart = args.offset;
+      const eventIndexEnd = args.offset + args.limit - 1;
+      const txIdBuffer = hexToBuffer(args.txId);
+      const blockHashBuffer = hexToBuffer(args.indexBlockHash);
       const stxLockResults = await client.query<{
         event_index: number;
         tx_id: Buffer;
@@ -1580,9 +1582,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         SELECT
           event_index, tx_id, tx_index, block_height, canonical, locked_amount, unlock_height, locked_address
         FROM stx_lock_events
-        WHERE tx_id = $1 AND index_block_hash = $2
+        WHERE tx_id = $1 AND index_block_hash = $2 AND event_index BETWEEN $3 AND $4
         `,
-        [txIdBuffer, blockHashBuffer]
+        [txIdBuffer, blockHashBuffer, eventIndexStart, eventIndexEnd]
       );
       const stxResults = await client.query<{
         event_index: number;
@@ -1599,11 +1601,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         SELECT
           event_index, tx_id, tx_index, block_height, canonical, asset_event_type_id, sender, recipient, amount
         FROM stx_events
-        WHERE tx_id = $1 AND index_block_hash = $2
-        ORDER BY event_index DESC
-        LIMIT 200
+        WHERE tx_id = $1 AND index_block_hash = $2 AND event_index BETWEEN $3 AND $4
         `,
-        [txIdBuffer, blockHashBuffer]
+        [txIdBuffer, blockHashBuffer, eventIndexStart, eventIndexEnd]
       );
       const ftResults = await client.query<{
         event_index: number;
@@ -1621,9 +1621,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         SELECT
           event_index, tx_id, tx_index, block_height, canonical, asset_event_type_id, sender, recipient, asset_identifier, amount
         FROM ft_events
-        WHERE tx_id = $1 AND index_block_hash = $2
+        WHERE tx_id = $1 AND index_block_hash = $2 AND event_index BETWEEN $3 AND $4
         `,
-        [txIdBuffer, blockHashBuffer]
+        [txIdBuffer, blockHashBuffer, eventIndexStart, eventIndexEnd]
       );
       const nftResults = await client.query<{
         event_index: number;
@@ -1641,9 +1641,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         SELECT
           event_index, tx_id, tx_index, block_height, canonical, asset_event_type_id, sender, recipient, asset_identifier, value
         FROM nft_events
-        WHERE tx_id = $1 AND index_block_hash = $2
+        WHERE tx_id = $1 AND index_block_hash = $2 AND event_index BETWEEN $3 AND $4
         `,
-        [txIdBuffer, blockHashBuffer]
+        [txIdBuffer, blockHashBuffer, eventIndexStart, eventIndexEnd]
       );
       const logResults = await client.query<{
         event_index: number;
@@ -1659,9 +1659,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         SELECT
           event_index, tx_id, tx_index, block_height, canonical, contract_identifier, topic, value
         FROM contract_logs
-        WHERE tx_id = $1 AND index_block_hash = $2
+        WHERE tx_id = $1 AND index_block_hash = $2 AND event_index BETWEEN $3 AND $4
         `,
-        [txIdBuffer, blockHashBuffer]
+        [txIdBuffer, blockHashBuffer, eventIndexStart, eventIndexEnd]
       );
       const events = new Array<DbEvent>(
         stxResults.rowCount +

--- a/src/migrations/1588252682585_stx_events.ts
+++ b/src/migrations/1588252682585_stx_events.ts
@@ -48,6 +48,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createIndex('stx_events', 'canonical');
   pgm.createIndex('stx_events', 'sender');
   pgm.createIndex('stx_events', 'recipient');
+  pgm.createIndex('stx_events', 'event_index');
 
   pgm.addConstraint('stx_events', 'valid_asset_transfer', `CHECK (asset_event_type_id != 1 OR (
     NOT (sender, recipient) IS NULL

--- a/src/migrations/1588256295395_ft_events.ts
+++ b/src/migrations/1588256295395_ft_events.ts
@@ -53,6 +53,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createIndex('ft_events', 'asset_identifier');
   pgm.createIndex('ft_events', 'sender');
   pgm.createIndex('ft_events', 'recipient');
+  pgm.createIndex('ft_events', 'event_index');
 
   pgm.addConstraint('ft_events', 'valid_asset_transfer', `CHECK (asset_event_type_id != 1 OR (
     NOT (sender, recipient) IS NULL

--- a/src/migrations/1588261750265_nft_events.ts
+++ b/src/migrations/1588261750265_nft_events.ts
@@ -53,6 +53,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createIndex('nft_events', 'asset_identifier');
   pgm.createIndex('nft_events', 'sender');
   pgm.createIndex('nft_events', 'recipient');
+  pgm.createIndex('nft_events', 'event_index');
 
   pgm.addConstraint('nft_events', 'valid_asset_transfer', `CHECK (asset_event_type_id != 1 OR (
     NOT (sender, recipient) IS NULL

--- a/src/migrations/1588266401242_contract_logs.ts
+++ b/src/migrations/1588266401242_contract_logs.ts
@@ -49,5 +49,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createIndex('contract_logs', 'index_block_hash');
   pgm.createIndex('contract_logs', 'canonical');
   pgm.createIndex('contract_logs', 'contract_identifier');
+  pgm.createIndex('contract_logs', 'event_index');
 
 }

--- a/src/migrations/1605100253938_stx_lock_events.ts
+++ b/src/migrations/1605100253938_stx_lock_events.ts
@@ -49,5 +49,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createIndex('stx_lock_events', 'index_block_hash');
   pgm.createIndex('stx_lock_events', 'canonical');
   pgm.createIndex('stx_lock_events', 'locked_address');
+  pgm.createIndex('stx_lock_events', 'event_index');
 
 }

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -1753,7 +1753,7 @@ describe('api tests', () => {
       source_code: '()',
       abi: JSON.stringify(contractAbi),
     });
-    const txQuery = await getTxFromDataStore(dbTx.tx_id, db);
+    const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id });
     expect(txQuery.found).toBe(true);
     if (!txQuery.found) {
       throw Error('not found');
@@ -1871,7 +1871,7 @@ describe('api tests', () => {
       source_code: '()',
       abi: JSON.stringify(contractAbi),
     });
-    const txQuery = await getTxFromDataStore(dbTx.tx_id, db);
+    const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id });
     expect(txQuery.found).toBe(true);
     if (!txQuery.found) {
       throw Error('not found');
@@ -1986,7 +1986,7 @@ describe('api tests', () => {
     });
     await db.updateTx(client, dbTx);
 
-    const txQuery = await getTxFromDataStore(dbTx.tx_id, db);
+    const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id });
     expect(txQuery.found).toBe(true);
     if (!txQuery.found) {
       throw Error('not found');
@@ -2056,7 +2056,7 @@ describe('api tests', () => {
     });
     await db.updateTx(client, dbTx);
 
-    const txQuery = await getTxFromDataStore(dbTx.tx_id, db);
+    const txQuery = await getTxFromDataStore(db, { txId: dbTx.tx_id });
     expect(txQuery.found).toBe(true);
     if (!txQuery.found) {
       throw Error('not found');

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -1761,7 +1761,12 @@ describe('postgres datastore', () => {
     assert(fetchContract1.found);
     expect(fetchContract1.result).toEqual(smartContract1);
 
-    const fetchTx1Events = await db.getTxEvents(tx1.tx_id, tx1.index_block_hash);
+    const fetchTx1Events = await db.getTxEvents({
+      txId: tx1.tx_id,
+      indexBlockHash: tx1.index_block_hash,
+      limit: 100,
+      offset: 0,
+    });
     expect(fetchTx1Events.results).toHaveLength(4);
     expect(fetchTx1Events.results.find(e => e.event_index === 1)).toEqual(stxEvent1);
     expect(fetchTx1Events.results.find(e => e.event_index === 2)).toEqual(ftEvent1);


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/365

Implement pagination for transaction events. 

The endpoint `/extended/v1/tx/<txid>` can now be passed query parameters `event_offset` and `event_limit`. If unspecified, the default is `96`. 