### PR TITLE
Add `height` filter to `/stx_inbound`

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -795,6 +795,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: height
+          in: query
+          description: Filter for transfers only at this given block height
+          required: false
+          schema:
+            type: number
       responses:
         200:
           description: Success

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -123,7 +123,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
 
     let heightFilter: number | undefined;
     if ('height' in req.query) {
-      heightFilter = parseInt(req.query['height'] as string);
+      heightFilter = parseInt(req.query['height'] as string, 10);
       if (!Number.isInteger(heightFilter)) {
         return res
           .status(400)
@@ -188,7 +188,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
       let heightFilter: number | undefined;
       if ('height' in req.query) {
-        heightFilter = parseInt(req.query['height'] as string);
+        heightFilter = parseInt(req.query['height'] as string, 10);
         if (!Number.isInteger(heightFilter)) {
           return res
             .status(400)

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -385,6 +385,7 @@ export interface DataStore extends DataStoreEventEmitter {
     limit: number;
     offset: number;
     sendManyContractId: string;
+    height?: number;
   }): Promise<{ results: DbInboundStxTransfer[]; total: number }>;
 
   searchHash(args: { hash: string }): Promise<FoundOrNot<DbSearchResult>>;


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/457

Adds a block `height` filter to the `/stx_inbound` endpoint, e.g.
`/extended/v1/address/ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y/stx_inbound?height=127`

Also increases pagination limit to 500, and fixes the error response message.