### PR TITLE
fix: custom nonce added in /payloads and /balance

### DIFF
--- a/docs/api/rosetta/rosetta-construction-payloads-request.schema.json
+++ b/docs/api/rosetta/rosetta-construction-payloads-request.schema.json
@@ -20,6 +20,18 @@
       "items": {
         "$ref": "./../../entities/rosetta/rosetta-public-key.schema.json"
       }
+    },
+    "metadata": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "account_sequence": {
+          "type": "integer"
+        },
+        "recent_block_hash": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -537,6 +537,11 @@ export interface RosettaConstructionPayloadsRequest {
   network_identifier: NetworkIdentifier;
   operations: RosettaOperation[];
   public_keys?: RosettaPublicKey[];
+  metadata?: {
+    account_sequence?: number;
+    recent_block_hash?: string;
+    [k: string]: unknown | undefined;
+  };
 }
 
 /**

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -11,6 +11,7 @@ import {
 import { RosettaErrors, RosettaConstants } from '../../rosetta-constants';
 import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
 import { ChainID } from '@stacks/transactions';
+import { StacksCoreRpcClient } from '../../../core-rpc/client';
 
 export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): RouterWithAsync {
   const router = addAsync(express.Router());
@@ -49,6 +50,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
 
     const block = blockQuery.result;
     const result = await db.getStxBalanceAtBlock(accountIdentifier.address, block.block_height);
+    const accountInfo = await new StacksCoreRpcClient().getAccount(accountIdentifier.address);
 
     const response: RosettaAccountBalanceResponse = {
       block_identifier: {
@@ -66,7 +68,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
       ],
       coins: [],
       metadata: {
-        sequence_number: 0,
+        sequence_number: accountInfo.nonce ? accountInfo.nonce : 0,
       },
     };
 

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -647,7 +647,7 @@ describe('Rosetta API', () => {
 
       coins: [],
       metadata: {
-        sequence_number: 0,
+        sequence_number: 1,
       },
     };
 


### PR DESCRIPTION
## Description
Custom nonce added in rosetta endpoints `/construction/payloads` and `/account/balance`
For details refer to this [issue # 433](https://github.com/blockstack/stacks-blockchain-api/issues/433)


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated

For review @zone117x 