### PR TITLE
chore: fix gh pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,12 +1,10 @@
 name: gh-pages
-env:
-  COMMIT_USER: Hiro DevOps
-  COMMIT_EMAIL: 45208873+blockstack-devops@users.noreply.github.com
 
 on:
   push:
     branches:
       - 'master'
+      - 'gh-pages-workflow'
   workflow_dispatch:
 
 jobs:
@@ -33,8 +31,11 @@ jobs:
         working-directory: docs
 
       - name: Generate and deploy gh-pages
-        run: |
-          git config --global user.email "${COMMIT_EMAIL}"
-          git config --global user.name "${COMMIT_USER}"
-          npm run deploy:docs
+        run: npm run generate:types && npm run generate:docs
         working-directory: docs
+
+      - name: Publish test coverage report
+        uses: JamesIves/github-pages-deploy-action@4.0.0
+        with:
+          branch: gh-pages
+          folder: docs/.tmp

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'master'
-      - 'gh-pages-workflow'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

Fixes github auth issue from [here](https://github.com/blockstack/stacks-blockchain-api/runs/2057412650?check_suite_focus=true#step:7:36) when pushing up gh-pages docs. I had to abandon using Gulp to deploy the docs because it's doing something weird and causing authentication problems where there shouldn't be any.

This solution generates the types and docs the same way it was being created previously, but uses a different method of publishing to the `gh-pages` branch.

Tested and working: https://github.com/blockstack/stacks-blockchain-api/tree/gh-pages

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Checklist
- [x] Tag 1 of @kyranjamie or @zone117x for review
