### PR TITLE
Tx mempool address filters

### DIFF
--- a/client/src/generated/apis/TransactionsApi.ts
+++ b/client/src/generated/apis/TransactionsApi.ts
@@ -27,6 +27,9 @@ import {
 } from '../models';
 
 export interface GetMempoolTransactionListRequest {
+    senderAddress?: string;
+    recipientAddress?: string;
+    address?: string;
     limit?: number;
     offset?: number;
 }
@@ -57,6 +60,9 @@ export interface TransactionsApiInterface {
     /**
      * Get all recently-broadcast mempool transactions
      * @summary Get mempool transactions
+     * @param {string} [senderAddress] Filter to only STX transfer transactions with this sender address.
+     * @param {string} [recipientAddress] Filter to only STX transfer transactions with this recipient address.
+     * @param {string} [address] Filter to only show STX transfer transactions with this address as the recipient or sender.
      * @param {number} [limit] max number of mempool transactions to fetch
      * @param {number} [offset] index of first mempool transaction to fetch
      * @param {*} [options] Override http request option.
@@ -136,6 +142,18 @@ export class TransactionsApi extends runtime.BaseAPI implements TransactionsApiI
      */
     async getMempoolTransactionListRaw(requestParameters: GetMempoolTransactionListRequest): Promise<runtime.ApiResponse<MempoolTransactionListResponse>> {
         const queryParameters: runtime.HTTPQuery = {};
+
+        if (requestParameters.senderAddress !== undefined) {
+            queryParameters['sender_address'] = requestParameters.senderAddress;
+        }
+
+        if (requestParameters.recipientAddress !== undefined) {
+            queryParameters['recipient_address'] = requestParameters.recipientAddress;
+        }
+
+        if (requestParameters.address !== undefined) {
+            queryParameters['address'] = requestParameters.address;
+        }
 
         if (requestParameters.limit !== undefined) {
             queryParameters['limit'] = requestParameters.limit;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -127,6 +127,24 @@ paths:
       operationId: get_mempool_transaction_list
       description: Get all recently-broadcast mempool transactions
       parameters:
+        - name: sender_address
+          in: query
+          description: Filter to only STX transfer transactions with this sender address.
+          required: false
+          schema:
+            type: string
+        - name: recipient_address
+          in: query
+          description: Filter to only STX transfer transactions with this recipient address.
+          required: false
+          schema:
+            type: string
+        - name: address
+          in: query
+          description: Filter to only show STX transfer transactions with this address as the recipient or sender.
+          required: false
+          schema:
+            type: string
         - name: limit
           in: query
           description: max number of mempool transactions to fetch

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -299,6 +299,9 @@ export interface DataStore extends DataStoreEventEmitter {
   getMempoolTxList(args: {
     limit: number;
     offset: number;
+    senderAddress?: string;
+    recipientAddress?: string;
+    address?: string;
   }): Promise<{ results: DbMempoolTx[]; total: number }>;
   getMempoolTxIdList(): Promise<{ results: DbMempoolTxId[] }>;
   getTx(txId: string): Promise<FoundOrNot<DbTx>>;


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/380

```yaml

  /extended/v1/tx/mempool:
    get:
      summary: Get mempool transactions
      tags:
        - Transactions
      operationId: get_mempool_transaction_list
      description: Get all recently-broadcast mempool transactions
      parameters:
        - name: sender_address
          in: query
          description: Filter to only STX transfer transactions with this sender address.
          required: false
          schema:
            type: string
        - name: recipient_address
          in: query
          description: Filter to only STX transfer transactions with this recipient address.
          required: false
          schema:
            type: string
        - name: address
          in: query
          description: Filter to only show STX transfer transactions with this address as the recipient or sender.
          required: false
          schema:
            type: string
        - name: limit
          in: query
          description: max number of mempool transactions to fetch
          required: false
          schema:
            type: integer
        - name: offset
          in: query
          description: index of first mempool transaction to fetch
          required: false
          schema:
            type: integer
```