### PR TITLE
feat: normalize express prometheus metrics with route parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19642,6 +19642,11 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+        },
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -25713,9 +25718,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+      "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
     },
     "path-type": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "node-fetch": "^2.6.0",
     "node-pg-migrate": "^4.2.3",
     "p-queue": "^6.3.0",
+    "path-to-regexp": "^6.2.0",
     "pg": "^8.2.1",
     "prom-client": "^12.0.0",
     "rpc-bitcoin": "^2.0.0",

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -76,8 +76,7 @@ export async function startApiServer(datastore: DataStore, chainId: ChainID): Pr
           // `/extended/v1/address/ST26DR4VGV507V1RZ1JNM7NN4K3DTGX810S62SBBR/stx` to
           // `/extended/v1/address/:stx_address/stx`
           for (const pathRegex of routes) {
-            const match = pathRegex.regexp.test(pathTemplate);
-            if (match) {
+            if (pathRegex.regexp.test(pathTemplate)) {
               pathTemplate = pathRegex.path;
               break;
             }

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -70,7 +70,8 @@ export async function startApiServer(datastore: DataStore, chainId: ChainID): Pr
       options: {
         normalizePath: path => {
           // Get the url pathname without a query string or fragment
-          let pathTemplate = new URL(path, 'http://localhost').pathname;
+          // (note base url doesn't matter, but required by URL constructor)
+          let pathTemplate = new URL(path, 'http://x').pathname;
           // Match request url to the Express route, e.g.:
           // `/extended/v1/address/ST26DR4VGV507V1RZ1JNM7NN4K3DTGX810S62SBBR/stx` to
           // `/extended/v1/address/:stx_address/stx`

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -60,9 +60,9 @@ export async function startApiServer(datastore: DataStore, chainId: ChainID): Pr
   // app.use(compression());
   // app.disable('x-powered-by');
 
-  let pathRegexes: {
+  let routes: {
     path: string;
-    match: pathToRegex.MatchFunction<object>;
+    regexp: RegExp;
   }[] = [];
 
   if (isProdEnv) {
@@ -75,8 +75,8 @@ export async function startApiServer(datastore: DataStore, chainId: ChainID): Pr
           // Match request url to the Express route, e.g.:
           // `/extended/v1/address/ST26DR4VGV507V1RZ1JNM7NN4K3DTGX810S62SBBR/stx` to
           // `/extended/v1/address/:stx_address/stx`
-          for (const pathRegex of pathRegexes) {
-            const match = pathRegex.match(pathTemplate);
+          for (const pathRegex of routes) {
+            const match = pathRegex.regexp.test(pathTemplate);
             if (match) {
               pathTemplate = pathRegex.path;
               break;
@@ -161,9 +161,9 @@ export async function startApiServer(datastore: DataStore, chainId: ChainID): Pr
   );
 
   // Store all the registered express routes for usage with metrics reporting
-  pathRegexes = expressListEndpoints(app).map(endpoint => ({
+  routes = expressListEndpoints(app).map(endpoint => ({
     path: endpoint.path,
-    match: pathToRegex.match(endpoint.path),
+    regexp: pathToRegex.pathToRegexp(endpoint.path),
   }));
 
   const server = createServer(app);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import { startApiServer } from './api/init';
 import { startEventServer } from './event-stream/event-server';
 import { StacksCoreRpcClient } from './core-rpc/client';
 import * as WebSocket from 'ws';
-import { createMiddleware as createPrometheusMiddleware } from '@promster/express';
 import { createServer as createPrometheusServer } from '@promster/server';
 import { ChainID } from '@stacks/transactions';
 
@@ -64,13 +63,12 @@ async function init(): Promise<void> {
     }
   }
 
-  const promMiddleware = isProdEnv ? createPrometheusMiddleware() : undefined;
-  await startEventServer({ db, promMiddleware });
+  await startEventServer({ db });
   monitorCoreRpcConnection().catch(error => {
     logger.error(`Error monitoring RPC connection: ${error}`, error);
   });
   const networkChainId = await getCoreChainID();
-  const apiServer = await startApiServer(db, networkChainId, promMiddleware);
+  const apiServer = await startApiServer(db, networkChainId);
   logger.info(`API server listening on: http://${apiServer.address}`);
 
   if (isProdEnv) {


### PR DESCRIPTION
Fixes https://github.com/blockstack/stacks-blockchain-api/issues/403

This converts the raw paths received by the `@promster/express` middleware into Express path template strings.

1. First, [`express-list-endpoints`](https://www.npmjs.com/package/express-list-endpoints) is used to enumerate all the application defined API route templates.
2. Then [`path-to-regexp`](https://www.npmjs.com/package/path-to-regexp) is used to map the Express route strings into a set of regexps.
3. The promster middleware runs the raw request URL paths through this set of regexes to determine the route template.

The resulting raw paths, e.g.
`/extended/v1/address/ST26DR4VGV507V1RZ1JNM7NN4K3DTGX810S62SBBR/stx?asdf=1234`
are now reported by their path template, .e.g.
`/extended/v1/address/:stx_address/stx `