### PR TITLE
Send stx faucet requests to both miner and follower

### DIFF
--- a/src/api/routes/faucets.ts
+++ b/src/api/routes/faucets.ts
@@ -193,14 +193,18 @@ export function createFaucetRouter(db: DataStore): RouterWithAsync {
 
       const nonces: BN[] = [];
       const fees: BN[] = [];
+      let txGenFetchError: Error | undefined;
       for (const network of networks) {
         try {
           const tx = await generateTx(network);
           nonces.push(tx.auth.spendingCondition?.nonce);
           fees.push(tx.auth.getFee());
         } catch (error) {
-          // ignore
+          txGenFetchError = error;
         }
+      }
+      if (nonces.length === 0) {
+        throw txGenFetchError;
       }
       let nextNonce = intMax(nonces);
       const fee = intMax(fees);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as winston from 'winston';
 import * as c32check from 'c32check';
 import * as btc from 'bitcoinjs-lib';
+import * as BN from 'bn.js';
 
 export const isDevEnv = process.env.NODE_ENV === 'development';
 export const isTestEnv = process.env.NODE_ENV === 'test';
@@ -369,6 +370,24 @@ export function* batchIterate<T>(
     logger.debug(`Iterated ${itemsPerSecond} items/second at ${caller}`);
   }
 }
+
+function intMax(args: bigint[]): bigint;
+function intMax(args: number[]): number;
+function intMax(args: BN[]): BN;
+function intMax(args: bigint[] | number[] | BN[]): any {
+  if (args.length === 0) {
+    throw new Error(`empty array not supported in intMax`);
+  } else if (typeof args[0] === 'bigint') {
+    return (args as bigint[]).reduce((m, e) => (e > m ? e : m));
+  } else if (typeof args[0] === 'number') {
+    return Math.max(...(args as number[]));
+  } else if (BN.isBN(args[0])) {
+    return (args as BN[]).reduce((m, e) => (e.gt(m) ? e : m));
+  } else {
+    throw new Error(`Unsupported type for intMax: ${(args[0] as object).constructor.name}`);
+  }
+}
+export { intMax };
 
 export function getOrAdd<K, V>(map: Map<K, V>, key: K, create: () => V): V {
   let val = map.get(key);

--- a/src/tests/faucet-stx-tests.ts
+++ b/src/tests/faucet-stx-tests.ts
@@ -1,17 +1,20 @@
 import * as process from 'process';
-import { getStxFaucetNetwork } from '../api/routes/faucets';
+import { getStxFaucetNetworks } from '../api/routes/faucets';
 
 describe('stx faucet', () => {
   test('faucet node env var override', () => {
-    const faucetDefault = getStxFaucetNetwork();
-    expect(faucetDefault.coreApiUrl).toBe('http://127.0.0.1:20443');
+    const faucetDefaults = getStxFaucetNetworks();
+    expect(faucetDefaults.length).toBe(1);
+    expect(faucetDefaults[0].coreApiUrl).toBe('http://127.0.0.1:20443');
 
     process.env.STACKS_FAUCET_NODE_HOST = '1.2.3.4';
     process.env.STACKS_FAUCET_NODE_PORT = '12345';
 
     try {
-      const faucetOverride = getStxFaucetNetwork();
-      expect(faucetOverride.coreApiUrl).toBe('http://1.2.3.4:12345');
+      const faucetOverride = getStxFaucetNetworks();
+      expect(faucetOverride.length).toBe(2);
+      expect(faucetDefaults[0].coreApiUrl).toBe('http://127.0.0.1:20443');
+      expect(faucetOverride[1].coreApiUrl).toBe('http://1.2.3.4:12345');
     } finally {
       delete process.env.STACKS_FAUCET_NODE_HOST;
       delete process.env.STACKS_FAUCET_NODE_PORT;


### PR DESCRIPTION
Reference https://github.com/blockstack/stacks-blockchain-api/issues/359

* Performs nonce incrementing without the previously hardcoded limit.
* Broadcast transaction to both miner and follower if both are configured.