### PR TITLE
fix: do not store aborted events

### DIFF
--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -22,6 +22,7 @@ export interface CoreNodeEventBase {
   /** 0x-prefix transaction hash. */
   txid: string;
   event_index: number;
+  committed: boolean;
 }
 
 export interface SmartContractEvent extends CoreNodeEventBase {

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -192,6 +192,10 @@ async function handleClientMessage(
   }
 
   for (const event of parsedMsg.events) {
+    if (!event.committed) {
+      logger.verbose(`Ignoring uncommitted tx event from tx ${event.txid}`);
+      continue;
+    }
     const dbTx = dbData.txs.find(entry => entry.tx.tx_id === event.txid);
     if (!dbTx) {
       throw new Error(`Unexpected missing tx during event parsing by tx_id ${event.txid}`);


### PR DESCRIPTION
Fixes https://github.com/blockstack/stacks-blockchain-api/issues/390

Events marked non-committed (i.e. their transaction was aborted) are no longer stored in the tables used to lookup balances. 

~~Also maybe https://github.com/blockstack/stacks-blockchain-api/issues/468 -- need to still test on mainnet.~~ EDIT: not a fix for this one