### PR TITLE
Feat/dropped mempool txs

### DIFF
--- a/docs/entities/mempool-transactions/abstract-transaction.schema.json
+++ b/docs/entities/mempool-transactions/abstract-transaction.schema.json
@@ -20,7 +20,7 @@
     "tx_status": {
       "type": "string",
       "description": "Status of the transaction in the mempool. Can be Or pending in the mempool. Or dropped from the mempool from being replaced by a transaction with the same nonce but a higher fee, replaced by a transaction with the same nonce but in the canonical fork, the transaction is too expensive to include in a block, or because it became stale.",
-      "$ref": "../transactions/transaction-status.schema.json"
+      "$ref": "./transaction-status.schema.json"
     },
     "tx_result": {
       "type": "object",

--- a/docs/entities/mempool-transactions/abstract-transaction.schema.json
+++ b/docs/entities/mempool-transactions/abstract-transaction.schema.json
@@ -19,7 +19,8 @@
     },
     "tx_status": {
       "type": "string",
-      "enum": ["pending"]
+      "description": "Status of the transaction in the mempool. Can be Or pending in the mempool. Or dropped from the mempool from being replaced by a transaction with the same nonce but a higher fee, replaced by a transaction with the same nonce but in the canonical fork, the transaction is too expensive to include in a block, or because it became stale.",
+      "$ref": "../transactions/transaction-status.schema.json"
     },
     "tx_result": {
       "type": "object",

--- a/docs/entities/mempool-transactions/abstract-transaction.schema.json
+++ b/docs/entities/mempool-transactions/abstract-transaction.schema.json
@@ -19,7 +19,7 @@
     },
     "tx_status": {
       "type": "string",
-      "description": "Status of the transaction in the mempool. Can be Or pending in the mempool. Or dropped from the mempool from being replaced by a transaction with the same nonce but a higher fee, replaced by a transaction with the same nonce but in the canonical fork, the transaction is too expensive to include in a block, or because it became stale.",
+      "description": "Status of the transaction in the mempool. Can be pending in the mempool. Or dropped from the mempool from being replaced by a transaction with the same nonce but a higher fee, replaced by a transaction with the same nonce but in the canonical fork, the transaction is too expensive to include in a block, or because it became stale.",
       "$ref": "./transaction-status.schema.json"
     },
     "tx_result": {

--- a/docs/entities/mempool-transactions/transaction-status.schema.json
+++ b/docs/entities/mempool-transactions/transaction-status.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MempoolTransactionStatus",
+  "description": "Status of the transaction",
+  "type": "string",
+  "enum": ["pending", "dropped_replace_by_fee", "dropped_replace_across_fork", "dropped_too_expensive", "dropped_stale_garbage_collect"]
+}

--- a/docs/entities/transactions/abstract-transaction.schema.json
+++ b/docs/entities/transactions/abstract-transaction.schema.json
@@ -48,7 +48,7 @@
       "description": "Index of the transaction, indicating the order. Starts at `0` and increases with each transaction"
     },
     "tx_status": {
-      "description": "Status of the transaction",
+      "description": "Status of the transaction. Can be included in a block with a success or aborted status. Or pending in the mempool. Or dropped from the mempool from being replaced by a transaction with the same nonce but a higher fee, replaced by a transaction with the same nonce but in the canonical fork, the transaction is too expensive to include in a block, or because it became stale.",
       "$ref": "./transaction-status.schema.json"
     },
     "tx_result": {

--- a/docs/entities/transactions/transaction-status.schema.json
+++ b/docs/entities/transactions/transaction-status.schema.json
@@ -3,5 +3,5 @@
   "title": "TransactionStatus",
   "description": "Status of the transaction",
   "type": "string",
-  "enum": ["success", "abort_by_response", "abort_by_post_condition", "pending", "dropped_replace_by_fee", "dropped_replace_across_fork", "dropped_too_expensive", "dropped_stale_garbage_collect"]
+  "enum": ["success", "abort_by_response", "abort_by_post_condition"]
 }

--- a/docs/entities/transactions/transaction-status.schema.json
+++ b/docs/entities/transactions/transaction-status.schema.json
@@ -3,5 +3,5 @@
   "title": "TransactionStatus",
   "description": "Status of the transaction",
   "type": "string",
-  "enum": ["success", "pending", "abort_by_response", "abort_by_post_condition"]
+  "enum": ["success", "abort_by_response", "abort_by_post_condition", "pending", "dropped_replace_by_fee", "dropped_replace_across_fork", "dropped_too_expensive", "dropped_stale_garbage_collect"]
 }

--- a/docs/entities/ws-rpc/rpc-address-tx-notification-params.schema.json
+++ b/docs/entities/ws-rpc/rpc-address-tx-notification-params.schema.json
@@ -20,7 +20,14 @@
       "$ref": "../transactions/transaction-type.schema.json"
     },
     "tx_status": {
-      "$ref": "../transactions/transaction-status.schema.json"
+      "oneOf": [
+        {
+          "$ref": "../transactions/transaction-status.schema.json"
+        },
+        {
+          "$ref": "../mempool-transactions/transaction-status.schema.json"
+        }
+      ]
     }
   }
 }

--- a/docs/entities/ws-rpc/rpc-tx-update-notification-params.schema.json
+++ b/docs/entities/ws-rpc/rpc-tx-update-notification-params.schema.json
@@ -16,7 +16,14 @@
       "$ref": "../transactions/transaction-type.schema.json"
     },
     "tx_status": {
-      "$ref": "../transactions/transaction-status.schema.json"
+      "oneOf": [
+        {
+          "$ref": "../transactions/transaction-status.schema.json"
+        },
+        {
+          "$ref": "../mempool-transactions/transaction-status.schema.json"
+        }
+      ]
     }
   }
 }

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -981,7 +981,7 @@ export interface ReadOnlyFunctionArgs {
  */
 export interface MempoolTokenTransferTransaction {
   tx_id: string;
-  tx_status: TransactionStatus;
+  tx_status: MempoolTransactionStatus;
   tx_result?: {
     hex: string;
     repr: string;
@@ -1028,7 +1028,7 @@ export interface MempoolTokenTransferTransaction {
  */
 export interface MempoolSmartContractTransaction {
   tx_id: string;
-  tx_status: TransactionStatus;
+  tx_status: MempoolTransactionStatus;
   tx_result?: {
     hex: string;
     repr: string;
@@ -1072,7 +1072,7 @@ export interface MempoolSmartContractTransaction {
  */
 export interface MempoolContractCallTransaction {
   tx_id: string;
-  tx_status: TransactionStatus;
+  tx_status: MempoolTransactionStatus;
   tx_result?: {
     hex: string;
     repr: string;
@@ -1116,7 +1116,7 @@ export interface MempoolContractCallTransaction {
  */
 export interface MempoolPoisonMicroblockTransaction {
   tx_id: string;
-  tx_status: TransactionStatus;
+  tx_status: MempoolTransactionStatus;
   tx_result?: {
     hex: string;
     repr: string;
@@ -1162,7 +1162,7 @@ export interface MempoolPoisonMicroblockTransaction {
  */
 export interface MempoolCoinbaseTransaction {
   tx_id: string;
-  tx_status: TransactionStatus;
+  tx_status: MempoolTransactionStatus;
   tx_result?: {
     hex: string;
     repr: string;
@@ -2366,15 +2366,7 @@ export interface CoinbaseTransaction {
 /**
  * Status of the transaction
  */
-export type TransactionStatus =
-  | "success"
-  | "abort_by_response"
-  | "abort_by_post_condition"
-  | "pending"
-  | "dropped_replace_by_fee"
-  | "dropped_replace_across_fork"
-  | "dropped_too_expensive"
-  | "dropped_stale_garbage_collect";
+export type TransactionStatus = "success" | "abort_by_response" | "abort_by_post_condition";
 
 /**
  * String literal of all Stacks 2.0 transaction types
@@ -2452,7 +2444,7 @@ export interface RpcAddressTxNotificationParams {
   address: string;
   tx_id: string;
   tx_type: TransactionType;
-  tx_status: TransactionStatus;
+  tx_status: TransactionStatus | MempoolTransactionStatus;
 }
 
 export interface RpcAddressTxNotificationResponse {
@@ -2478,7 +2470,7 @@ export type RpcSubscriptionType = "tx_update" | "address_tx_update" | "address_b
 export interface RpcTxUpdateNotificationParams {
   tx_id: string;
   tx_type: TransactionType;
-  tx_status: TransactionStatus;
+  tx_status: TransactionStatus | MempoolTransactionStatus;
 }
 
 export interface RpcTxUpdateNotificationResponse {

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -981,7 +981,7 @@ export interface ReadOnlyFunctionArgs {
  */
 export interface MempoolTokenTransferTransaction {
   tx_id: string;
-  tx_status: "pending";
+  tx_status: TransactionStatus;
   tx_result?: {
     hex: string;
     repr: string;
@@ -1028,7 +1028,7 @@ export interface MempoolTokenTransferTransaction {
  */
 export interface MempoolSmartContractTransaction {
   tx_id: string;
-  tx_status: "pending";
+  tx_status: TransactionStatus;
   tx_result?: {
     hex: string;
     repr: string;
@@ -1072,7 +1072,7 @@ export interface MempoolSmartContractTransaction {
  */
 export interface MempoolContractCallTransaction {
   tx_id: string;
-  tx_status: "pending";
+  tx_status: TransactionStatus;
   tx_result?: {
     hex: string;
     repr: string;
@@ -1116,7 +1116,7 @@ export interface MempoolContractCallTransaction {
  */
 export interface MempoolPoisonMicroblockTransaction {
   tx_id: string;
-  tx_status: "pending";
+  tx_status: TransactionStatus;
   tx_result?: {
     hex: string;
     repr: string;
@@ -1162,7 +1162,7 @@ export interface MempoolPoisonMicroblockTransaction {
  */
 export interface MempoolCoinbaseTransaction {
   tx_id: string;
-  tx_status: "pending";
+  tx_status: TransactionStatus;
   tx_result?: {
     hex: string;
     repr: string;
@@ -1198,6 +1198,16 @@ export interface MempoolCoinbaseTransaction {
     data: string;
   };
 }
+
+/**
+ * Status of the transaction
+ */
+export type MempoolTransactionStatus =
+  | "pending"
+  | "dropped_replace_by_fee"
+  | "dropped_replace_across_fork"
+  | "dropped_too_expensive"
+  | "dropped_stale_garbage_collect";
 
 /**
  * Describes all transaction types on Stacks 2.0 blockchain
@@ -2356,7 +2366,15 @@ export interface CoinbaseTransaction {
 /**
  * Status of the transaction
  */
-export type TransactionStatus = "success" | "pending" | "abort_by_response" | "abort_by_post_condition";
+export type TransactionStatus =
+  | "success"
+  | "abort_by_response"
+  | "abort_by_post_condition"
+  | "pending"
+  | "dropped_replace_by_fee"
+  | "dropped_replace_across_fork"
+  | "dropped_too_expensive"
+  | "dropped_stale_garbage_collect";
 
 /**
  * String literal of all Stacks 2.0 transaction types

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -167,6 +167,36 @@ paths:
               example:
                 $ref: ./api/transaction/get-mempool-transactions.example.json
 
+  /extended/v1/tx/mempool/dropped:
+    get:
+      summary: Get dropped mempool transactions
+      tags:
+        - Transactions
+      operationId: get_dropped_mempool_transaction_list
+      description: Get all recently-broadcast mempool transactions
+      parameters:
+        - name: limit
+          in: query
+          description: max number of mempool transactions to fetch
+          required: false
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          description: index of first mempool transaction to fetch
+          required: false
+          schema:
+            type: integer
+      responses:
+        200:
+          description: List of dropped mempool transactions
+          content:
+            application/json:
+              schema:
+                $ref: ./api/transaction/get-mempool-transactions.schema.json
+              example:
+                $ref: ./api/transaction/get-mempool-transactions.example.json
+
   /extended/v1/tx/{tx_id}:
     parameters:
       - name: tx_id

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -479,7 +479,7 @@ export interface GetTxWithEventsArgs extends GetTxArgs {
 }
 
 function isDroppedTx(tx: DbMempoolTx): boolean {
-  switch (tx.status){
+  switch (tx.status) {
     case DbTxStatus.DroppedReplaceByFee:
     case DbTxStatus.DroppedReplaceAcrossFork:
     case DbTxStatus.DroppedTooExpensive:

--- a/src/api/routes/rosetta/mempool.ts
+++ b/src/api/routes/rosetta/mempool.ts
@@ -48,12 +48,12 @@ export function createRosettaMempoolRouter(db: DataStore, chainId: ChainID): Rou
       return;
     }
 
-    let tx_id = req.body.transaction_identifier.hash;
+    let tx_id: string = req.body.transaction_identifier.hash;
 
     if (!has0xPrefix(tx_id)) {
       tx_id = '0x' + tx_id;
     }
-    const mempoolTxQuery = await db.getMempoolTx(tx_id);
+    const mempoolTxQuery = await db.getMempoolTx({ txId: tx_id });
 
     if (!mempoolTxQuery.found) {
       return res.status(404).json(RosettaErrors.transactionNotFound);

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -116,6 +116,18 @@ export function createTxRouter(db: DataStore): RouterWithAsync {
     res.json(response);
   });
 
+  router.getAsync('/mempool/dropped', async (req, res) => {
+    const limit = parseTxQueryLimit(req.query.limit ?? 96);
+    const offset = parsePagingQueryInput(req.query.offset ?? 0);
+    const { results: txResults, total } = await db.getDroppedTxs({
+      offset,
+      limit,
+    });
+    const results = txResults.map(tx => parseDbMempoolTx(tx));
+    const response: MempoolTransactionListResponse = { limit, offset, total, results };
+    res.json(response);
+  });
+
   router.getAsync('/stream', async (req, res) => {
     const protocol = req.query['protocol'];
     const useEventSource = protocol === 'eventsource';

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -326,7 +326,6 @@ export interface DataStore extends DataStoreEventEmitter {
     senderAddress?: string;
     recipientAddress?: string;
     address?: string;
-    includeDropped?: boolean;
   }): Promise<{ results: DbMempoolTx[]; total: number }>;
   getDroppedTxs(args: {
     limit: number;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -326,6 +326,11 @@ export interface DataStore extends DataStoreEventEmitter {
     senderAddress?: string;
     recipientAddress?: string;
     address?: string;
+    includeDropped?: boolean;
+  }): Promise<{ results: DbMempoolTx[]; total: number }>;
+  getDroppedTxs(args: {
+    limit: number;
+    offset: number;
   }): Promise<{ results: DbMempoolTx[]; total: number }>;
   getMempoolTxIdList(): Promise<{ results: DbMempoolTxId[] }>;
   getTx(txId: string): Promise<FoundOrNot<DbTx>>;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -2,7 +2,11 @@ import * as crypto from 'crypto';
 import { EventEmitter } from 'events';
 import StrictEventEmitter from 'strict-event-emitter-types';
 import { hexToBuffer, parseEnum, FoundOrNot } from '../helpers';
-import { CoreNodeParsedTxMessage, CoreNodeTxStatus } from '../event-stream/core-node-message';
+import {
+  CoreNodeDropMempoolTxReasonType,
+  CoreNodeParsedTxMessage,
+  CoreNodeTxStatus,
+} from '../event-stream/core-node-message';
 import {
   TransactionAuthTypeID,
   TransactionPayloadTypeID,
@@ -66,6 +70,14 @@ export enum DbTxStatus {
   Success = 1,
   AbortByResponse = -1,
   AbortByPostCondition = -2,
+  /** Replaced by a transaction with the same nonce, but a higher fee. */
+  DroppedReplaceByFee = -10,
+  /** Replaced by a transaction with the same nonce but in the canonical fork. */
+  DroppedReplaceAcrossFork = -11,
+  /** The transaction is too expensive to include in a block. */
+  DroppedTooExpensive = -12,
+  /** Transaction was dropped because it became stale. */
+  DroppedStaleGarbageCollect = -13,
 }
 
 export interface BaseTx {
@@ -82,7 +94,7 @@ export interface BaseTx {
   token_transfer_amount?: bigint;
   /** Hex encoded arbitrary message, up to 34 bytes length (should try decoding to an ASCII string). */
   token_transfer_memo?: Buffer;
-  status: DbTxStatus | string;
+  status: DbTxStatus;
   type_id: DbTxTypeId;
   /** Only valid for `contract_call` tx types */
   contract_call_contract_id?: string;
@@ -307,7 +319,7 @@ export interface DataStore extends DataStoreEventEmitter {
   getBlockTxs(indexBlockHash: string): Promise<{ results: string[] }>;
   getBlockTxsRows(blockHash: string): Promise<FoundOrNot<DbTx[]>>;
 
-  getMempoolTx(txId: string): Promise<FoundOrNot<DbMempoolTx>>;
+  getMempoolTx(args: { txId: string; includePruned?: boolean }): Promise<FoundOrNot<DbMempoolTx>>;
   getMempoolTxList(args: {
     limit: number;
     offset: number;
@@ -340,6 +352,7 @@ export interface DataStore extends DataStoreEventEmitter {
 
   update(data: DataStoreUpdateData): Promise<void>;
   updateMempoolTxs(args: { mempoolTxs: DbMempoolTx[] }): Promise<void>;
+  dropMempoolTxs(args: { status: DbTxStatus; txIds: string[] }): Promise<void>;
 
   updateBurnchainRewards(args: {
     burnchainBlockHash: string;
@@ -407,7 +420,9 @@ export function getAssetEventId(event_index: number, event_tx_id: string): strin
   return '0x' + hashed;
 }
 
-function getTxDbStatus(txCoreStatus: CoreNodeTxStatus): DbTxStatus {
+export function getTxDbStatus(
+  txCoreStatus: CoreNodeTxStatus | CoreNodeDropMempoolTxReasonType
+): DbTxStatus {
   switch (txCoreStatus) {
     case 'success':
       return DbTxStatus.Success;
@@ -415,6 +430,14 @@ function getTxDbStatus(txCoreStatus: CoreNodeTxStatus): DbTxStatus {
       return DbTxStatus.AbortByResponse;
     case 'abort_by_post_condition':
       return DbTxStatus.AbortByPostCondition;
+    case 'ReplaceByFee':
+      return DbTxStatus.DroppedReplaceByFee;
+    case 'ReplaceAcrossFork':
+      return DbTxStatus.DroppedReplaceAcrossFork;
+    case 'TooExpensive':
+      return DbTxStatus.DroppedTooExpensive;
+    case 'StaleGarbageCollect':
+      return DbTxStatus.DroppedStaleGarbageCollect;
     default:
       throw new Error(`Unexpected tx status: ${txCoreStatus}`);
   }

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -219,6 +219,13 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     return Promise.resolve({ found: true, result: tx });
   }
 
+  getDroppedTxs(args: {
+    limit: number;
+    offset: number;
+  }): Promise<{ results: DbMempoolTx[]; total: number }> {
+    throw new Error('not yet implemented');
+  }
+
   getMempoolTxList(args: {
     limit: number;
     offset: number;

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1512,7 +1512,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       const selectCols = MEMPOOL_TX_COLUMNS.replace('tx_id', 'mempool.tx_id');
       const resultQuery = await client.query<MempoolTxQueryResult & { count: string }>(
         `
-        SELECT ${selectCols}, COUNT(*) OVER() AS full_count
+        SELECT ${selectCols}, COUNT(*) OVER() AS count
         FROM (
           SELECT *
           FROM mempool_txs

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -202,3 +202,14 @@ export interface CoreNodeBurnBlockMessage {
     }
   ];
 }
+
+export type CoreNodeDropMempoolTxReasonType =
+  | 'ReplaceByFee'
+  | 'ReplaceAcrossFork'
+  | 'TooExpensive'
+  | 'StaleGarbageCollect';
+
+export interface CoreNodeDropMempoolTxMessage {
+  dropped_txids: string[];
+  reason: CoreNodeDropMempoolTxReasonType;
+}

--- a/src/migrations/1584619633448_txs.ts
+++ b/src/migrations/1584619633448_txs.ts
@@ -95,6 +95,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createIndex('txs', 'type_id');
   pgm.createIndex('txs', 'block_height');
   pgm.createIndex('txs', 'canonical');
+  pgm.createIndex('txs', 'status');
   pgm.createIndex('txs', 'sender_address');
   pgm.createIndex('txs', 'token_transfer_recipient_address');
   pgm.createIndex('txs', 'contract_call_contract_id');

--- a/src/migrations/1591291822107_mempool_txs.ts
+++ b/src/migrations/1591291822107_mempool_txs.ts
@@ -71,6 +71,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   });
 
   pgm.createIndex('mempool_txs', 'pruned');
+  pgm.createIndex('mempool_txs', 'status');
   pgm.createIndex('mempool_txs', 'tx_id');
   pgm.createIndex('mempool_txs', 'type_id');
   pgm.createIndex('mempool_txs', 'sender_address');

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -353,7 +353,7 @@ export function rawTxToBaseTx(raw_tx: string): BaseTx {
     token_transfer_recipient_address: recipientAddr,
     tx_id: txId,
     type_id: transactionType,
-    status: '',
+    status: '' as any,
     nonce: Number(transaction.auth.originCondition.nonce),
     fee_rate: fee,
     sender_address: txSender,

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -34,6 +34,7 @@ import {
   DbSmartContractEvent,
   DbTxStatus,
   DbBurnchainReward,
+  DataStoreUpdateData,
 } from '../datastore/common';
 import { startApiServer, ApiServer } from '../api/init';
 import { PgDataStore, cycleMigrations, runMigrations } from '../datastore/postgres-store';
@@ -445,22 +446,34 @@ describe('api tests', () => {
       origin_hash_mode: 1,
     };
     const mempoolTx2: DbMempoolTx = {
-      pruned: false,
+      ...mempoolTx1,
       tx_id: '0x8912000000000000000000000000000000000000000000000000000000000001',
-      nonce: 0,
-      raw_tx: Buffer.from('test-raw-tx'),
-      type_id: DbTxTypeId.Coinbase,
-      status: DbTxStatus.Pending,
-      receipt_time: 1594307695,
-      coinbase_payload: Buffer.from('coinbase hi'),
-      post_conditions: Buffer.from([0x01, 0xf5]),
-      fee_rate: 1234n,
-      sponsored: true,
-      sender_address: 'sender-addr',
-      sponsor_address: 'sponsor-addr',
-      origin_hash_mode: 1,
+      receipt_time: 1594307702,
     };
-    await db.updateMempoolTxs({ mempoolTxs: [mempoolTx1, mempoolTx2] });
+    const mempoolTx3: DbMempoolTx = {
+      ...mempoolTx1,
+      tx_id: '0x8912000000000000000000000000000000000000000000000000000000000003',
+      receipt_time: 1594307703,
+    };
+    const mempoolTx4: DbMempoolTx = {
+      ...mempoolTx1,
+      tx_id: '0x8912000000000000000000000000000000000000000000000000000000000004',
+      receipt_time: 1594307704,
+    };
+    const mempoolTx5: DbMempoolTx = {
+      ...mempoolTx1,
+      tx_id: '0x8912000000000000000000000000000000000000000000000000000000000005',
+      receipt_time: 1594307705,
+    };
+    const mempoolTx6: DbMempoolTx = {
+      ...mempoolTx1,
+      tx_id: '0x8912000000000000000000000000000000000000000000000000000000000006',
+      receipt_time: 1594307706,
+    };
+
+    await db.updateMempoolTxs({
+      mempoolTxs: [mempoolTx1, mempoolTx2, mempoolTx3, mempoolTx4, mempoolTx5],
+    });
     await db.dropMempoolTxs({
       status: DbTxStatus.DroppedReplaceAcrossFork,
       txIds: [mempoolTx1.tx_id, mempoolTx2.tx_id],
@@ -499,8 +512,8 @@ describe('api tests', () => {
       sponsor_address: 'sponsor-addr',
       sponsored: true,
       post_condition_mode: 'allow',
-      receipt_time: 1594307695,
-      receipt_time_iso: '2020-07-09T15:14:55.000Z',
+      receipt_time: 1594307702,
+      receipt_time_iso: '2020-07-09T15:15:02.000Z',
       coinbase_payload: { data: '0x636f696e62617365206869' },
       events: [],
     };
@@ -508,13 +521,13 @@ describe('api tests', () => {
 
     await db.dropMempoolTxs({
       status: DbTxStatus.DroppedReplaceByFee,
-      txIds: [mempoolTx1.tx_id],
+      txIds: [mempoolTx3.tx_id],
     });
-    const searchResult3 = await supertest(api.server).get(`/extended/v1/tx/${mempoolTx1.tx_id}`);
+    const searchResult3 = await supertest(api.server).get(`/extended/v1/tx/${mempoolTx3.tx_id}`);
     expect(searchResult3.status).toBe(200);
     expect(searchResult3.type).toBe('application/json');
     const expectedResp3 = {
-      tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
+      tx_id: '0x8912000000000000000000000000000000000000000000000000000000000003',
       tx_status: 'dropped_replace_by_fee',
       tx_type: 'coinbase',
       fee_rate: '1234',
@@ -523,22 +536,46 @@ describe('api tests', () => {
       sponsor_address: 'sponsor-addr',
       sponsored: true,
       post_condition_mode: 'allow',
-      receipt_time: 1594307695,
-      receipt_time_iso: '2020-07-09T15:14:55.000Z',
+      receipt_time: 1594307703,
+      receipt_time_iso: '2020-07-09T15:15:03.000Z',
       coinbase_payload: { data: '0x636f696e62617365206869' },
       events: [],
     };
     expect(JSON.parse(searchResult3.text)).toEqual(expectedResp3);
 
     await db.dropMempoolTxs({
-      status: DbTxStatus.DroppedStaleGarbageCollect,
-      txIds: [mempoolTx1.tx_id],
+      status: DbTxStatus.DroppedTooExpensive,
+      txIds: [mempoolTx4.tx_id],
     });
-    const searchResult4 = await supertest(api.server).get(`/extended/v1/tx/${mempoolTx1.tx_id}`);
+    const searchResult4 = await supertest(api.server).get(`/extended/v1/tx/${mempoolTx4.tx_id}`);
     expect(searchResult4.status).toBe(200);
     expect(searchResult4.type).toBe('application/json');
     const expectedResp4 = {
-      tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
+      tx_id: '0x8912000000000000000000000000000000000000000000000000000000000004',
+      tx_status: 'dropped_too_expensive',
+      tx_type: 'coinbase',
+      fee_rate: '1234',
+      nonce: 0,
+      sender_address: 'sender-addr',
+      sponsor_address: 'sponsor-addr',
+      sponsored: true,
+      post_condition_mode: 'allow',
+      receipt_time: 1594307704,
+      receipt_time_iso: '2020-07-09T15:15:04.000Z',
+      coinbase_payload: { data: '0x636f696e62617365206869' },
+      events: [],
+    };
+    expect(JSON.parse(searchResult4.text)).toEqual(expectedResp4);
+
+    await db.dropMempoolTxs({
+      status: DbTxStatus.DroppedStaleGarbageCollect,
+      txIds: [mempoolTx5.tx_id],
+    });
+    const searchResult5 = await supertest(api.server).get(`/extended/v1/tx/${mempoolTx5.tx_id}`);
+    expect(searchResult5.status).toBe(200);
+    expect(searchResult5.type).toBe('application/json');
+    const expectedResp5 = {
+      tx_id: '0x8912000000000000000000000000000000000000000000000000000000000005',
       tx_status: 'dropped_stale_garbage_collect',
       tx_type: 'coinbase',
       fee_rate: '1234',
@@ -547,12 +584,111 @@ describe('api tests', () => {
       sponsor_address: 'sponsor-addr',
       sponsored: true,
       post_condition_mode: 'allow',
-      receipt_time: 1594307695,
-      receipt_time_iso: '2020-07-09T15:14:55.000Z',
+      receipt_time: 1594307705,
+      receipt_time_iso: '2020-07-09T15:15:05.000Z',
       coinbase_payload: { data: '0x636f696e62617365206869' },
       events: [],
     };
-    expect(JSON.parse(searchResult4.text)).toEqual(expectedResp4);
+    expect(JSON.parse(searchResult5.text)).toEqual(expectedResp5);
+
+    const mempoolDroppedResult1 = await supertest(api.server).get(
+      '/extended/v1/tx/mempool/dropped'
+    );
+    expect(mempoolDroppedResult1.status).toBe(200);
+    expect(mempoolDroppedResult1.type).toBe('application/json');
+    expect(mempoolDroppedResult1.body).toEqual(
+      expect.objectContaining({
+        results: expect.arrayContaining([
+          expect.objectContaining({
+            tx_id: '0x8912000000000000000000000000000000000000000000000000000000000005',
+            tx_status: 'dropped_stale_garbage_collect',
+          }),
+          expect.objectContaining({
+            tx_id: '0x8912000000000000000000000000000000000000000000000000000000000004',
+            tx_status: 'dropped_too_expensive',
+          }),
+          expect.objectContaining({
+            tx_id: '0x8912000000000000000000000000000000000000000000000000000000000003',
+            tx_status: 'dropped_replace_by_fee',
+          }),
+          expect.objectContaining({
+            tx_id: '0x8912000000000000000000000000000000000000000000000000000000000001',
+            tx_status: 'dropped_replace_across_fork',
+          }),
+          expect.objectContaining({
+            tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
+            tx_status: 'dropped_replace_across_fork',
+          }),
+        ]),
+      })
+    );
+
+    const dbBlock1: DbBlock = {
+      block_hash: '0x0123',
+      index_block_hash: '0x1234',
+      parent_index_block_hash: '0x00',
+      parent_block_hash: '0x5678',
+      parent_microblock: '0x0987',
+      block_height: 1,
+      burn_block_time: 39486,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
+      canonical: false,
+    };
+    const dbTx1: DbTx = {
+      ...mempoolTx1,
+      ...dbBlock1,
+      tx_index: 4,
+      status: DbTxStatus.Success,
+      raw_result: '0x0100000000000000000000000000000001', // u1
+      canonical: true,
+    };
+    const dataStoreUpdate1: DataStoreUpdateData = {
+      block: dbBlock1,
+      minerRewards: [],
+      txs: [
+        {
+          tx: dbTx1,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          smartContracts: [],
+        },
+      ],
+    };
+    await db.update(dataStoreUpdate1);
+
+    const mempoolDroppedResult2 = await supertest(api.server).get(
+      '/extended/v1/tx/mempool/dropped'
+    );
+    expect(mempoolDroppedResult2.status).toBe(200);
+    expect(mempoolDroppedResult2.type).toBe('application/json');
+    expect(mempoolDroppedResult2.body.results).toHaveLength(4);
+    expect(mempoolDroppedResult2.body).toEqual(
+      expect.objectContaining({
+        results: expect.arrayContaining([
+          expect.objectContaining({
+            tx_id: '0x8912000000000000000000000000000000000000000000000000000000000005',
+            tx_status: 'dropped_stale_garbage_collect',
+          }),
+          expect.objectContaining({
+            tx_id: '0x8912000000000000000000000000000000000000000000000000000000000004',
+            tx_status: 'dropped_too_expensive',
+          }),
+          expect.objectContaining({
+            tx_id: '0x8912000000000000000000000000000000000000000000000000000000000003',
+            tx_status: 'dropped_replace_by_fee',
+          }),
+          expect.objectContaining({
+            tx_id: '0x8912000000000000000000000000000000000000000000000000000000000001',
+            tx_status: 'dropped_replace_across_fork',
+          }),
+        ]),
+      })
+    );
   });
 
   test('fetch mempool-tx list', async () => {

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -505,6 +505,54 @@ describe('api tests', () => {
       events: [],
     };
     expect(JSON.parse(searchResult2.text)).toEqual(expectedResp2);
+
+    await db.dropMempoolTxs({
+      status: DbTxStatus.DroppedReplaceByFee,
+      txIds: [mempoolTx1.tx_id],
+    });
+    const searchResult3 = await supertest(api.server).get(`/extended/v1/tx/${mempoolTx1.tx_id}`);
+    expect(searchResult3.status).toBe(200);
+    expect(searchResult3.type).toBe('application/json');
+    const expectedResp3 = {
+      tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
+      tx_status: 'dropped_replace_by_fee',
+      tx_type: 'coinbase',
+      fee_rate: '1234',
+      nonce: 0,
+      sender_address: 'sender-addr',
+      sponsor_address: 'sponsor-addr',
+      sponsored: true,
+      post_condition_mode: 'allow',
+      receipt_time: 1594307695,
+      receipt_time_iso: '2020-07-09T15:14:55.000Z',
+      coinbase_payload: { data: '0x636f696e62617365206869' },
+      events: [],
+    };
+    expect(JSON.parse(searchResult3.text)).toEqual(expectedResp3);
+
+    await db.dropMempoolTxs({
+      status: DbTxStatus.DroppedStaleGarbageCollect,
+      txIds: [mempoolTx1.tx_id],
+    });
+    const searchResult4 = await supertest(api.server).get(`/extended/v1/tx/${mempoolTx1.tx_id}`);
+    expect(searchResult4.status).toBe(200);
+    expect(searchResult4.type).toBe('application/json');
+    const expectedResp4 = {
+      tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
+      tx_status: 'dropped_stale_garbage_collect',
+      tx_type: 'coinbase',
+      fee_rate: '1234',
+      nonce: 0,
+      sender_address: 'sender-addr',
+      sponsor_address: 'sponsor-addr',
+      sponsored: true,
+      post_condition_mode: 'allow',
+      receipt_time: 1594307695,
+      receipt_time_iso: '2020-07-09T15:14:55.000Z',
+      coinbase_payload: { data: '0x636f696e62617365206869' },
+      events: [],
+    };
+    expect(JSON.parse(searchResult4.text)).toEqual(expectedResp4);
   });
 
   test('fetch mempool-tx list', async () => {

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -2086,7 +2086,7 @@ describe('postgres datastore', () => {
     };
 
     await db.updateMempoolTxs({ mempoolTxs: [tx1Mempool] });
-    const txQuery1 = await db.getMempoolTx(tx1Mempool.tx_id);
+    const txQuery1 = await db.getMempoolTx({ txId: tx1Mempool.tx_id });
     expect(txQuery1.found).toBe(true);
     expect(txQuery1?.result?.status).toBe(DbTxStatus.Pending);
     expect(txQuery1?.result?.raw_tx.toString('hex')).toBe(
@@ -2118,7 +2118,7 @@ describe('postgres datastore', () => {
     });
 
     // tx should still be in mempool since it was included in a non-canonical chain-tip
-    const txQuery2 = await db.getMempoolTx(tx1Mempool.tx_id);
+    const txQuery2 = await db.getMempoolTx({ txId: tx1Mempool.tx_id });
     expect(txQuery2.found).toBe(true);
     expect(txQuery2?.result?.status).toBe(DbTxStatus.Pending);
 
@@ -2129,7 +2129,7 @@ describe('postgres datastore', () => {
     });
 
     // the fork containing this tx was made canonical, it should no longer be in the mempool
-    const txQuery3 = await db.getMempoolTx(tx1Mempool.tx_id);
+    const txQuery3 = await db.getMempoolTx({ txId: tx1Mempool.tx_id });
     expect(txQuery3.found).toBe(false);
 
     // the tx should be in the mined tx table, marked as canonical and success status
@@ -2157,7 +2157,7 @@ describe('postgres datastore', () => {
     expect(txQuery5?.result?.canonical).toBe(false);
 
     // the fork containing this tx was made canonical again, it should now in the mempool
-    const txQuery6 = await db.getMempoolTx(tx1Mempool.tx_id);
+    const txQuery6 = await db.getMempoolTx({ txId: tx1Mempool.tx_id });
     expect(txQuery6.found).toBe(true);
     expect(txQuery6?.result?.status).toBe(DbTxStatus.Pending);
 
@@ -2179,7 +2179,7 @@ describe('postgres datastore', () => {
     });
 
     // tx should no longer be in the mempool after being mined
-    const txQuery7 = await db.getMempoolTx(tx1b.tx_id);
+    const txQuery7 = await db.getMempoolTx({ txId: tx1b.tx_id });
     expect(txQuery7.found).toBe(false);
 
     // tx should be back in the mined tx table and associated with the new block

--- a/src/tests/pagination-tests.ts
+++ b/src/tests/pagination-tests.ts
@@ -1,4 +1,4 @@
-import { parsePagingQueryInput, parseLimitQuery } from '../../api/pagination';
+import { parsePagingQueryInput, parseLimitQuery } from '../api/pagination';
 
 describe('parsePagingQueryInput()', () => {
   test('it returns same input when passed number', () => {

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -18,6 +18,7 @@ export default async (): Promise<void> => {
       handleBlockMessage: () => {},
       handleBurnBlock: () => {},
       handleMempoolTxs: () => {},
+      handleDroppedMempoolTxs: () => {},
     },
   });
   Object.assign(global, { server: server });

--- a/src/tests/websocket-tests.ts
+++ b/src/tests/websocket-tests.ts
@@ -25,6 +25,7 @@ import {
   RpcAddressBalanceSubscriptionParams,
   RpcAddressBalanceNotificationParams,
   TransactionStatus,
+  MempoolTransactionStatus,
 } from '@blockstack/stacks-blockchain-api-types';
 import { connectWebSocketClient } from '@stacks/blockchain-api-client';
 import { ChainID } from '@stacks/transactions';
@@ -139,7 +140,11 @@ describe('websocket notifications', () => {
 
       // watch for update to this tx
       let updateIndex = 0;
-      const txUpdates: Waiter<TransactionStatus>[] = [waiter(), waiter(), waiter()];
+      const txUpdates: Waiter<TransactionStatus | MempoolTransactionStatus>[] = [
+        waiter(),
+        waiter(),
+        waiter(),
+      ];
       client.onNotification.push(msg => {
         if (msg.method === 'tx_update') {
           const txUpdate: RpcTxUpdateNotificationParams = msg.params;


### PR DESCRIPTION
Implements the dropped mempool tx event handling from https://github.com/blockstack/stacks-blockchain/pull/2479

Likely fixes https://github.com/blockstack/stacks-blockchain-api/issues/458

Transactions that previously were stuck at `tx_status: pending` or (in rare cases) `canonical: false`, can now return more accurate `dropped` statuses:

```ts
interface MempoolTxResponse {
  /** Replaced by a transaction with the same nonce, but a higher fee. */
  tx_status: 'dropped_replace_by_fee';
  /** Replaced by a transaction with the same nonce but in the canonical fork. */
  tx_status: 'dropped_replace_across_fork';
  /** The transaction is too expensive to include in a block. */
  tx_status: 'dropped_too_expensive';
  /** Transaction was dropped because it became stale. */
  tx_status: 'dropped_stale_garbage_collect';
}
```

Note that dropped mempool transactions will not be included in the `/extended/v1/tx/mempool` endpoint. A new endpoint is provided to retrieve dropped transactions -- the primary use-case for this endpoint is currently for diagnostic purpose:

#### `GET /extended/v1/tx/mempool/dropped`

```json
{
  "limit": 96,
  "offset": 0,
  "total": 5,
  "results": [
    {
      "tx_id": "0x8912000000000000000000000000000000000000000000000000000000000005",
      "tx_status": "dropped_stale_garbage_collect",
      "tx_type": "coinbase",
      "receipt_time": 1594307705,
      "receipt_time_iso": "2020-07-09T15:15:05.000Z",
      "nonce": 0,
      "fee_rate": "1234",
      "sender_address": "sender-addr",
      "sponsored": true,
      "sponsor_address": "sponsor-addr",
      "post_condition_mode": "allow",
      "coinbase_payload": {
        "data": "0x636f696e62617365206869"
      }
    },
    {
      "tx_id": "0x8912000000000000000000000000000000000000000000000000000000000004",
      "tx_status": "dropped_too_expensive",
      "tx_type": "coinbase",
      "receipt_time": 1594307704,
      "receipt_time_iso": "2020-07-09T15:15:04.000Z",
      "nonce": 0,
      "fee_rate": "1234",
      "sender_address": "sender-addr",
      "sponsored": true,
      "sponsor_address": "sponsor-addr",
      "post_condition_mode": "allow",
      "coinbase_payload": {
        "data": "0x636f696e62617365206869"
      }
    },
    {
      "tx_id": "0x8912000000000000000000000000000000000000000000000000000000000003",
      "tx_status": "dropped_replace_by_fee",
      "tx_type": "coinbase",
      "receipt_time": 1594307703,
      "receipt_time_iso": "2020-07-09T15:15:03.000Z",
      "nonce": 0,
      "fee_rate": "1234",
      "sender_address": "sender-addr",
      "sponsored": true,
      "sponsor_address": "sponsor-addr",
      "post_condition_mode": "allow",
      "coinbase_payload": {
        "data": "0x636f696e62617365206869"
      }
    },
    {
      "tx_id": "0x8912000000000000000000000000000000000000000000000000000000000001",
      "tx_status": "dropped_replace_across_fork",
      "tx_type": "coinbase",
      "receipt_time": 1594307702,
      "receipt_time_iso": "2020-07-09T15:15:02.000Z",
      "nonce": 0,
      "fee_rate": "1234",
      "sender_address": "sender-addr",
      "sponsored": true,
      "sponsor_address": "sponsor-addr",
      "post_condition_mode": "allow",
      "coinbase_payload": {
        "data": "0x636f696e62617365206869"
      }
    },
    {
      "tx_id": "0x8912000000000000000000000000000000000000000000000000000000000000",
      "tx_status": "dropped_replace_across_fork",
      "tx_type": "coinbase",
      "receipt_time": 1594307695,
      "receipt_time_iso": "2020-07-09T15:14:55.000Z",
      "nonce": 0,
      "fee_rate": "1234",
      "sender_address": "sender-addr",
      "sponsored": true,
      "sponsor_address": "sponsor-addr",
      "post_condition_mode": "allow",
      "coinbase_payload": {
        "data": "0x636f696e62617365206869"
      }
    }
  ]
}
```
