### PR TITLE
Correct re-org handling for miner rewards

### DIFF
--- a/follower.Dockerfile
+++ b/follower.Dockerfile
@@ -7,7 +7,7 @@ RUN echo "GIT_TAG=$(git tag --points-at HEAD)" >> .env
 RUN npm config set unsafe-perm true && npm install && npm run build && npm prune --production
 
 ### Fetch stacks-node binary
-FROM blockstack/stacks-blockchain:2.0.1-stretch as stacks-node-build
+FROM blockstack/stacks-blockchain:2.0.2-stretch as stacks-node-build
 
 ### Begin building base image
 FROM ubuntu:focal

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -50,6 +50,7 @@ export interface DbMinerReward {
   coinbase_amount: bigint;
   tx_fees_anchored: bigint;
   tx_fees_streamed_confirmed: bigint;
+  tx_fees_streamed_produced: bigint;
 }
 
 export enum DbTxTypeId {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -41,6 +41,7 @@ export interface DbBurnchainReward {
 export interface DbMinerReward {
   block_hash: string;
   index_block_hash: string;
+  from_index_block_hash: string;
   mature_block_height: number;
   /** Set to `true` if entry corresponds to the canonical chain tip */
   canonical: boolean;

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -948,8 +948,8 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     const result = await client.query(
       `
       INSERT INTO miner_rewards(
-        block_hash, index_block_hash, from_index_block_hash, mature_block_height, canonical, recipient, coinbase_amount, tx_fees_anchored, tx_fees_streamed_confirmed
-      ) values($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        block_hash, index_block_hash, from_index_block_hash, mature_block_height, canonical, recipient, coinbase_amount, tx_fees_anchored, tx_fees_streamed_confirmed, tx_fees_streamed_produced
+      ) values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
       `,
       [
         hexToBuffer(minerReward.block_hash),
@@ -961,6 +961,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         minerReward.coinbase_amount,
         minerReward.tx_fees_anchored,
         minerReward.tx_fees_streamed_confirmed,
+        minerReward.tx_fees_streamed_produced,
       ]
     );
     return result.rowCount;
@@ -2231,7 +2232,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     const minerRewardQuery = await client.query<{ amount: string }>(
       `
       SELECT sum(
-        coinbase_amount + tx_fees_anchored + tx_fees_streamed_confirmed
+        coinbase_amount + tx_fees_anchored + tx_fees_streamed_confirmed + tx_fees_streamed_produced
       ) amount
       FROM miner_rewards
       WHERE canonical = true AND recipient = $1 AND mature_block_height <= $2

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -947,12 +947,13 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     const result = await client.query(
       `
       INSERT INTO miner_rewards(
-        block_hash, index_block_hash, mature_block_height, canonical, recipient, coinbase_amount, tx_fees_anchored, tx_fees_streamed_confirmed
-      ) values($1, $2, $3, $4, $5, $6, $7, $8)
+        block_hash, index_block_hash, from_index_block_hash, mature_block_height, canonical, recipient, coinbase_amount, tx_fees_anchored, tx_fees_streamed_confirmed
+      ) values($1, $2, $3, $4, $5, $6, $7, $8, $9)
       `,
       [
         hexToBuffer(minerReward.block_hash),
         hexToBuffer(minerReward.index_block_hash),
+        hexToBuffer(minerReward.from_index_block_hash),
         minerReward.mature_block_height,
         minerReward.canonical,
         minerReward.recipient,

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -411,6 +411,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
           contractLogEvents: tx.contractLogEvents.map(e => ({ ...e, canonical: false })),
           smartContracts: tx.smartContracts.map(e => ({ ...e, canonical: false })),
         }));
+        data.minerRewards = data.minerRewards.map(mr => ({ ...mr, canonical: false }));
       } else {
         // When storing newly mined canonical txs, remove them from the mempool table.
         // Note: coinbase tx types will never be in the mempool, filter them early.

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -166,6 +166,8 @@ export interface CoreNodeBlockMessage {
     tx_fees_anchored: string;
     /** String quoted micro-STX amount. */
     tx_fees_streamed_confirmed: string;
+    /** String quoted micro-STX amount. */
+    tx_fees_streamed_produced: string;
   }[];
 }
 

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -196,7 +196,7 @@ export interface CoreNodeBurnBlockMessage {
       /** Bitcoin address (b58 encoded). */
       recipient: string;
       /** Amount in BTC satoshis. */
-      amount: number;
+      amt: number;
     }
   ];
 }

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -50,7 +50,7 @@ async function handleBurnBlockMessage(
       burn_block_height: burnBlockMsg.burn_block_height,
       burn_amount: BigInt(burnBlockMsg.burn_amount),
       reward_recipient: r.recipient,
-      reward_amount: BigInt(r.amount),
+      reward_amount: BigInt(r.amt),
       reward_index: index,
     };
     return dbReward;
@@ -136,7 +136,8 @@ async function handleClientMessage(
     const dbMinerReward: DbMinerReward = {
       canonical: true,
       block_hash: minerReward.from_stacks_block_hash,
-      index_block_hash: minerReward.from_index_consensus_hash,
+      index_block_hash: msg.index_block_hash,
+      from_index_block_hash: minerReward.from_index_consensus_hash,
       mature_block_height: parsedMsg.block_height,
       recipient: minerReward.recipient,
       coinbase_amount: BigInt(minerReward.coinbase_amount),

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -143,6 +143,7 @@ async function handleClientMessage(
       coinbase_amount: BigInt(minerReward.coinbase_amount),
       tx_fees_anchored: BigInt(minerReward.tx_fees_anchored),
       tx_fees_streamed_confirmed: BigInt(minerReward.tx_fees_streamed_confirmed),
+      tx_fees_streamed_produced: BigInt(minerReward.tx_fees_streamed_produced),
     };
     dbMinerRewards.push(dbMinerReward);
   }

--- a/src/migrations/1605184662317_miner_rewards.ts
+++ b/src/migrations/1605184662317_miner_rewards.ts
@@ -42,6 +42,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       type: 'numeric',
       notNull: true,
     },
+    tx_fees_streamed_produced: {
+      type: 'numeric',
+      notNull: true,
+    }
   });
 
   pgm.createIndex('miner_rewards', 'block_hash');

--- a/src/migrations/1605184662317_miner_rewards.ts
+++ b/src/migrations/1605184662317_miner_rewards.ts
@@ -14,6 +14,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       type: 'bytea',
       notNull: true,
     },
+    from_index_block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
     mature_block_height: {
       type: 'integer',
       notNull: true,
@@ -42,6 +46,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 
   pgm.createIndex('miner_rewards', 'block_hash');
   pgm.createIndex('miner_rewards', 'index_block_hash');
+  pgm.createIndex('miner_rewards', 'from_index_block_hash');
   pgm.createIndex('miner_rewards', 'mature_block_height');
   pgm.createIndex('miner_rewards', 'canonical');
   pgm.createIndex('miner_rewards', 'recipient');

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -86,6 +86,7 @@ describe('postgres datastore', () => {
       const minerReward: DbMinerReward = {
         block_hash: '0x9876',
         index_block_hash: '0x5432',
+        from_index_block_hash: '0x6789',
         mature_block_height: 68456,
         canonical: canonical,
         recipient: recipient,
@@ -2249,6 +2250,7 @@ describe('postgres datastore', () => {
 
     const minerReward1: DbMinerReward = {
       ...block1,
+      from_index_block_hash: '0x33',
       mature_block_height: 3,
       recipient: 'miner-addr1',
       coinbase_amount: 1000n,
@@ -2421,6 +2423,7 @@ describe('postgres datastore', () => {
     const minerReward1: DbMinerReward = {
       ...block1,
       mature_block_height: 3,
+      from_index_block_hash: '0x11',
       recipient: 'miner-addr1',
       coinbase_amount: 1000n,
       tx_fees_anchored: 2n,
@@ -2430,6 +2433,7 @@ describe('postgres datastore', () => {
     const minerReward2: DbMinerReward = {
       ...block2,
       mature_block_height: 4,
+      from_index_block_hash: '0x22',
       recipient: 'miner-addr2',
       coinbase_amount: 1000n,
       tx_fees_anchored: 2n,

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -81,6 +81,7 @@ describe('postgres datastore', () => {
       amount: bigint,
       txFeeAnchored: bigint,
       txFeeConfirmed: bigint,
+      txFeeProduced: bigint,
       canonical: boolean = true
     ): DbMinerReward => {
       const minerReward: DbMinerReward = {
@@ -93,15 +94,16 @@ describe('postgres datastore', () => {
         coinbase_amount: amount,
         tx_fees_anchored: txFeeAnchored,
         tx_fees_streamed_confirmed: txFeeConfirmed,
+        tx_fees_streamed_produced: txFeeProduced,
       };
       return minerReward;
     };
 
     const minerRewards = [
-      createMinerReward('addrA', 100_000n, 2n, 3n),
-      createMinerReward('addrB', 100n, 40n, 0n),
-      createMinerReward('addrB', 0n, 30n, 40n),
-      createMinerReward('addrB', 99999n, 92n, 93n, false),
+      createMinerReward('addrA', 100_000n, 2n, 3n, 5n),
+      createMinerReward('addrB', 100n, 40n, 0n, 0n),
+      createMinerReward('addrB', 0n, 30n, 40n, 7n),
+      createMinerReward('addrB', 99999n, 92n, 93n, 0n, false),
     ];
     for (const reward of minerRewards) {
       await db.updateMinerReward(client, reward);
@@ -200,11 +202,11 @@ describe('postgres datastore', () => {
     const addrDResult = await db.getStxBalance('addrD');
 
     expect(addrAResult).toEqual({
-      balance: 198286n,
+      balance: 198291n,
       totalReceived: 100000n,
       totalSent: 385n,
       totalFeesSent: 1334n,
-      totalMinerRewardsReceived: 100005n,
+      totalMinerRewardsReceived: 100010n,
       burnchainLockHeight: 123,
       burnchainUnlockHeight: 68656,
       lockHeight: 68456,
@@ -212,11 +214,11 @@ describe('postgres datastore', () => {
       locked: 400n,
     });
     expect(addrBResult).toEqual({
-      balance: 545n,
+      balance: 552n,
       totalReceived: 350n,
       totalSent: 15n,
       totalFeesSent: 0n,
-      totalMinerRewardsReceived: 210n,
+      totalMinerRewardsReceived: 217n,
       burnchainLockHeight: 0,
       burnchainUnlockHeight: 0,
       lockHeight: 0,
@@ -2256,6 +2258,7 @@ describe('postgres datastore', () => {
       coinbase_amount: 1000n,
       tx_fees_anchored: 2n,
       tx_fees_streamed_confirmed: 3n,
+      tx_fees_streamed_produced: 5n,
     };
 
     const tx1: DbTx = {
@@ -2428,6 +2431,7 @@ describe('postgres datastore', () => {
       coinbase_amount: 1000n,
       tx_fees_anchored: 2n,
       tx_fees_streamed_confirmed: 3n,
+      tx_fees_streamed_produced: 9n,
     };
 
     const minerReward2: DbMinerReward = {
@@ -2438,6 +2442,7 @@ describe('postgres datastore', () => {
       coinbase_amount: 1000n,
       tx_fees_anchored: 2n,
       tx_fees_streamed_confirmed: 3n,
+      tx_fees_streamed_produced: 0n,
     };
 
     const tx1: DbTx = {
@@ -2646,7 +2651,7 @@ describe('postgres datastore', () => {
 
     const r1 = await db.getStxBalance(minerReward1.recipient);
     const r2 = await db.getStxBalance(minerReward2.recipient);
-    expect(r1.totalMinerRewardsReceived).toBe(1005n);
+    expect(r1.totalMinerRewardsReceived).toBe(1014n);
     expect(r2.totalMinerRewardsReceived).toBe(0n);
 
     const lock1 = await db.getStxBalance(stxLockEvent1.locked_address);

--- a/stx-rosetta.Dockerfile
+++ b/stx-rosetta.Dockerfile
@@ -15,7 +15,7 @@ RUN npm install && npm run build && npm prune --production
 
 FROM rust:stretch as stacks-node-build
 
-ARG STACKS_TAG=2.0.1
+ARG STACKS_TAG=2.0.2
 
 RUN mkdir -p /src /stacks
 WORKDIR /src


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/376

This fixes miner rewards being higher than what the stacks-node reports for account balance.

There were a few issues:
1. Re-orgs for miner rewards were using the block index hash for the reward origin block, rather than the reward maturation block.
2. Miner rewards received by immediately non-canonical blocks were not being immediately set as non-canonical.
3. `tx_fees_streamed_produced`, one of the three values that make up the tx fee reward amount, was missing entirely from the event stream. This required a fix in the core node.

This PR is blocked on https://github.com/blockstack/stacks-blockchain/pull/2418