### PR TITLE
feat: add pricing names and namespaces

### DIFF
--- a/src/api/routes/bns/pricing.ts
+++ b/src/api/routes/bns/pricing.ts
@@ -1,0 +1,116 @@
+import * as express from 'express';
+import { RouterWithAsync, addAsync } from '@awaitjs/express';
+import { DataStore, DbBNSNamespace } from '../../../datastore/common';
+import {
+  makeRandomPrivKey,
+  getAddressFromPrivateKey,
+  TransactionVersion,
+  ReadOnlyFunctionOptions,
+  bufferCVFromString,
+  callReadOnlyFunction,
+  ClarityType,
+  tupleCV,
+  uintCV,
+  listCV,
+} from '@stacks/transactions';
+import { GetStacksTestnetNetwork } from './../../../bns-helpers';
+
+export function createBNSPriceRouter(db: DataStore): RouterWithAsync {
+  const router = addAsync(express.Router());
+  const stacksNetwork = GetStacksTestnetNetwork();
+
+  router.getAsync('/namespaces/:namespace', async (req, res) => {
+    const { namespace } = req.params;
+    if (namespace.length > 20) {
+      res.status(400).json({ error: 'Invalid namespace' });
+      return;
+    }
+    const randomPrivKey = makeRandomPrivKey();
+    const address = getAddressFromPrivateKey(randomPrivKey.data, TransactionVersion.Testnet);
+
+    const txOptions: ReadOnlyFunctionOptions = {
+      senderAddress: address,
+      contractAddress: 'ST000000000000000000002AMW42H',
+      contractName: 'bns',
+      functionName: 'compute-namespace-price?',
+      functionArgs: [bufferCVFromString(namespace)],
+      network: stacksNetwork,
+    };
+    console.log(req.params);
+    try {
+      const contractCallTx = await callReadOnlyFunction(txOptions);
+      if (
+        contractCallTx.type == ClarityType.ResponseOk &&
+        contractCallTx.value.type == ClarityType.UInt
+      ) {
+        const response = {
+          units: 'STX',
+          amount: contractCallTx.value.value.toString(10),
+        };
+        res.json(response);
+      } else {
+        res.status(400).json({ error: 'Invalid namespace' });
+      }
+    } catch (error) {
+      console.log(error);
+      res.status(400).json({ error: 'Invalid namespace' });
+    }
+  });
+
+  router.getAsync('/names/:name', async (req, res) => {
+    const input = req.params.name;
+    if (!input.includes('.')) {
+      res.status(400).json({ error: 'Invalid name' });
+      return;
+    }
+    const split = input.split('.');
+    if (split.length != 2) {
+      res.status(400).json({ error: 'Invalid name' });
+      return;
+    }
+    const name = split[0];
+    const namespace = split[1];
+    const namespaceQuery = await db.getNamespace({ namespace });
+    if (!namespaceQuery.found) {
+      res.status(400).json({ error: 'Namespace not exits' });
+      return;
+    }
+    const dbNamespace: DbBNSNamespace = namespaceQuery.result;
+    const randomPrivKey = makeRandomPrivKey();
+    const address = getAddressFromPrivateKey(randomPrivKey.data, TransactionVersion.Testnet);
+    const buckets = dbNamespace.buckets.split(';').map(x => uintCV(x));
+    const txOptions: ReadOnlyFunctionOptions = {
+      senderAddress: address,
+      contractAddress: 'ST000000000000000000002AMW42H',
+      contractName: 'bns',
+      functionName: 'compute-name-price',
+      functionArgs: [
+        bufferCVFromString(name),
+        tupleCV({
+          buckets: listCV(buckets),
+          base: uintCV(dbNamespace.base),
+          coeff: uintCV(dbNamespace.coeff),
+          'nonalpha-discount': uintCV(dbNamespace.nonalpha_discount),
+          'no-vowel-discount': uintCV(dbNamespace.no_vowel_discount),
+        }),
+      ],
+      network: stacksNetwork,
+    };
+
+    const contractCall = await callReadOnlyFunction(txOptions);
+    if (
+      contractCall.type == ClarityType.ResponseOk &&
+      contractCall.value.type == ClarityType.UInt
+    ) {
+      const response = {
+        units: 'STX',
+        amount: contractCall.value.value.toString(10),
+      };
+      res.json(response);
+    } else {
+      res.status(400).json({ error: 'Invalid name' });
+    }
+  });
+
+  return router;
+}

--- a/src/api/routes/bns/pricing.ts
+++ b/src/api/routes/bns/pricing.ts
@@ -36,7 +36,6 @@ export function createBNSPriceRouter(db: DataStore): RouterWithAsync {
       functionArgs: [bufferCVFromString(namespace)],
       network: stacksNetwork,
     };
-    console.log(req.params);
     try {
       const contractCallTx = await callReadOnlyFunction(txOptions);
       if (
@@ -52,7 +51,6 @@ export function createBNSPriceRouter(db: DataStore): RouterWithAsync {
         res.status(400).json({ error: 'Invalid namespace' });
       }
     } catch (error) {
-      console.log(error);
       res.status(400).json({ error: 'Invalid namespace' });
     }
   });

--- a/src/bns-helpers.ts
+++ b/src/bns-helpers.ts
@@ -19,7 +19,8 @@ import { hexToBuffer } from './helpers';
 import BN = require('bn.js');
 import { CoreNodeParsedTxMessage } from './event-stream/core-node-message';
 import { TransactionPayloadTypeID } from './p2p/tx';
-import { StacksCoreRpcClient } from './core-rpc/client';
+import { StacksCoreRpcClient, getCoreNodeEndpoint } from './core-rpc/client';
+import { StacksTestnet } from '@stacks/network';
 
 export interface Attachment {
   attachment: {
@@ -174,4 +175,10 @@ export function getFunctionName(tx_id: string, transactions: CoreNodeParsedTxMes
     }
   }
   return contract_function_name;
+}
+
+export function GetStacksTestnetNetwork() {
+  const stacksNetwork = new StacksTestnet();
+  stacksNetwork.coreApiUrl = `http://${getCoreNodeEndpoint()}`;
+  return stacksNetwork;
 }

--- a/src/tests-bns/api.ts
+++ b/src/tests-bns/api.ts
@@ -121,6 +121,8 @@ describe('BNS API', () => {
     expect(query1.status).toBe(400);
   });
 
+  // TODO: implement schema validation test
+  // TODO: implement price check successful test
   test('Success: names returned with page number in namespaces/{namespace}/names', async () => {
     const query1 = await supertest(api.server).get(`/v1/namespaces/abc/names?page=0`);
     expect(query1.status).toBe(200);

--- a/src/tests-bns/api.ts
+++ b/src/tests-bns/api.ts
@@ -126,6 +126,26 @@ describe('BNS API', () => {
     expect(query1.status).toBe(200);
   });
 
+  test('Fail namespace price', async () => {
+    // if namespace length greater than 20 chars
+    const query1 = await supertest(api.server).get(`/v2/prices/namespaces/someLongIdString12345`);
+    expect(query1.status).toBe(400);
+    expect(query1.type).toBe('application/json');
+  });
+
+  test('Fail names price invalid name', async () => {
+    // if name is without dot
+    const query1 = await supertest(api.server).get(`/v2/prices/names/withoutdot`);
+    expect(query1.status).toBe(400);
+    expect(query1.type).toBe('application/json');
+  });
+
+  test('Fail names price invalid name multi dots', async () => {
+    const query1 = await supertest(api.server).get(`/v2/prices/names/name.test.id`);
+    expect(query1.status).toBe(400);
+    expect(query1.type).toBe('application/json');
+  });
+
   afterAll(async () => {
     await new Promise(resolve => eventServer.close(() => resolve(true)));
     await api.terminate();


### PR DESCRIPTION
## Description
Following endpoints are implemented: 
1. /v2/prices/namespaces/{tld}
2. /v2/prices/names/{name}

For details please refer to this [issue](https://github.com/blockstack/stacks-blockchain-api/issues/317)

## Type of Change
- [x] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
Test cases are added for the endpoints implemented.
To run the test cases `npm run test:bns`

## Checklist
- [x] Code is commented where needed
- [ ]  Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ]  Changelog is updated
- [x]  @zone117x for review
