### PR TITLE
feat: handling for on-btc-chain stx-stacks operations

### DIFF
--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -103,6 +103,15 @@ async function handleClientMessage(
 ): Promise<void> {
   const parsedMsg = parseMessageTransactions(chainId, msg);
 
+  // Delete on-btc-chain transactions that failed, there is no useful data in them,
+  // and the db and API schemas can't currently fit these types of transactions.
+  for (let i = parsedMsg.transactions.length - 1; i >= 0; i--) {
+    if (!parsedMsg.parsed_transactions[i]) {
+      parsedMsg.parsed_transactions.splice(i, 1);
+      parsedMsg.transactions.splice(i, 1);
+    }
+  }
+
   const dbBlock: DbBlock = {
     canonical: true,
     block_hash: parsedMsg.block_hash,

--- a/src/event-stream/reader.ts
+++ b/src/event-stream/reader.ts
@@ -200,7 +200,8 @@ export function parseMessageTransactions(
       if (coreTx.raw_tx === '0x00') {
         const event = msg.events.find(event => event.txid === coreTx.txid);
         if (!event) {
-          throw new Error(`Could not find txid for process BTC tx: ${JSON.stringify(msg)}`);
+          logger.warn(`Could not find txid for process BTC tx: ${JSON.stringify(msg)}`);
+          continue;
         }
         if (event.type === CoreNodeEventType.StxTransferEvent) {
           rawTx = createTransactionFromCoreBtcTxEvent(chainId, event);

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,12 +62,11 @@ async function init(): Promise<void> {
       );
     }
   }
-
-  await startEventServer({ db });
+  const networkChainId = await getCoreChainID();
+  await startEventServer({ db, chainId: networkChainId });
   monitorCoreRpcConnection().catch(error => {
     logger.error(`Error monitoring RPC connection: ${error}`, error);
   });
-  const networkChainId = await getCoreChainID();
   const apiServer = await startApiServer(db, networkChainId);
   logger.info(`API server listening on: http://${apiServer.address}`);
 

--- a/src/tests-rosetta-cli/validate-rosetta-construction.ts
+++ b/src/tests-rosetta-cli/validate-rosetta-construction.ts
@@ -125,7 +125,7 @@ describe('Rosetta API', () => {
     await cycleMigrations();
     db = await PgDataStore.connect();
     client = await db.pool.connect();
-    eventServer = await startEventServer({ db });
+    eventServer = await startEventServer({ db, chainId: ChainID.Testnet });
     api = await startApiServer(db, ChainID.Testnet);
 
     // build rosetta-cli container

--- a/src/tests-rosetta-cli/validate-rosetta.ts
+++ b/src/tests-rosetta-cli/validate-rosetta.ts
@@ -125,7 +125,7 @@ describe('Rosetta API', () => {
     await cycleMigrations();
     db = await PgDataStore.connect();
     client = await db.pool.connect();
-    eventServer = await startEventServer({ db });
+    eventServer = await startEventServer({ db, chainId: ChainID.Testnet });
     api = await startApiServer(db, ChainID.Testnet);
 
     // remove previous outputs if any

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -66,7 +66,7 @@ describe('Rosetta API', () => {
     await cycleMigrations();
     db = await PgDataStore.connect();
     client = await db.pool.connect();
-    eventServer = await startEventServer({ db });
+    eventServer = await startEventServer({ db, chainId: ChainID.Testnet });
     api = await startApiServer(db, ChainID.Testnet);
   });
 

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -3,6 +3,7 @@ import { loadDotEnv } from '../helpers';
 import { MemoryDataStore } from '../datastore/memory-store';
 import { startEventServer } from '../event-stream/event-server';
 import { StacksCoreRpcClient } from '../core-rpc/client';
+import { ChainID } from '@stacks/transactions';
 
 export default async (): Promise<void> => {
   console.log('Jest - setup..');
@@ -11,6 +12,7 @@ export default async (): Promise<void> => {
   }
   loadDotEnv();
   const server = await startEventServer({
+    chainId: ChainID.Testnet,
     db: new MemoryDataStore(),
     messageHandler: {
       handleBlockMessage: () => {},


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/411

PR adds support for the on-btc-chain `stx-stacks` operation. A synthetic pox contract call tx is generated for the operation event, similar to the previous on-btc-chain stx-transfer operation.

This was tested by grabbing event data generated by this stacks-node integration test: https://github.com/blockstack/stacks-blockchain/commit/d163d5cf2c817d83d7d120f8f988d9abf0a684be and injecting it into the API while running in mocknet mode.