### PR TITLE
Total STX supply endpoint

### DIFF
--- a/docs/api/info/get-total-stx-supply-legacy-format.example.json
+++ b/docs/api/info/get-total-stx-supply-legacy-format.example.json
@@ -1,0 +1,8 @@
+{
+  "unlockedPercent": "71.99",
+  "totalStacks": "1352464600.000000",
+  "totalStacksFormatted": "1,352,464,600.000000",
+  "unlockedSupply": "973705260.219817",
+  "unlockedSupplyFormatted": "973,705,260.219817",
+  "blockHeight": "665746"
+}

--- a/docs/api/info/get-total-stx-supply-legacy-format.schema.json
+++ b/docs/api/info/get-total-stx-supply-legacy-format.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "GET request that returns network target block times",
+  "title": "GetTotalStxSupplyLegacyFormatResponse",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["unlockedPercent", "totalStacks", "totalStacksFormatted", "unlockedSupply", "unlockedSupplyFormatted", "blockHeight"],
+  "properties": {
+    "unlockedPercent": {
+      "type": "string",
+      "description": "String quoted decimal number of the percentage of STX that have unlocked"
+    },
+    "totalStacks": {
+      "type": "string",
+      "description": "String quoted decimal number of the total possible number of STX"
+    },
+    "totalStacksFormatted": {
+      "type": "string",
+      "description": "Same as `totalStacks` but formatted with comma thousands separators"
+    },
+    "unlockedSupply": {
+      "type": "string",
+      "description": "String quoted decimal number of the STX that have been mined or unlocked"
+    },
+    "unlockedSupplyFormatted": {
+      "type": "string",
+      "description": "Same as `unlockedSupply` but formatted with comma thousands separators"
+    },
+    "blockHeight": {
+      "type": "string",
+      "description": "The block height at which this information was queried"
+    }
+  }
+}

--- a/docs/api/info/get-total-stx-supply.example.json
+++ b/docs/api/info/get-total-stx-supply.example.json
@@ -1,0 +1,6 @@
+{
+  "unlocked_percent": "71.99",
+  "total_stx": "1352464600.000000",
+  "unlocked_stx": "973705260.219817",
+  "block_height": 3210
+}

--- a/docs/api/info/get-total-stx-supply.schema.json
+++ b/docs/api/info/get-total-stx-supply.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "GET request that returns network target block times",
+  "title": "GetTotalStxSupplyResponse",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["unlocked_percent", "total_stx", "unlocked_stx", "block_height"],
+  "properties": {
+    "unlocked_percent": {
+      "type": "string",
+      "description": "String quoted decimal number of the percentage of STX that have unlocked"
+    },
+    "total_stx": {
+      "type": "string",
+      "description": "String quoted decimal number of the total possible number of STX"
+    },
+    "unlocked_stx": {
+      "type": "string",
+      "description": "String quoted decimal number of the STX that have been mined or unlocked"
+    },
+    "block_height": {
+      "type": "integer",
+      "description": "The block height at which this information was queried"
+    }
+  }
+}

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -365,6 +365,36 @@ export interface NetworkBlockTimesResponse {
 /**
  * GET request that returns network target block times
  */
+export interface GetTotalStxSupplyLegacyFormatResponse {
+  /**
+   * String quoted decimal number of the percentage of STX that have unlocked
+   */
+  unlockedPercent: string;
+  /**
+   * String quoted decimal number of the total possible number of STX
+   */
+  totalStacks: string;
+  /**
+   * Same as `totalStacks` but formatted with comma thousands separators
+   */
+  totalStacksFormatted: string;
+  /**
+   * String quoted decimal number of the STX that have been mined or unlocked
+   */
+  unlockedSupply: string;
+  /**
+   * Same as `unlockedSupply` but formatted with comma thousands separators
+   */
+  unlockedSupplyFormatted: string;
+  /**
+   * The block height at which this information was queried
+   */
+  blockHeight: string;
+}
+
+/**
+ * GET request that returns network target block times
+ */
 export interface GetTotalStxSupplyResponse {
   /**
    * String quoted decimal number of the percentage of STX that have unlocked

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -363,6 +363,28 @@ export interface NetworkBlockTimesResponse {
 }
 
 /**
+ * GET request that returns network target block times
+ */
+export interface GetTotalStxSupplyResponse {
+  /**
+   * String quoted decimal number of the percentage of STX that have unlocked
+   */
+  unlocked_percent: string;
+  /**
+   * String quoted decimal number of the total possible number of STX
+   */
+  total_stx: string;
+  /**
+   * String quoted decimal number of the STX that have been mined or unlocked
+   */
+  unlocked_stx: string;
+  /**
+   * The block height at which this information was queried
+   */
+  block_height: number;
+}
+
+/**
  * An AccountBalanceRequest is utilized to make a balance request on the /account/balance endpoint. If the block_identifier is populated, a historical balance query should be performed.
  */
 export interface RosettaAccountBalanceRequest {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -990,6 +990,29 @@ paths:
               schema:
                 $ref: ./api/info/get-total-stx-supply.schema.json
 
+  /extended/v1/total_supply/legacy_format:
+    get:
+      tags:
+        - Info
+      operationId: get_total_stx_supply_legacy_format
+      summary: Get total and unlocked STX supply (results formatted the same as the legacy 1.0 API)
+      parameters:
+        - in: query
+          name: height
+          required: false
+          schema:
+            type: number
+          description: The block height at which to query supply details from, if not provided then the latest block height is used
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              example:
+                $ref: ./api/info/get-total-stx-supply-legacy-format.example.json
+              schema:
+                $ref: ./api/info/get-total-stx-supply-legacy-format.schema.json
+
   /v2/pox:
     get:
       summary: Get PoX details

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -967,6 +967,29 @@ paths:
               schema:
                 $ref: ./api/info/get-network-block-time-by-network.schema.json
 
+  /extended/v1/total_supply:
+    get:
+      tags:
+        - Info
+      operationId: get_total_stx_supply
+      summary: Get total and unlocked STX supply
+      parameters:
+        - in: query
+          name: height
+          required: false
+          schema:
+            type: number
+          description: The block height at which to query supply details from, if not provided then the latest block height is used
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              example:
+                $ref: ./api/info/get-total-stx-supply.example.json
+              schema:
+                $ref: ./api/info/get-total-stx-supply.schema.json
+
   /v2/pox:
     get:
       summary: Get PoX details

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -17,6 +17,7 @@ import { createBlockRouter } from './routes/block';
 import { createFaucetRouter } from './routes/faucets';
 import { createAddressRouter } from './routes/address';
 import { createSearchRouter } from './routes/search';
+import { createTotalSupplyRouter } from './routes/total-supply';
 import { createRosettaNetworkRouter } from './routes/rosetta/network';
 import { createRosettaMempoolRouter } from './routes/rosetta/mempool';
 import { createRosettaBlockRouter } from './routes/rosetta/block';
@@ -113,6 +114,7 @@ export async function startApiServer(datastore: DataStore, chainId: ChainID): Pr
       router.use('/address', createAddressRouter(datastore, chainId));
       router.use('/search', createSearchRouter(datastore));
       router.use('/info', createInfoRouter(datastore));
+      router.use('/total_supply', createTotalSupplyRouter(datastore));
       router.use('/debug', createDebugRouter(datastore));
       router.use('/status', (req, res) => res.status(200).json({ status: 'ready' }));
       router.use('/faucets', createFaucetRouter(datastore));

--- a/src/api/routes/total-supply.ts
+++ b/src/api/routes/total-supply.ts
@@ -14,6 +14,7 @@ import {
 import {
   NetworkBlockTimesResponse,
   NetworkBlockTimeResponse,
+  GetTotalStxSupplyResponse,
 } from '@blockstack/stacks-blockchain-api-types';
 
 export function createTotalSupplyRouter(db: DataStore): RouterWithAsync {
@@ -59,7 +60,7 @@ export function createTotalSupplyRouter(db: DataStore): RouterWithAsync {
       }
     }
     const supply = await getStxSupplyInfo(atBlockHeight);
-    const result = {
+    const result: GetTotalStxSupplyResponse = {
       unlocked_percent: supply.unlockedPercent,
       total_stx: supply.totalStx,
       unlocked_stx: supply.unlockedStx,

--- a/src/api/routes/total-supply.ts
+++ b/src/api/routes/total-supply.ts
@@ -2,18 +2,9 @@ import * as express from 'express';
 import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import BigNumber from 'bignumber.js';
 import { DataStore } from '../../datastore/common';
-import { validate } from '../validate';
+import { microStxToStx, STACKS_DECIMAL_PLACES, TOTAL_STACKS } from '../../helpers';
 import {
-  isProdEnv,
-  MICROSTACKS_IN_STACKS,
-  microStxToStx,
-  STACKS_DECIMAL_PLACES,
-  timeout,
-  TOTAL_STACKS,
-} from '../../helpers';
-import {
-  NetworkBlockTimesResponse,
-  NetworkBlockTimeResponse,
+  GetTotalStxSupplyLegacyFormatResponse,
   GetTotalStxSupplyResponse,
 } from '@blockstack/stacks-blockchain-api-types';
 
@@ -86,7 +77,7 @@ export function createTotalSupplyRouter(db: DataStore): RouterWithAsync {
     }
 
     const supply = await getStxSupplyInfo(atBlockHeight);
-    const result = {
+    const result: GetTotalStxSupplyLegacyFormatResponse = {
       unlockedPercent: supply.unlockedPercent,
       totalStacks: supply.totalStx,
       totalStacksFormatted: new BigNumber(supply.totalStx).toFormat(STACKS_DECIMAL_PLACES, 8),

--- a/src/api/routes/total-supply.ts
+++ b/src/api/routes/total-supply.ts
@@ -1,0 +1,100 @@
+import * as express from 'express';
+import { addAsync, RouterWithAsync } from '@awaitjs/express';
+import BigNumber from 'bignumber.js';
+import { DataStore } from '../../datastore/common';
+import { validate } from '../validate';
+import {
+  isProdEnv,
+  MICROSTACKS_IN_STACKS,
+  microStxToStx,
+  STACKS_DECIMAL_PLACES,
+  timeout,
+  TOTAL_STACKS,
+} from '../../helpers';
+import {
+  NetworkBlockTimesResponse,
+  NetworkBlockTimeResponse,
+} from '@blockstack/stacks-blockchain-api-types';
+
+export function createTotalSupplyRouter(db: DataStore): RouterWithAsync {
+  const router = addAsync(express.Router());
+
+  async function getStxSupplyInfo(
+    atBlockHeight?: number
+  ): Promise<{
+    unlockedPercent: string;
+    totalStx: string;
+    unlockedStx: string;
+    blockHeight: number;
+  }> {
+    const { stx: unlockedSupply, blockHeight } = await db.getUnlockedStxSupply({
+      blockHeight: atBlockHeight,
+    });
+    const totalMicroStx = new BigNumber(TOTAL_STACKS).shiftedBy(STACKS_DECIMAL_PLACES);
+    const unlockedPercent = new BigNumber(unlockedSupply.toString())
+      .div(totalMicroStx)
+      .times(100)
+      .toFixed(2);
+    return {
+      unlockedPercent,
+      totalStx: microStxToStx(totalMicroStx),
+      unlockedStx: microStxToStx(unlockedSupply),
+      blockHeight: blockHeight,
+    };
+  }
+
+  router.getAsync('/', async (req, res) => {
+    let atBlockHeight: number | undefined;
+    if ('height' in req.query) {
+      atBlockHeight = parseInt(req.query['height'] as string, 10);
+      if (!Number.isInteger(atBlockHeight)) {
+        return res
+          .status(400)
+          .json({ error: `height is not a valid integer: ${req.query['height']}` });
+      }
+      if (atBlockHeight < 1) {
+        return res
+          .status(400)
+          .json({ error: `height is not a positive integer: ${atBlockHeight}` });
+      }
+    }
+    const supply = await getStxSupplyInfo(atBlockHeight);
+    const result = {
+      unlocked_percent: supply.unlockedPercent,
+      total_stx: supply.totalStx,
+      unlocked_stx: supply.unlockedStx,
+      block_height: supply.blockHeight,
+    };
+    res.json(result);
+  });
+
+  router.getAsync('/legacy_format', async (req, res) => {
+    let atBlockHeight: number | undefined;
+    if ('height' in req.query) {
+      atBlockHeight = parseInt(req.query['height'] as string, 10);
+      if (!Number.isInteger(atBlockHeight)) {
+        return res
+          .status(400)
+          .json({ error: `height is not a valid integer: ${req.query['height']}` });
+      }
+      if (atBlockHeight < 1) {
+        return res
+          .status(400)
+          .json({ error: `height is not a positive integer: ${atBlockHeight}` });
+      }
+    }
+
+    const supply = await getStxSupplyInfo(atBlockHeight);
+    const result = {
+      unlockedPercent: supply.unlockedPercent,
+      totalStacks: supply.totalStx,
+      totalStacksFormatted: new BigNumber(supply.totalStx).toFormat(STACKS_DECIMAL_PLACES, 8),
+      unlockedSupply: supply.unlockedStx,
+      unlockedSupplyFormatted: new BigNumber(supply.unlockedStx).toFormat(STACKS_DECIMAL_PLACES, 8),
+      blockHeight: supply.blockHeight.toString(),
+    };
+    res.json(result);
+  });
+
+  return router;
+}

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -363,6 +363,10 @@ export interface DataStore extends DataStoreEventEmitter {
     stxAddress: string
   ): Promise<Map<string, { count: bigint; totalSent: bigint; totalReceived: bigint }>>;
 
+  getUnlockedStxSupply(args: {
+    blockHeight?: number;
+  }): Promise<{ stx: bigint; blockHeight: number }>;
+
   getBTCFaucetRequests(address: string): Promise<{ results: DbFaucetRequest[] }>;
 
   getSTXFaucetRequests(address: string): Promise<{ results: DbFaucetRequest[] }>;

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -411,6 +411,12 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     return Promise.resolve();
   }
 
+  getUnlockedStxSupply(args: {
+    blockHeight?: number | undefined;
+  }): Promise<{ stx: bigint; blockHeight: number }> {
+    throw new Error('Method not implemented.');
+  }
+
   getBTCFaucetRequests(address: string) {
     const request = this.faucetRequests
       .filter(f => f.address === address)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -7,6 +7,7 @@ import * as c32check from 'c32check';
 import * as btc from 'bitcoinjs-lib';
 import * as BN from 'bn.js';
 import { ChainID } from '@stacks/transactions';
+import BigNumber from 'bignumber.js';
 
 export const isDevEnv = process.env.NODE_ENV === 'development';
 export const isTestEnv = process.env.NODE_ENV === 'test';
@@ -154,11 +155,23 @@ export function formatMapToObject<TKey extends string, TValue, TFormatted>(
   return obj;
 }
 
-export const MICROSTACKS_IN_STACKS = 1_000_000n;
+export const TOTAL_STACKS = new BigNumber(1320000000)
+  .plus(322146 * 100 + 5 * 50000) // air drop
+  .toString();
 
-export function stxToMicroStx(microStx: bigint | number): bigint {
-  const input = typeof microStx === 'bigint' ? microStx : BigInt(microStx);
+export const MICROSTACKS_IN_STACKS = 1_000_000n;
+export const STACKS_DECIMAL_PLACES = 6;
+
+export function stxToMicroStx(stx: bigint | number): bigint {
+  const input = typeof stx === 'bigint' ? stx : BigInt(stx);
   return input * MICROSTACKS_IN_STACKS;
+}
+
+export function microStxToStx(microStx: bigint | BigNumber): string {
+  const MAX_BIGNUMBER_ROUND_MODE = 8;
+  const input = typeof microStx === 'bigint' ? new BigNumber(microStx.toString()) : microStx;
+  const bigNumResult = new BigNumber(input).shiftedBy(-STACKS_DECIMAL_PLACES);
+  return bigNumResult.toFixed(STACKS_DECIMAL_PLACES, MAX_BIGNUMBER_ROUND_MODE);
 }
 
 export function digestSha512_256(input: Buffer): Buffer {


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/455

Implements a total STX supply endpoint, and another that is formatted the same as the legacy 1.0 API -- so integrators would only need to change the URL.

Examples:

`GET /extended/v1/total_supply`:
```json
{
  "unlocked_percent": "77.48",
  "total_stx": "1352464600.000000",
  "unlocked_stx": "1047848171.287772",
  "block_height": 5086
}
```

`GET /extended/v1/total_supply/legacy_format`:
```json
{
  "unlockedPercent": "77.48",
  "totalStacks": "1352464600.000000",
  "totalStacksFormatted": "1,352,464,600.000000",
  "unlockedSupply": "1047848171.287772",
  "unlockedSupplyFormatted": "1,047,848,171.287772",
  "blockHeight": "5086
}
```