### PR TITLE
fix: add `?tip` query param to RPC methods

### DIFF
--- a/client/src/generated/apis/AccountsApi.ts
+++ b/client/src/generated/apis/AccountsApi.ts
@@ -45,6 +45,7 @@ export interface GetAccountBalanceRequest {
 export interface GetAccountInfoRequest {
     principal: string;
     proof?: number;
+    tip?: string;
 }
 
 export interface GetAccountStxBalanceRequest {
@@ -101,6 +102,7 @@ export interface AccountsApiInterface {
      * @summary Get account info
      * @param {string} principal Stacks address or a Contract identifier (e.g. &#x60;SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0.get-info&#x60;)
      * @param {number} [proof] Returns object without the proof field if set to 0
+     * @param {string} [tip] The Stacks chain tip to query from
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AccountsApiInterface
@@ -233,6 +235,10 @@ export class AccountsApi extends runtime.BaseAPI implements AccountsApiInterface
 
         if (requestParameters.proof !== undefined) {
             queryParameters['proof'] = requestParameters.proof;
+        }
+
+        if (requestParameters.tip !== undefined) {
+            queryParameters['tip'] = requestParameters.tip;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/client/src/generated/apis/SmartContractsApi.ts
+++ b/client/src/generated/apis/SmartContractsApi.ts
@@ -37,6 +37,7 @@ export interface CallReadOnlyFunctionRequest {
     contractName: string;
     functionName: string;
     readOnlyFunctionArgs: ReadOnlyFunctionArgs;
+    tip?: string;
 }
 
 export interface GetContractByIdRequest {
@@ -49,6 +50,7 @@ export interface GetContractDataMapEntryRequest {
     mapName: string;
     key: string;
     proof?: number;
+    tip?: string;
 }
 
 export interface GetContractEventsByIdRequest {
@@ -60,12 +62,14 @@ export interface GetContractEventsByIdRequest {
 export interface GetContractInterfaceRequest {
     contractAddress: string;
     contractName: string;
+    tip?: string;
 }
 
 export interface GetContractSourceRequest {
     contractAddress: string;
     contractName: string;
     proof?: number;
+    tip?: string;
 }
 
 /**
@@ -82,6 +86,7 @@ export interface SmartContractsApiInterface {
      * @param {string} contractName Contract name
      * @param {string} functionName Function name
      * @param {ReadOnlyFunctionArgs} readOnlyFunctionArgs 
+     * @param {string} [tip] The Stacks chain tip to query from
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof SmartContractsApiInterface
@@ -118,6 +123,7 @@ export interface SmartContractsApiInterface {
      * @param {string} mapName Map name
      * @param {string} key Hex string serialization of the lookup key (which should be a Clarity value)
      * @param {number} [proof] Returns object without the proof field when set to 0
+     * @param {string} [tip] The Stacks chain tip to query from
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof SmartContractsApiInterface
@@ -153,6 +159,7 @@ export interface SmartContractsApiInterface {
      * @summary Get contract interface
      * @param {string} contractAddress Stacks address
      * @param {string} contractName Contract name
+     * @param {string} [tip] The Stacks chain tip to query from
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof SmartContractsApiInterface
@@ -171,6 +178,7 @@ export interface SmartContractsApiInterface {
      * @param {string} contractAddress Stacks address
      * @param {string} contractName Contract name
      * @param {number} [proof] Returns object without the proof field if set to 0
+     * @param {string} [tip] The Stacks chain tip to query from
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof SmartContractsApiInterface
@@ -212,6 +220,10 @@ export class SmartContractsApi extends runtime.BaseAPI implements SmartContracts
         }
 
         const queryParameters: runtime.HTTPQuery = {};
+
+        if (requestParameters.tip !== undefined) {
+            queryParameters['tip'] = requestParameters.tip;
+        }
 
         const headerParameters: runtime.HTTPHeaders = {};
 
@@ -296,6 +308,10 @@ export class SmartContractsApi extends runtime.BaseAPI implements SmartContracts
             queryParameters['proof'] = requestParameters.proof;
         }
 
+        if (requestParameters.tip !== undefined) {
+            queryParameters['tip'] = requestParameters.tip;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         headerParameters['Content-Type'] = 'application/json';
@@ -375,6 +391,10 @@ export class SmartContractsApi extends runtime.BaseAPI implements SmartContracts
 
         const queryParameters: runtime.HTTPQuery = {};
 
+        if (requestParameters.tip !== undefined) {
+            queryParameters['tip'] = requestParameters.tip;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         const response = await this.request({
@@ -413,6 +433,10 @@ export class SmartContractsApi extends runtime.BaseAPI implements SmartContracts
 
         if (requestParameters.proof !== undefined) {
             queryParameters['proof'] = requestParameters.proof;
+        }
+
+        if (requestParameters.tip !== undefined) {
+            queryParameters['tip'] = requestParameters.tip;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -477,6 +477,11 @@ paths:
         description: Contract name
         schema:
           type: string
+      - name: tip
+        in: query
+        schema:
+          type: string
+        description: The Stacks chain tip to query from
 
   /v2/map_entry/{contract_address}/{contract_name}/{map_name}:
     post:
@@ -525,6 +530,11 @@ paths:
           description: Returns object without the proof field when set to 0
           schema:
             type: integer
+        - name: tip
+          in: query
+          schema:
+            type: string
+          description: The Stacks chain tip to query from
       x-codegen-request-body-name: key
       requestBody:
         description: Hex string serialization of the lookup key (which should be a Clarity value)
@@ -568,6 +578,12 @@ paths:
         description: Returns object without the proof field if set to 0
         schema:
           type: integer
+      - name: tip
+        in: query
+        schema:
+          type: string
+        description: The Stacks chain tip to query from
+        required: false
 
   /v2/contracts/call-read/{contract_address}/{contract_name}/{function_name}:
     post:
@@ -610,6 +626,12 @@ paths:
           description: Function name
           schema:
             type: string
+        - name: tip
+          in: query
+          schema:
+            type: string
+          description: The Stacks chain tip to query from
+          required: false
       requestBody:
         description: map of arguments and the simulated tx-sender where sender is either a Contract identifier or a normal Stacks address, and arguments is an array of hex serialized Clarity values.
         required: true
@@ -763,6 +785,11 @@ paths:
           description: Returns object without the proof field if set to 0
           schema:
             type: integer
+        - name: tip
+          in: query
+          schema:
+            type: string
+          description: The Stacks chain tip to query from
       responses:
         200:
           description: Success


### PR DESCRIPTION
A few of the RPC methods accept a `tip` query parameter. This can be used to query at a chain tip. Importantly, this lets you query data at an `unanchored_chain_tip`, AKA microblock.