### PR TITLE
Implement sql query leak detection and logging

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "declaration": false,
     "strict": true,
     "outDir": "lib",
-    "sourceMap": false,
+    "sourceMap": true,
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": false,
     "resolveJsonModule": true,


### PR DESCRIPTION
Closes (hopefully) https://github.com/blockstack/stacks-blockchain-api/issues/384

Followed the guide from https://node-postgres.com/guides/project-structure to augment the postgres lib with query leak detection and logging. This appears to be one of the least invasive methods, but this PR will still cause merge conflicts with other PRs modifying the postgres layer.

Changes:
* All db queries are performed with a new helper function that logs an error if a query/pg-client isn't released after 5 seconds. This should help identify any queries that could be causing the "idle in transaction" status reported by postgres.
* All sql transactions are performed in a similar helper function that enforces the `try { BEGIN; <query>; COMMIT; } catch { ROLLBACK; }` statements.