### PR TITLE
chore: set gh-pages commit info

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,7 @@
 name: gh-pages
+env:
+  COMMIT_USER: Hiro DevOps
+  COMMIT_EMAIL: 45208873+blockstack-devops@users.noreply.github.com
 
 on:
   push:
@@ -30,5 +33,8 @@ jobs:
         working-directory: docs
 
       - name: Generate and deploy gh-pages
-        run: npm run deploy:docs
+        run: |
+          git config --global user.email "${COMMIT_EMAIL}"
+          git config --global user.name "${COMMIT_USER}"
+          npm run deploy:docs
         working-directory: docs


### PR DESCRIPTION
## Description

Sets github user and email info when generating and committing gh-pages docs.

Addresses comment https://github.com/blockstack/stacks-blockchain-api/pull/476#issuecomment-792657387

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Checklist
- [x] `npm run test` passes
- [x] Tag 1 of @kyranjamie or @zone117x for review
