### PR TITLE
feat: get names by address and historical zonefile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10259,12 +10259,12 @@
       "version": "file:client",
       "dev": true,
       "requires": {
-        "@blockstack/stacks-blockchain-api-types": "^0.5.3",
-        "@types/ws": "^7.2.6",
+        "@blockstack/stacks-blockchain-api-types": "^0.34.1",
+        "@types/ws": "^7.4.0",
         "cross-fetch": "^3.0.6",
         "eventemitter3": "^4.0.4",
         "jsonrpc-lite": "^2.2.0",
-        "ws": "^7.3.1"
+        "ws": "^7.4.0"
       },
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": {

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -27,6 +27,8 @@ import { createWsRpcRouter } from './routes/ws-rpc';
 import { createBurnchainRouter } from './routes/burnchain';
 import { createBNSNamespacesRouter } from './routes/bns/namespaces';
 import { createBNSPriceRouter } from './routes/bns/pricing';
+import { createBNSNamesRouter } from './routes/bns/names';
+import { createBNSAddressesRouter } from './routes/bns/addresses';
 
 export interface ApiServer {
   expressApp: ExpressWithAsync;
@@ -132,6 +134,8 @@ export async function startApiServer(
       const router = addAsync(express.Router());
       router.use(cors());
       router.use('/namespaces', createBNSNamespacesRouter(datastore));
+      router.use('/names', createBNSNamesRouter(datastore));
+      router.use('/addresses', createBNSAddressesRouter(datastore));
       return router;
     })()
   );

--- a/src/api/routes/bns/addresses.ts
+++ b/src/api/routes/bns/addresses.ts
@@ -1,0 +1,29 @@
+import * as express from 'express';
+import { RouterWithAsync, addAsync } from '@awaitjs/express';
+import { DataStore } from '../../../datastore/common';
+
+const SUPPORTED_BLOCKCHAINS = ['stacks'];
+
+export function createBNSAddressesRouter(db: DataStore): RouterWithAsync {
+  const router = addAsync(express.Router());
+
+  router.getAsync('/:blockchain/:address', async (req, res) => {
+    // Retrieves a list of names owned by the address provided.
+    const { blockchain, address } = req.params;
+    if (!SUPPORTED_BLOCKCHAINS.includes(blockchain)) {
+      res.status(404).json({ error: 'Unsupported blockchain' });
+      return;
+    }
+    const namesByAddress = await db.getNamesByAddressList({
+      blockchain: blockchain,
+      address: address,
+    });
+    if (namesByAddress.found) {
+      res.json({ names: namesByAddress.result });
+    } else {
+      res.json([]);
+    }
+  });
+
+  return router;
+}

--- a/src/api/routes/bns/names.ts
+++ b/src/api/routes/bns/names.ts
@@ -1,0 +1,43 @@
+import * as express from 'express';
+import { RouterWithAsync, addAsync } from '@awaitjs/express';
+import { DataStore } from '../../../datastore/common';
+
+export function createBNSNamesRouter(db: DataStore): RouterWithAsync {
+  const router = addAsync(express.Router());
+
+  router.getAsync('/:name/zonefile/:zoneFileHash', async (req, res) => {
+    // Fetches the historical zonefile specified by the username and zone hash.
+    const { name, zoneFileHash } = req.params;
+
+    const nameQuery = await db.getName({ name: name });
+    if (nameQuery.found) {
+      const zonefile = await db.getHistoricalZoneFile({ name: name, zoneFileHash: zoneFileHash });
+      if (zonefile.found) {
+        res.json(zonefile.result);
+      } else {
+        res.status(404).json({ error: 'No such zonefile' });
+      }
+    } else {
+      res.status(400).json({ error: 'Invalid name or subdomain' });
+    }
+  });
+
+  router.getAsync('/:name/zonefile', async (req, res) => {
+    // Fetch a user’s raw zone file. This only works for RFC-compliant zone files. This method returns an error for names that have non-standard zone files.
+    const { name } = req.params;
+
+    const nameQuery = await db.getName({ name: name });
+    if (nameQuery.found) {
+      const zonefile = await db.getLatestZoneFile({ name: name });
+      if (zonefile.found) {
+        res.json(zonefile.result);
+      } else {
+        res.status(404).json({ error: 'No zone file for name' });
+      }
+    } else {
+      res.status(400).json({ error: 'Invalid name or subdomain' });
+    }
+  });
+
+  return router;
+}

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -285,6 +285,9 @@ export interface DbStxBalance {
   burnchainUnlockHeight: number;
 }
 
+export interface DbBNSZoneFile {
+  zonefile: string;
+}
 export interface DbBNSNamespace {
   id?: number;
   namespace_id: string;
@@ -422,6 +425,16 @@ export interface DataStore extends DataStoreEventEmitter {
   }>;
 
   getNamespace(args: { namespace: string }): Promise<FoundOrNot<DbBNSNamespace>>;
+  getName(args: { name: string }): Promise<FoundOrNot<DbBNSName>>;
+  getHistoricalZoneFile(args: {
+    name: string;
+    zoneFileHash: string;
+  }): Promise<FoundOrNot<DbBNSZoneFile>>;
+  getLatestZoneFile(args: { name: string }): Promise<FoundOrNot<DbBNSZoneFile>>;
+  getNamesByAddressList(args: {
+    blockchain: string;
+    address: string;
+  }): Promise<FoundOrNot<string[]>>;
 }
 
 export function getAssetEventId(event_index: number, event_tx_id: string): string {

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -20,6 +20,7 @@ import {
   DbBurnchainReward,
   DbBNSName,
   DbBNSNamespace,
+  DbBNSZoneFile,
 } from './common';
 import { logger, FoundOrNot } from '../helpers';
 import { TransactionType } from '@blockstack/stacks-blockchain-api-types';
@@ -429,6 +430,28 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
   }
 
   getNamespace(args: { namespace: string }): Promise<FoundOrNot<DbBNSNamespace>> {
+    throw new Error('Method not implemented.');
+  }
+
+  getName(args: { name: string }): Promise<FoundOrNot<DbBNSName>> {
+    throw new Error('Method not implemented.');
+  }
+
+  getHistoricalZoneFile(args: {
+    name: string;
+    zoneFileHash: string;
+  }): Promise<FoundOrNot<DbBNSZoneFile>> {
+    throw new Error('Method not implemented.');
+  }
+
+  getLatestZoneFile(args: { name: string }): Promise<FoundOrNot<DbBNSZoneFile>> {
+    throw new Error('Method not implemented.');
+  }
+
+  getNamesByAddressList(args: {
+    blockchain: string;
+    address: string;
+  }): Promise<FoundOrNot<string[]>> {
     throw new Error('Method not implemented.');
   }
 }

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -2919,6 +2919,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     return { found: false } as const;
   }
 
+  //TODO: add where canonical = true
   async getLatestZoneFile(args: { name: string }): Promise<FoundOrNot<DbBNSZoneFile>> {
     const queryResult = await this.pool.query(
       `
@@ -2940,6 +2941,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     return { found: false } as const;
   }
 
+  //TODO: add WHERE latest = true AND canonical = true
   async getNamesByAddressList(args: {
     blockchain: string;
     address: string;

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -45,6 +45,7 @@ import {
   DbBurnchainReward,
   DbBNSName,
   DbBNSNamespace,
+  DbBNSZoneFile,
 } from './common';
 import { TransactionType } from '@blockstack/stacks-blockchain-api-types';
 import { getTxTypeId } from '../api/controllers/db-controller';
@@ -2871,6 +2872,91 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       return {
         found: true,
         result: queryResult.rows[0],
+      };
+    }
+    return { found: false } as const;
+  }
+
+  async getName(args: { name: string }) {
+    const queryResult = await this.pool.query(
+      `
+      SELECT *
+      FROM names
+      WHERE name = $1
+      `,
+      [args.name]
+    );
+    if (queryResult.rowCount > 0) {
+      return {
+        found: true,
+        result: queryResult.rows[0],
+      };
+    }
+    return { found: false } as const;
+  }
+
+  async getHistoricalZoneFile(args: {
+    name: string;
+    zoneFileHash: string;
+  }): Promise<FoundOrNot<DbBNSZoneFile>> {
+    const queryResult = await this.pool.query(
+      `
+      SELECT zonefile
+      FROM names
+      WHERE name = $1
+      AND
+      zonefile_hash = $2
+      `,
+      [args.name, args.zoneFileHash]
+    );
+
+    if (queryResult.rowCount > 0) {
+      return {
+        found: true,
+        result: queryResult.rows[0],
+      };
+    }
+    return { found: false } as const;
+  }
+
+  async getLatestZoneFile(args: { name: string }): Promise<FoundOrNot<DbBNSZoneFile>> {
+    const queryResult = await this.pool.query(
+      `
+      SELECT zonefile
+      FROM names
+      WHERE name = $1
+      AND
+      latest = $2
+      `,
+      [args.name, true]
+    );
+
+    if (queryResult.rowCount > 0) {
+      return {
+        found: true,
+        result: queryResult.rows[0],
+      };
+    }
+    return { found: false } as const;
+  }
+
+  async getNamesByAddressList(args: {
+    blockchain: string;
+    address: string;
+  }): Promise<FoundOrNot<string[]>> {
+    const queryResult = await this.pool.query(
+      `
+      SELECT name
+      FROM names
+      WHERE address = $1
+      `,
+      [args.address]
+    );
+
+    if (queryResult.rowCount > 0) {
+      return {
+        found: true,
+        result: queryResult.rows.map(r => r.name),
       };
     }
     return { found: false } as const;


### PR DESCRIPTION
## Description
Following endpoints are implemented:
1. /:name/zonefile/:zoneFileHash
2. /:name/zonefile
3. /:blockchain/:address

For details refer to [issue](https://github.com/blockstack/stacks-blockchain-api/issues/317)

## Type of Change
- [x] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Testing information
Test cases are added for the endpoints implemented.
To run the test cases `npm run test:bns`

## Checklist
- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] @zone117x for review
