### PR TITLE
Include any tx type in the address filtered mempool result

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -129,19 +129,19 @@ paths:
       parameters:
         - name: sender_address
           in: query
-          description: Filter to only STX transfer transactions with this sender address.
+          description: Filter to only return transactions with this sender address.
           required: false
           schema:
             type: string
         - name: recipient_address
           in: query
-          description: Filter to only STX transfer transactions with this recipient address.
+          description: Filter to only return transactions with this recipient address (only applicable for STX transfer tx types).
           required: false
           schema:
             type: string
         - name: address
           in: query
-          description: Filter to only show STX transfer transactions with this address as the recipient or sender.
+          description: Filter to only return transactions with this address as the sender or recipient (recipient only applicable for STX transfer tx types).
           required: false
           schema:
             type: string

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1482,19 +1482,17 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     let queryValues: any[];
 
     if (address) {
-      whereCondition =
-        'type_id = $1 AND (sender_address = $2 OR token_transfer_recipient_address = $2)';
-      queryValues = [DbTxTypeId.TokenTransfer, address];
+      whereCondition = 'sender_address = $1 OR token_transfer_recipient_address = $1';
+      queryValues = [address];
     } else if (senderAddress && recipientAddress) {
-      whereCondition =
-        'type_id = $1 AND sender_address = $2 AND token_transfer_recipient_address = $3';
-      queryValues = [DbTxTypeId.TokenTransfer, senderAddress, recipientAddress];
+      whereCondition = 'sender_address = $1 AND token_transfer_recipient_address = $2';
+      queryValues = [senderAddress, recipientAddress];
     } else if (senderAddress) {
-      whereCondition = 'type_id = $1 AND sender_address = $2';
-      queryValues = [DbTxTypeId.TokenTransfer, senderAddress];
+      whereCondition = 'sender_address = $1';
+      queryValues = [senderAddress];
     } else if (recipientAddress) {
-      whereCondition = 'type_id = $1 AND token_transfer_recipient_address = $2';
-      queryValues = [DbTxTypeId.TokenTransfer, recipientAddress];
+      whereCondition = 'token_transfer_recipient_address = $1';
+      queryValues = [recipientAddress];
     } else {
       whereCondition = undefined;
       queryValues = [];


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/438

Previously, when using an address filter for the `/extended/v1/tx/mempool` endpoint, only `stx-transfer` tx types would be returned. This decision was initially made because only `stx-transfer` types have anything like a known `recipient` before the tx is mined. This is in contrast to a `contract-call` tx type, where there _can_ be recipients in the events generated, but events are not available until the tx is actually mined (and the contract code is ran).

This change allows any tx type to be returned, but keep in mind that only the tx `sender` will be checked for all tx types that are not a `stx-transfer`. 