### PR TITLE
chore: add gh workflow to publish gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'master'
+  workflow_dispatch:
 
 jobs:
   gh-pages:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,25 @@
+name: gh-pages
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  gh-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
+      - name: Install deps
+        run: npm install
+        working-directory: docs
+
+      - name: Generate and deploy gh-pages
+        run: npm run deploy:docs
+        working-directory: docs

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,6 +17,14 @@ jobs:
         with:
           node-version: '14.x'
 
+      - name: Install client deps
+        run: npm install
+        working-directory: client
+
+      - name: Generate client docs
+        run: npm run generate:docs
+        working-directory: client
+
       - name: Install deps
         run: npm install
         working-directory: docs


### PR DESCRIPTION
## Description

Adds a Github workflow to generate and publish gh-pages docs on each commit + merge into the `master` branch.
I haven't used this gulp library before, so I'm not sure if anything special is needed for it to work in a GH workflow, but it's placed in a separate workflow file to ensure it doesn't interfere with the standard release workflow.

Closes https://github.com/blockstack/stacks-blockchain-api/issues/297

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [X] Other

## Does this introduce a breaking change?
No

## Checklist
- [x] Tag 1 of @kyranjamie or @zone117x for review
