### PR TITLE
fix: miner reward event parse error

### DIFF
--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -47,8 +47,7 @@ export interface DbMinerReward {
   /** STX principal */
   recipient: string;
   coinbase_amount: bigint;
-  tx_fees_anchored_shared: bigint;
-  tx_fees_anchored_exclusive: bigint;
+  tx_fees_anchored: bigint;
   tx_fees_streamed_confirmed: bigint;
 }
 

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -886,8 +886,8 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     const result = await client.query(
       `
       INSERT INTO miner_rewards(
-        block_hash, index_block_hash, mature_block_height, canonical, recipient, coinbase_amount, tx_fees_anchored_shared, tx_fees_anchored_exclusive, tx_fees_streamed_confirmed
-      ) values($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        block_hash, index_block_hash, mature_block_height, canonical, recipient, coinbase_amount, tx_fees_anchored, tx_fees_streamed_confirmed
+      ) values($1, $2, $3, $4, $5, $6, $7, $8)
       `,
       [
         hexToBuffer(minerReward.block_hash),
@@ -896,8 +896,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         minerReward.canonical,
         minerReward.recipient,
         minerReward.coinbase_amount,
-        minerReward.tx_fees_anchored_shared,
-        minerReward.tx_fees_anchored_exclusive,
+        minerReward.tx_fees_anchored,
         minerReward.tx_fees_streamed_confirmed,
       ]
     );
@@ -2187,7 +2186,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     const minerRewardQuery = await client.query<{ amount: string }>(
       `
       SELECT sum(
-        coinbase_amount + tx_fees_anchored_shared + tx_fees_anchored_exclusive + tx_fees_streamed_confirmed
+        coinbase_amount + tx_fees_anchored + tx_fees_streamed_confirmed
       ) amount
       FROM miner_rewards
       WHERE canonical = true AND recipient = $1 AND mature_block_height <= $2

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -163,9 +163,7 @@ export interface CoreNodeBlockMessage {
     /** String quoted micro-STX amount. */
     coinbase_amount: string;
     /** String quoted micro-STX amount. */
-    tx_fees_anchored_shared: string;
-    /** String quoted micro-STX amount. */
-    tx_fees_anchored_exclusive: string;
+    tx_fees_anchored: string;
     /** String quoted micro-STX amount. */
     tx_fees_streamed_confirmed: string;
   }[];

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -127,8 +127,7 @@ async function handleClientMessage(msg: CoreNodeBlockMessage, db: DataStore): Pr
       mature_block_height: parsedMsg.block_height,
       recipient: minerReward.recipient,
       coinbase_amount: BigInt(minerReward.coinbase_amount),
-      tx_fees_anchored_shared: BigInt(minerReward.tx_fees_anchored_shared),
-      tx_fees_anchored_exclusive: BigInt(minerReward.tx_fees_anchored_exclusive),
+      tx_fees_anchored: BigInt(minerReward.tx_fees_anchored),
       tx_fees_streamed_confirmed: BigInt(minerReward.tx_fees_streamed_confirmed),
     };
     dbMinerRewards.push(dbMinerReward);

--- a/src/migrations/1605184662317_miner_rewards.ts
+++ b/src/migrations/1605184662317_miner_rewards.ts
@@ -1,5 +1,5 @@
 import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
-// block_hash, index_block_hash, canonical, recipient, coinbase_amount, tx_fees_anchored_shared, tx_fees_anchored_exclusive, tx_fees_streamed_confirmed
+// block_hash, index_block_hash, canonical, recipient, coinbase_amount, tx_fees_anchored, tx_fees_streamed_confirmed
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createTable('miner_rewards', {
     id: {
@@ -30,11 +30,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       type: 'numeric',
       notNull: true,
     },
-    tx_fees_anchored_shared: {
-      type: 'numeric',
-      notNull: true,
-    },
-    tx_fees_anchored_exclusive: {
+    tx_fees_anchored: {
       type: 'numeric',
       notNull: true,
     },

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -79,8 +79,7 @@ describe('postgres datastore', () => {
     const createMinerReward = (
       recipient: string,
       amount: bigint,
-      txFeeShared: bigint,
-      txFeeExclusive: bigint,
+      txFeeAnchored: bigint,
       txFeeConfirmed: bigint,
       canonical: boolean = true
     ): DbMinerReward => {
@@ -91,18 +90,17 @@ describe('postgres datastore', () => {
         canonical: canonical,
         recipient: recipient,
         coinbase_amount: amount,
-        tx_fees_anchored_shared: txFeeShared,
-        tx_fees_anchored_exclusive: txFeeExclusive,
+        tx_fees_anchored: txFeeAnchored,
         tx_fees_streamed_confirmed: txFeeConfirmed,
       };
       return minerReward;
     };
 
     const minerRewards = [
-      createMinerReward('addrA', 100_000n, 1n, 2n, 3n),
-      createMinerReward('addrB', 100n, 0n, 40n, 0n),
-      createMinerReward('addrB', 0n, 20n, 30n, 40n),
-      createMinerReward('addrB', 99999n, 91n, 92n, 93n, false),
+      createMinerReward('addrA', 100_000n, 2n, 3n),
+      createMinerReward('addrB', 100n, 40n, 0n),
+      createMinerReward('addrB', 0n, 30n, 40n),
+      createMinerReward('addrB', 99999n, 92n, 93n, false),
     ];
     for (const reward of minerRewards) {
       await db.updateMinerReward(client, reward);
@@ -200,11 +198,11 @@ describe('postgres datastore', () => {
     const addrDResult = await db.getStxBalance('addrD');
 
     expect(addrAResult).toEqual({
-      balance: 198287n,
+      balance: 198286n,
       totalReceived: 100000n,
       totalSent: 385n,
       totalFeesSent: 1334n,
-      totalMinerRewardsReceived: 100006n,
+      totalMinerRewardsReceived: 100005n,
       burnchainLockHeight: 123,
       burnchainUnlockHeight: 68656,
       lockHeight: 68456,
@@ -212,11 +210,11 @@ describe('postgres datastore', () => {
       locked: 400n,
     });
     expect(addrBResult).toEqual({
-      balance: 565n,
+      balance: 545n,
       totalReceived: 350n,
       totalSent: 15n,
       totalFeesSent: 0n,
-      totalMinerRewardsReceived: 230n,
+      totalMinerRewardsReceived: 210n,
       burnchainLockHeight: 0,
       burnchainUnlockHeight: 0,
       lockHeight: 0,
@@ -2232,8 +2230,7 @@ describe('postgres datastore', () => {
       mature_block_height: 3,
       recipient: 'miner-addr1',
       coinbase_amount: 1000n,
-      tx_fees_anchored_shared: 1n,
-      tx_fees_anchored_exclusive: 2n,
+      tx_fees_anchored: 2n,
       tx_fees_streamed_confirmed: 3n,
     };
 
@@ -2402,8 +2399,7 @@ describe('postgres datastore', () => {
       mature_block_height: 3,
       recipient: 'miner-addr1',
       coinbase_amount: 1000n,
-      tx_fees_anchored_shared: 1n,
-      tx_fees_anchored_exclusive: 2n,
+      tx_fees_anchored: 2n,
       tx_fees_streamed_confirmed: 3n,
     };
 
@@ -2412,8 +2408,7 @@ describe('postgres datastore', () => {
       mature_block_height: 4,
       recipient: 'miner-addr2',
       coinbase_amount: 1000n,
-      tx_fees_anchored_shared: 1n,
-      tx_fees_anchored_exclusive: 2n,
+      tx_fees_anchored: 2n,
       tx_fees_streamed_confirmed: 3n,
     };
 
@@ -2620,7 +2615,7 @@ describe('postgres datastore', () => {
 
     const r1 = await db.getStxBalance(minerReward1.recipient);
     const r2 = await db.getStxBalance(minerReward2.recipient);
-    expect(r1.totalMinerRewardsReceived).toBe(1006n);
+    expect(r1.totalMinerRewardsReceived).toBe(1005n);
     expect(r2.totalMinerRewardsReceived).toBe(0n);
 
     const lock1 = await db.getStxBalance(stxLockEvent1.locked_address);


### PR DESCRIPTION
Fixed a bug with API getting stuck around block 101 on current Xenon testnet. A parse error in the miner reward event handler was stalling block processing. 