### PR TITLE
Feat/reward slot holders

### DIFF
--- a/docs/api/burnchain/get-reward-slot-holders.example.json
+++ b/docs/api/burnchain/get-reward-slot-holders.example.json
@@ -1,0 +1,21 @@
+{
+  "limit": 20,
+  "offset": 0,
+  "total": 2,
+  "results": [
+    {
+        "canonical": true,
+        "burn_block_hash": "0x4eaabcd105865e471f697eff5dd5bd85d47ecb5a26a3379d74fae0ae87c40904",
+        "burn_block_height": 331,
+        "address": "1C56LYirKa3PFXFsvhSESgDy2acEHVAEt6",
+        "slot_index": 0
+    },
+    {
+      "canonical": true,
+      "burn_block_hash": "0x4eaabcd105865e471f697eff5dd5bd85d47ecb5a26a3379d74fae0ae87c40904",
+      "burn_block_height": 331,
+      "address": "1M3bvWB9CRh5BTumeVxtHDEV6W4S2R9AZw",
+      "slot_index": 0
+    }
+  ]
+}

--- a/docs/api/burnchain/get-reward-slot-holders.schema.json
+++ b/docs/api/burnchain/get-reward-slot-holders.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "GET request that returns reward slot holders",
+  "additionalProperties": false,
+  "title": "BurnchainRewardSlotHolderListResponse",
+  "type": "object",
+  "required": ["results", "limit", "offset", "total"],
+  "properties": {
+    "limit": {
+      "type": "integer",
+      "maximum": 30,
+      "description": "The number of items to return"
+    },
+    "offset": {
+      "type": "integer",
+      "description": "The number of items to skip (starting at `0`)",
+      "default": 0
+    },
+    "total": {
+      "type": "integer",
+      "description": "Total number of available items"
+    },
+    "results": {
+      "type": "array",
+      "items": {
+        "$ref": "../../entities/burnchain/reward-slot-holder.schema.json"
+      }
+    }
+  }
+}

--- a/docs/entities/burnchain/reward-slot-holder.example.json
+++ b/docs/entities/burnchain/reward-slot-holder.example.json
@@ -1,0 +1,7 @@
+{
+  "canonical": true,
+  "burn_block_hash": "0x4eaabcd105865e471f697eff5dd5bd85d47ecb5a26a3379d74fae0ae87c40904",
+  "burn_block_height": 331,
+  "address": "1C56LYirKa3PFXFsvhSESgDy2acEHVAEt6",
+  "slot_index": 0
+}

--- a/docs/entities/burnchain/reward-slot-holder.schema.json
+++ b/docs/entities/burnchain/reward-slot-holder.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "BurnchainRewardSlotHolder",
+  "description": "Reward slot holder on the burnchain",
+  "type": "object",
+  "required": ["canonical", "burn_block_hash", "burn_block_height", "address", "slot_index"],
+  "properties": {
+    "canonical": {
+      "type": "boolean",
+      "description": "Set to `true` if block corresponds to the canonical burchchain tip"
+    },
+    "burn_block_hash": {
+      "type": "string",
+      "description": "The hash representing the burnchain block"
+    },
+    "burn_block_height": {
+      "type": "integer",
+      "description": "Height of the burnchain block"
+    },
+    "address": {
+      "type": "string",
+      "description": "The recipient address that validly received PoX commitments, in the format native to the burnchain (e.g. B58 encoded for Bitcoin)"
+    },
+    "slot_index": {
+      "type": "integer",
+      "description": "The index position of the reward entry, useful for ordering when there's more than one slot per burnchain block"
+    }
+  }
+}

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -154,6 +154,25 @@ export interface BlockListResponse {
 }
 
 /**
+ * GET request that returns reward slot holders
+ */
+export interface BurnchainRewardSlotHolderListResponse {
+  /**
+   * The number of items to return
+   */
+  limit: number;
+  /**
+   * The number of items to skip (starting at `0`)
+   */
+  offset: number;
+  /**
+   * Total number of available items
+   */
+  total: number;
+  results: BurnchainRewardSlotHolder[];
+}
+
+/**
  * GET request that returns blocks
  */
 export interface BurnchainRewardListResponse {
@@ -943,6 +962,32 @@ export interface Block {
    * List of transactions included in the block
    */
   txs: string[];
+}
+
+/**
+ * Reward slot holder on the burnchain
+ */
+export interface BurnchainRewardSlotHolder {
+  /**
+   * Set to `true` if block corresponds to the canonical burchchain tip
+   */
+  canonical: boolean;
+  /**
+   * The hash representing the burnchain block
+   */
+  burn_block_hash: string;
+  /**
+   * Height of the burnchain block
+   */
+  burn_block_height: number;
+  /**
+   * The recipient address that validly received PoX commitments, in the format native to the burnchain (e.g. B58 encoded for Bitcoin)
+   */
+  address: string;
+  /**
+   * The index position of the reward entry, useful for ordering when there's more than one slot per burnchain block
+   */
+  slot_index: number;
 }
 
 /**

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -385,6 +385,36 @@ paths:
               example:
                 $ref: ./api/errors/block-not-found.json
 
+  /extended/v1/burnchain/reward_slot_holders:
+    get:
+      summary: Get recent reward slot holders
+      description: Array of the Bitcoin addresses that would validly receive PoX commitments.
+      tags:
+        - Burnchain
+      operationId: get_burnchain_reward_slot_holders
+      parameters:
+        - name: limit
+          in: query
+          description: max number of items to fetch
+          required: false
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          description: index of the first items to fetch
+          required: false
+          schema:
+            type: integer
+      responses:
+        200:
+          description: List of burnchain reward recipients and amounts
+          content:
+            application/json:
+              schema:
+                $ref: ./api/burnchain/get-reward-slot-holders.schema.json
+              example:
+                $ref: ./api/burnchain/get-reward-slot-holders.example.json
+
   /extended/v1/burnchain/rewards:
     get:
       summary: Get recent burnchain reward recipients

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -415,6 +415,42 @@ paths:
               example:
                 $ref: ./api/burnchain/get-reward-slot-holders.example.json
 
+  /extended/v1/burnchain/reward_slot_holders/{address}:
+    get:
+      summary: Get recent reward slot holder entries for the given address
+      description: Array of the Bitcoin addresses that would validly receive PoX commitments.
+      tags:
+        - Burnchain
+      operationId: get_burnchain_reward_slot_holders_by_address
+      parameters:
+        - name: address
+          in: path
+          description: Reward slot holder recipient address. Should either be in the native burnchain's format (e.g. B58 for Bitcoin), or if a STX principal address is provided it will be encoded as into the equivalent burnchain format
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: max number of items to fetch
+          required: false
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          description: index of the first items to fetch
+          required: false
+          schema:
+            type: integer
+      responses:
+        200:
+          description: List of burnchain reward recipients and amounts
+          content:
+            application/json:
+              schema:
+                $ref: ./api/burnchain/get-reward-slot-holders.schema.json
+              example:
+                $ref: ./api/burnchain/get-reward-slot-holders.example.json
+
   /extended/v1/burnchain/rewards:
     get:
       summary: Get recent burnchain reward recipients

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -43,6 +43,14 @@ export interface DbBurnchainReward {
   reward_index: number;
 }
 
+export interface DbRewardSlotHolder {
+  canonical: boolean;
+  burn_block_hash: string;
+  burn_block_height: number;
+  address: string;
+  slot_index: number;
+}
+
 export interface DbMinerReward {
   block_hash: string;
   index_block_hash: string;
@@ -384,6 +392,18 @@ export interface DataStore extends DataStoreEventEmitter {
   getBurnchainRewardsTotal(
     burnchainRecipient: string
   ): Promise<{ reward_recipient: string; reward_amount: bigint }>;
+
+  updateBurnchainRewardSlotHolders(args: {
+    burnchainBlockHash: string;
+    burnchainBlockHeight: number;
+    slotHolders: DbRewardSlotHolder[];
+  }): Promise<void>;
+  getBurnchainRewardSlotHolders(args: {
+    /** Optionally search for slots for a given address. */
+    burnchainAddress?: string;
+    limit: number;
+    offset: number;
+  }): Promise<{ total: number; slotHolders: DbRewardSlotHolder[] }>;
 
   getStxBalance(stxAddress: string): Promise<DbStxBalance>;
   getStxBalanceAtBlock(stxAddress: string, blockHeight: number): Promise<DbStxBalance>;

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -21,6 +21,7 @@ import {
   DbInboundStxTransfer,
   DbTxStatus,
   AddressNftEventIdentifier,
+  DbRewardSlotHolder,
 } from './common';
 import { logger, FoundOrNot } from '../helpers';
 import { TransactionType } from '@blockstack/stacks-blockchain-api-types';
@@ -183,6 +184,22 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
   getBurnchainRewardsTotal(
     burnchainRecipient: string
   ): Promise<{ reward_recipient: string; reward_amount: bigint }> {
+    throw new Error('Method not implemented.');
+  }
+
+  updateBurnchainRewardSlotHolders(args: {
+    burnchainBlockHash: string;
+    burnchainBlockHeight: number;
+    slotHolders: DbRewardSlotHolder[];
+  }): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+
+  getBurnchainRewardSlotHolders(args: {
+    burnchainAddress?: string;
+    limit: number;
+    offset: number;
+  }): Promise<{ total: number; slotHolders: DbRewardSlotHolder[] }> {
     throw new Error('Method not implemented.');
   }
 

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -228,6 +228,12 @@ export interface CoreNodeBurnBlockMessage {
       amt: number;
     }
   ];
+  /**
+   * Array of the Bitcoin addresses that would validly receive PoX commitments during this block.
+   * These addresses may not actually receive rewards during this block if the block is faster
+   * than miners have an opportunity to commit.
+   */
+  reward_slot_holders: string[];
 }
 
 export type CoreNodeDropMempoolTxReasonType =

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -30,6 +30,7 @@ import {
   DbMinerReward,
   DbBurnchainReward,
   getTxDbStatus,
+  DbRewardSlotHolder,
 } from '../datastore/common';
 import { parseMessageTransactions, getTxSenderAddress, getTxSponsorAddress } from './reader';
 import { TransactionPayloadTypeID, readTransaction } from '../p2p/tx';
@@ -57,10 +58,25 @@ async function handleBurnBlockMessage(
     };
     return dbReward;
   });
+  const slotHolders = burnBlockMsg.reward_slot_holders.map((r, index) => {
+    const slotHolder: DbRewardSlotHolder = {
+      canonical: true,
+      burn_block_hash: burnBlockMsg.burn_block_hash,
+      burn_block_height: burnBlockMsg.burn_block_height,
+      address: r,
+      slot_index: index,
+    };
+    return slotHolder;
+  });
   await db.updateBurnchainRewards({
     burnchainBlockHash: burnBlockMsg.burn_block_hash,
     burnchainBlockHeight: burnBlockMsg.burn_block_height,
     rewards: rewards,
+  });
+  await db.updateBurnchainRewardSlotHolders({
+    burnchainBlockHash: burnBlockMsg.burn_block_hash,
+    burnchainBlockHeight: burnBlockMsg.burn_block_height,
+    slotHolders: slotHolders,
   });
 }
 

--- a/src/migrations/1614862087968_reward_slot_holders.ts
+++ b/src/migrations/1614862087968_reward_slot_holders.ts
@@ -1,0 +1,36 @@
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('reward_slot_holders', {
+    id: {
+      type: 'serial',
+      primaryKey: true,
+    },
+    canonical: {
+      type: 'boolean',
+      notNull: true,
+    },
+    burn_block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    burn_block_height: {
+      type: 'integer',
+      notNull: true,
+    },
+    address: {
+      type: 'string',
+      notNull: true,
+    },
+    slot_index: {
+      type: 'integer',
+      notNull: true,
+    },
+  });
+
+  pgm.createIndex('reward_slot_holders', 'canonical');
+  pgm.createIndex('reward_slot_holders', 'burn_block_hash');
+  pgm.createIndex('reward_slot_holders', 'burn_block_height');
+  pgm.createIndex('reward_slot_holders', 'address');
+
+}

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -484,6 +484,48 @@ describe('api tests', () => {
     expect(JSON.parse(rewardResult.text)).toEqual(expectedResp1);
   });
 
+  test('fetch burnchain rewards for testnet STX address', async () => {
+    const testnetStxAddr = 'STDFV22FCWGHB7B5563BHXVMCSYM183PRB9DH090';
+    const testnetBtcAddr = 'mhyfanXuwsCMrixyQcCDzh28iHEdtQzZEm';
+
+    const reward1: DbBurnchainReward = {
+      canonical: true,
+      burn_block_hash: '0x1234',
+      burn_block_height: 200,
+      burn_amount: 2000n,
+      reward_recipient: testnetBtcAddr,
+      reward_amount: 900n,
+      reward_index: 0,
+    };
+    await db.updateBurnchainRewards({
+      burnchainBlockHash: reward1.burn_block_hash,
+      burnchainBlockHeight: reward1.burn_block_height,
+      rewards: [reward1],
+    });
+    const rewardResult = await supertest(api.server).get(
+      `/extended/v1/burnchain/rewards/${testnetStxAddr}`
+    );
+    expect(rewardResult.status).toBe(200);
+    expect(rewardResult.type).toBe('application/json');
+    const expectedResp1 = {
+      limit: 96,
+      offset: 0,
+      results: [
+        {
+          canonical: true,
+          burn_block_hash: '0x1234',
+          burn_block_height: 200,
+          burn_amount: '2000',
+          reward_recipient: testnetBtcAddr,
+          reward_amount: '900',
+          reward_index: 0,
+        },
+      ],
+    };
+
+    expect(JSON.parse(rewardResult.text)).toEqual(expectedResp1);
+  });
+
   test('fetch mempool-tx', async () => {
     const mempoolTx: DbMempoolTx = {
       pruned: false,

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -129,6 +129,93 @@ describe('api tests', () => {
     expect(JSON.parse(result.text)).toEqual(expectedResp1);
   });
 
+  test('fetch reward slot holder entries for BTC address', async () => {
+    const slotHolder1: DbRewardSlotHolder = {
+      canonical: true,
+      burn_block_hash: '0x1234',
+      burn_block_height: 2,
+      address: '1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ',
+      slot_index: 0,
+    };
+    const slotHolder2: DbRewardSlotHolder = {
+      canonical: true,
+      burn_block_hash: '0x1234',
+      burn_block_height: 2,
+      address: '1DDUAqoyXvhF4cxznN9uL6j9ok1oncsT2z',
+      slot_index: 1,
+    };
+    await db.updateBurnchainRewardSlotHolders({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 2,
+      slotHolders: [slotHolder1, slotHolder2],
+    });
+    const result = await supertest(api.server).get(
+      `/extended/v1/burnchain/reward_slot_holders/${slotHolder1.address}`
+    );
+    expect(result.status).toBe(200);
+    expect(result.type).toBe('application/json');
+    const expectedResp1 = {
+      limit: 96,
+      offset: 0,
+      total: 1,
+      results: [
+        {
+          canonical: true,
+          burn_block_hash: '0x1234',
+          burn_block_height: 2,
+          address: '1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ',
+          slot_index: 0,
+        },
+      ],
+    };
+    expect(JSON.parse(result.text)).toEqual(expectedResp1);
+  });
+
+  test('fetch reward slot holder entries for mainnet STX address', async () => {
+    const mainnetStxAddr = 'SP2JKEZC09WVMR33NBSCWQAJC5GS590RP1FR9CK55';
+    const mainnetBtcAddr = '1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ';
+
+    const slotHolder1: DbRewardSlotHolder = {
+      canonical: true,
+      burn_block_hash: '0x1234',
+      burn_block_height: 2,
+      address: mainnetBtcAddr,
+      slot_index: 0,
+    };
+    const slotHolder2: DbRewardSlotHolder = {
+      canonical: true,
+      burn_block_hash: '0x1234',
+      burn_block_height: 2,
+      address: '1DDUAqoyXvhF4cxznN9uL6j9ok1oncsT2z',
+      slot_index: 1,
+    };
+    await db.updateBurnchainRewardSlotHolders({
+      burnchainBlockHash: '0x1234',
+      burnchainBlockHeight: 2,
+      slotHolders: [slotHolder1, slotHolder2],
+    });
+    const result = await supertest(api.server).get(
+      `/extended/v1/burnchain/reward_slot_holders/${mainnetStxAddr}`
+    );
+    expect(result.status).toBe(200);
+    expect(result.type).toBe('application/json');
+    const expectedResp1 = {
+      limit: 96,
+      offset: 0,
+      total: 1,
+      results: [
+        {
+          canonical: true,
+          burn_block_hash: '0x1234',
+          burn_block_height: 2,
+          address: '1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ',
+          slot_index: 0,
+        },
+      ],
+    };
+    expect(JSON.parse(result.text)).toEqual(expectedResp1);
+  });
+
   test('fetch burnchain rewards', async () => {
     const addr1 = '1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ';
     const addr2 = '1DDUAqoyXvhF4cxznN9uL6j9ok1oncsT2z';
@@ -295,7 +382,7 @@ describe('api tests', () => {
     expect(rewardResult.status).toBe(200);
     expect(rewardResult.type).toBe('application/json');
     const expectedResp1 = {
-      limit: 20,
+      limit: 96,
       offset: 0,
       results: [
         {
@@ -337,7 +424,7 @@ describe('api tests', () => {
     expect(rewardResult.status).toBe(200);
     expect(rewardResult.type).toBe('application/json');
     const expectedResp1 = {
-      limit: 20,
+      limit: 96,
       offset: 0,
       results: [
         {
@@ -379,7 +466,7 @@ describe('api tests', () => {
     expect(rewardResult.status).toBe(200);
     expect(rewardResult.type).toBe('application/json');
     const expectedResp1 = {
-      limit: 20,
+      limit: 96,
       offset: 0,
       results: [
         {


### PR DESCRIPTION
Implements PoX reward slot holder handling from https://github.com/blockstack/stacks-blockchain/pull/2479

Examples:

#### `GET /extended/v1/burnchain/reward_slot_holders`
```ts
{
  limit: 96,
  offset: 0,
  total: 2,
  results: [
    {
      canonical: true,
      burn_block_hash: '0x1234',
      burn_block_height: 2,
      address: '1DDUAqoyXvhF4cxznN9uL6j9ok1oncsT2z',
      slot_index: 1,
    },
    {
      canonical: true,
      burn_block_hash: '0x1234',
      burn_block_height: 2,
      address: '1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ',
      slot_index: 0,
    },
  ],
}
```

#### `GET /extended/v1/burnchain/reward_slot_holders/1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ`
```ts
{
  limit: 96,
  offset: 0,
  total: 1,
  results: [
    {
      canonical: true,
      burn_block_hash: '0x1234',
      burn_block_height: 2,
      address: '1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ',
      slot_index: 0,
    },
  ],
}
```

#### `GET /extended/v1/burnchain/reward_slot_holders/SP2JKEZC09WVMR33NBSCWQAJC5GS590RP1FR9CK55`
Note: address is directly encoded from a STX address to a BTC address, no lookup/matching logic is performed. In other words, if STX address Y submits a stacking tx for BTC address X, then there is no logic to attempt to match STX address Y to BTC address X.
```ts
{
  limit: 96,
  offset: 0,
  total: 1,
  results: [
    {
      canonical: true,
      burn_block_hash: '0x1234',
      burn_block_height: 2,
      address: '1G4ayBXJvxZMoZpaNdZG6VyWwWq2mHpMjQ',
      slot_index: 0,
    },
  ],
}
```