### PR TITLE
fix: correct post-condition code string

### DIFF
--- a/src/api/serializers/post-conditions.ts
+++ b/src/api/serializers/post-conditions.ts
@@ -114,10 +114,10 @@ export function serializePostCondition(pc: TransactionPostCondition): PostCondit
 
 const fungibleConditionCodeMap = {
   [FungibleConditionCode.SentEq]: 'sent_equal_to',
-  [FungibleConditionCode.SentGe]: 'sent_greater_than',
-  [FungibleConditionCode.SentGt]: 'sent_greater_than_or_equal_to',
-  [FungibleConditionCode.SentLe]: 'sent_less_than',
-  [FungibleConditionCode.SentLt]: 'sent_less_than_or_equal_to',
+  [FungibleConditionCode.SentGt]: 'sent_greater_than',
+  [FungibleConditionCode.SentGe]: 'sent_greater_than_or_equal_to',
+  [FungibleConditionCode.SentLt]: 'sent_less_than',
+  [FungibleConditionCode.SentLe]: 'sent_less_than_or_equal_to',
 } as const;
 
 export function serializeFungibleConditionCode(

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -2429,7 +2429,7 @@ describe('api tests', () => {
         },
         {
           type: 'fungible',
-          condition_code: 'sent_greater_than',
+          condition_code: 'sent_greater_than_or_equal_to',
           amount: '123456',
           principal: {
             type_id: 'principal_standard',
@@ -2443,7 +2443,7 @@ describe('api tests', () => {
         },
         {
           type: 'stx',
-          condition_code: 'sent_less_than',
+          condition_code: 'sent_less_than_or_equal_to',
           amount: '36723458',
           principal: {
             type_id: 'principal_standard',


### PR DESCRIPTION
Fixes https://github.com/blockstack/stacks-blockchain-api/issues/486

Fixes the bug seen here:
![image](https://user-images.githubusercontent.com/1447546/110822616-88af7100-8291-11eb-967a-7a2f6b2ec196.png)
![image](https://user-images.githubusercontent.com/1447546/110822637-8cdb8e80-8291-11eb-88ad-592bd6118610.png)

Ge => greater than or equal
Le => less than or equal

/ht @kantai, @aulneau, @jasperjansz 