### PR TITLE
fix: create mock tx from event for BTC tx's

### DIFF
--- a/src/event-stream/reader.ts
+++ b/src/event-stream/reader.ts
@@ -2,6 +2,7 @@ import {
   CoreNodeBlockMessage,
   CoreNodeMessageParsed,
   CoreNodeParsedTxMessage,
+  StxTransferEvent,
 } from './core-node-message';
 import {
   readTransaction,
@@ -9,6 +10,10 @@ import {
   RecipientPrincipalTypeId,
   Transaction,
   TransactionAuthTypeID,
+  SigHashMode,
+  TransactionPublicKeyEncoding,
+  TransactionAnchorMode,
+  TransactionPostConditionMode,
 } from '../p2p/tx';
 import { NotImplementedError } from '../errors';
 import { getEnumDescription, logger, logError } from '../helpers';
@@ -19,6 +24,9 @@ import {
   addressToString,
   AddressHashMode,
   BufferReader,
+  ChainID,
+  createSingleSigSpendingCondition,
+  createAddress,
 } from '@stacks/transactions';
 import { c32address } from 'c32check';
 
@@ -67,9 +75,53 @@ export function parseMessageTransactions(msg: CoreNodeBlockMessage): CoreNodeMes
     try {
       const txBuffer = Buffer.from(coreTx.raw_tx.substring(2), 'hex');
       const bufferReader = BufferReader.fromBuffer(txBuffer);
-      const rawTx = readTransaction(bufferReader);
-      const txSender = getTxSenderAddress(rawTx);
-      const sponsorAddress = getTxSponsorAddress(rawTx);
+      let txSender: string;
+      let sponsorAddress = undefined;
+      let rawTx: Transaction;
+      try {
+        rawTx = readTransaction(bufferReader);
+        txSender = getTxSenderAddress(rawTx);
+        sponsorAddress = getTxSponsorAddress(rawTx);
+      } catch (error) {
+        logError(
+          `BTC transaction found. Recreating from event. TX: ${JSON.stringify(coreTx)}: ${error}`,
+          error
+        );
+        const event = msg.events[i] as StxTransferEvent;
+        txSender = event.stx_transfer_event.sender;
+        const recipientAddress = createAddress(event.stx_transfer_event.recipient);
+        rawTx = {
+          version: TransactionVersion.Mainnet,
+          chainId: ChainID.Mainnet,
+          auth: {
+            typeId: TransactionAuthTypeID.Standard,
+            originCondition: {
+              hashMode: SigHashMode.P2PKH,
+              signer: Buffer.alloc(0),
+              nonce: BigInt(0),
+              feeRate: BigInt(0),
+              keyEncoding: TransactionPublicKeyEncoding.Compressed,
+              signature: Buffer.alloc(0),
+            },
+          },
+          anchorMode: TransactionAnchorMode.Any,
+          postConditionMode: TransactionPostConditionMode.Allow,
+          postConditions: [],
+          rawPostConditions: Buffer.from([TransactionPostConditionMode.Allow]),
+          payload: {
+            typeId: TransactionPayloadTypeID.TokenTransfer,
+            recipient: {
+              typeId: RecipientPrincipalTypeId.Address,
+              address: {
+                version: recipientAddress.version,
+                bytes: Buffer.from(recipientAddress.hash160, 'hex'),
+              },
+            },
+            amount: BigInt(event.stx_transfer_event.amount),
+            memo: Buffer.alloc(0),
+          },
+        };
+      }
       const parsedTx: CoreNodeParsedTxMessage = {
         core_tx: coreTx,
         raw_tx: txBuffer,
@@ -124,7 +176,7 @@ export function parseMessageTransactions(msg: CoreNodeBlockMessage): CoreNodeMes
         }
       }
     } catch (error) {
-      logError(`error parsing message transaction ${coreTx}: ${error}`, error);
+      logError(`error parsing message transaction ${JSON.stringify(coreTx)}: ${error}`, error);
       throw error;
     }
   }

--- a/src/p2p/tx.ts
+++ b/src/p2p/tx.ts
@@ -14,7 +14,7 @@ export const MICROBLOCK_HEADER_SIZE =
   // 65-byte signature
   65;
 
-enum SigHashMode {
+export enum SigHashMode {
   /** SingleSigHashMode */
   P2PKH = 0x00,
   /** SingleSigHashMode */
@@ -25,7 +25,7 @@ enum SigHashMode {
   P2WSH = 0x03,
 }
 
-enum TransactionPublicKeyEncoding {
+export enum TransactionPublicKeyEncoding {
   Compressed = 0x00,
   Uncompressed = 0x01,
 }
@@ -92,7 +92,7 @@ interface TransactionAuthSponsored {
   sponsorCondition: TransactionSpendingCondition;
 }
 
-enum TransactionAnchorMode {
+export enum TransactionAnchorMode {
   /** must be included in a StacksBlock */
   OnChainOnly = 1,
   /** must be included in a StacksMicroBlock */
@@ -101,12 +101,12 @@ enum TransactionAnchorMode {
   Any = 3,
 }
 
-enum TransactionPostConditionMode {
+export enum TransactionPostConditionMode {
   Allow = 0x01,
   Deny = 0x02,
 }
 
-enum TransactionVersion {
+export enum TransactionVersion {
   Mainnet = 0x00,
   Testnet = 0x80,
 }


### PR DESCRIPTION
Just the first commit from #398, which is the only one tested

Fixes #396 , which was halting progress on the api at block 119