### PR TITLE
fix: #402 tx events not showing due to pagination issue

### DIFF
--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -294,10 +294,18 @@ async function handleClientMessage(msg: CoreNodeBlockMessage, db: DataStore): Pr
 
   // Normalize event indexes from per-block to per-transaction contiguous series.
   for (const tx of dbData.txs) {
-    [tx.contractLogEvents, tx.ftEvents, tx.nftEvents, tx.stxEvents, tx.stxLockEvents]
+    const sortedEvents = [
+      tx.contractLogEvents,
+      tx.ftEvents,
+      tx.nftEvents,
+      tx.stxEvents,
+      tx.stxLockEvents,
+    ]
       .flat()
-      .sort((a, b) => a.event_index - b.event_index)
-      .map((event, index) => (event.event_index = index));
+      .sort((a, b) => a.event_index - b.event_index);
+    for (let i = 0; i < sortedEvents.length; i++) {
+      sortedEvents[i].event_index = i;
+    }
   }
 
   await db.update(dbData);

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -292,6 +292,14 @@ async function handleClientMessage(msg: CoreNodeBlockMessage, db: DataStore): Pr
     }
   }
 
+  // Normalize event indexes from per-block to per-transaction contiguous series.
+  for (const tx of dbData.txs) {
+    [tx.contractLogEvents, tx.ftEvents, tx.nftEvents, tx.stxEvents, tx.stxLockEvents]
+      .flat()
+      .sort((a, b) => a.event_index - b.event_index)
+      .map((event, index) => (event.event_index = index));
+  }
+
   await db.update(dbData);
 }
 


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/402

Transaction event indexes are received scoped to block level rather than a transaction. E.g. if a block has 100 transactions, with one or more events per transaction, then transactions N+1 will have event indexes started _after_ 0. 

This resulted in some STX transfer transactions, which should only have 1 event, not showing the event because it was pushed 1 or more pages down when queried. 

This PR modifies the event server to re-calculate event indexes on a per-transaction level. 