### PR TITLE
Add get block by height endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -297,6 +297,35 @@ paths:
             application/json:
               example:
                 $ref: ./api/errors/block-not-found.json
+  /extended/v1/block/by_height/{height}:
+    parameters:
+      - name: height
+        in: path
+        description: Height of the block
+        required: true
+        schema:
+          type: number
+    get:
+      summary: Get block
+      description: Get a specific block by height
+      tags:
+        - Blocks
+      operationId: get_block_by_height
+      responses:
+        200:
+          description: Block
+          content:
+            application/json:
+              schema:
+                $ref: ./entities/blocks/block.schema.json
+              example:
+                $ref: ./entities/blocks/block.example.json
+        404:
+          description: Cannot find block with given height
+          content:
+            application/json:
+              example:
+                $ref: ./api/errors/block-not-found.json
 
   /extended/v1/burnchain/rewards:
     get:

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -36,6 +36,7 @@ import {
   DbEvent,
   DbTx,
   DbMempoolTx,
+  DbBlock,
 } from '../../datastore/common';
 import {
   assertNotNullish as unwrapOptional,
@@ -297,11 +298,19 @@ export async function getRosettaBlockFromDataStore(
   return { found: true, result: apiBlock };
 }
 
-export async function getBlockFromDataStore(
-  blockHash: string,
-  db: DataStore
-): Promise<FoundOrNot<Block>> {
-  const blockQuery = await db.getBlock(blockHash);
+export async function getBlockFromDataStore({
+  blockIdentifer,
+  db,
+}: {
+  blockIdentifer: { hash: string } | { height: number };
+  db: DataStore;
+}): Promise<FoundOrNot<Block>> {
+  let blockQuery: FoundOrNot<DbBlock>;
+  if ('hash' in blockIdentifer) {
+    blockQuery = await db.getBlock(blockIdentifer.hash);
+  } else {
+    blockQuery = await db.getBlockByHeight(blockIdentifer.height);
+  }
   if (!blockQuery.found) {
     return { found: false };
   }

--- a/src/api/routes/block.ts
+++ b/src/api/routes/block.ts
@@ -40,7 +40,7 @@ export function createBlockRouter(db: DataStore): RouterWithAsync {
   });
 
   router.getAsync('/by_height/:height', async (req, res) => {
-    const height = parseInt(req.params['height']);
+    const height = parseInt(req.params['height'], 10);
     if (!Number.isInteger(height)) {
       return res
         .status(400)

--- a/src/api/routes/block.ts
+++ b/src/api/routes/block.ts
@@ -25,7 +25,10 @@ export function createBlockRouter(db: DataStore): RouterWithAsync {
     const { results: blocks, total } = await db.getBlocks({ offset, limit });
     // TODO: fix duplicate pg queries
     const results = await Bluebird.mapSeries(blocks, async block => {
-      const blockQuery = await getBlockFromDataStore(block.block_hash, db);
+      const blockQuery = await getBlockFromDataStore({
+        blockIdentifer: { hash: block.block_hash },
+        db,
+      });
       if (!blockQuery.found) {
         throw new Error('unexpected block not found -- fix block enumeration query');
       }
@@ -36,6 +39,25 @@ export function createBlockRouter(db: DataStore): RouterWithAsync {
     res.json(response);
   });
 
+  router.getAsync('/by_height/:height', async (req, res) => {
+    const height = parseInt(req.params['height']);
+    if (!Number.isInteger(height)) {
+      return res
+        .status(400)
+        .json({ error: `height is not a valid integer: ${req.query['height']}` });
+    }
+    if (height < 1) {
+      return res.status(400).json({ error: `height is not a positive integer: ${height}` });
+    }
+    const block = await getBlockFromDataStore({ blockIdentifer: { height }, db });
+    if (!block.found) {
+      res.status(404).json({ error: `cannot find block by height ${height}` });
+      return;
+    }
+    // TODO: block schema validation
+    res.json(block.result);
+  });
+
   router.getAsync('/:hash', async (req, res) => {
     const { hash } = req.params;
 
@@ -43,7 +65,7 @@ export function createBlockRouter(db: DataStore): RouterWithAsync {
       return res.redirect('/extended/v1/block/0x' + hash);
     }
 
-    const block = await getBlockFromDataStore(hash, db);
+    const block = await getBlockFromDataStore({ blockIdentifer: { hash }, db });
     if (!block.found) {
       res.status(404).json({ error: `cannot find block by hash ${hash}` });
       return;

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -1900,7 +1900,10 @@ describe('api tests', () => {
     };
     await db.updateTx(client, tx);
 
-    const blockQuery = await getBlockFromDataStore(block.block_hash, db);
+    const blockQuery = await getBlockFromDataStore({
+      blockIdentifer: { hash: block.block_hash },
+      db,
+    });
     if (!blockQuery.found) {
       throw new Error('block not found');
     }
@@ -1920,10 +1923,19 @@ describe('api tests', () => {
 
     expect(blockQuery.result).toEqual(expectedResp);
 
-    const fetchTx = await supertest(api.server).get(`/extended/v1/block/${block.block_hash}`);
-    expect(fetchTx.status).toBe(200);
-    expect(fetchTx.type).toBe('application/json');
-    expect(JSON.parse(fetchTx.text)).toEqual(expectedResp);
+    const fetchBlockByHash = await supertest(api.server).get(
+      `/extended/v1/block/${block.block_hash}`
+    );
+    expect(fetchBlockByHash.status).toBe(200);
+    expect(fetchBlockByHash.type).toBe('application/json');
+    expect(JSON.parse(fetchBlockByHash.text)).toEqual(expectedResp);
+
+    const fetchBlockByHeight = await supertest(api.server).get(
+      `/extended/v1/block/by_height/${block.block_height}`
+    );
+    expect(fetchBlockByHeight.status).toBe(200);
+    expect(fetchBlockByHeight.type).toBe('application/json');
+    expect(JSON.parse(fetchBlockByHeight.text)).toEqual(expectedResp);
   });
 
   test('tx - sponsored', async () => {


### PR DESCRIPTION
Implement a new endpoint `get block by height`, similar to the `get block by hash` endpoint. 

`GET /extended/v1/block/by_height/<number>`