### PR TITLE
Condense all v2 routes into a single prom metric bucket

### DIFF
--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -169,6 +169,22 @@ export async function startApiServer(datastore: DataStore, chainId: ChainID): Pr
 
   // Manual route definitions for the /v2/ proxied endpoints
   routes.push({
+    path: '/v2/pox',
+    regexp: /^\/v2\/pox(.*)/,
+  });
+  routes.push({
+    path: '/v2/info',
+    regexp: /^\/v2\/info(.*)/,
+  });
+  routes.push({
+    path: '/v2/contracts/call-read',
+    regexp: /^\/v2\/contracts\/call-read(.*)/,
+  });
+  routes.push({
+    path: '/v2/map_entry',
+    regexp: /^\/v2\/map_entry(.*)/,
+  });
+  routes.push({
     path: '/v2/*',
     regexp: /^\/v2(.*)/,
   });

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -167,6 +167,12 @@ export async function startApiServer(datastore: DataStore, chainId: ChainID): Pr
     regexp: pathToRegex.pathToRegexp(endpoint.path),
   }));
 
+  // Manual route definitions for the /v2/ proxied endpoints
+  routes.push({
+    path: '/v2/*',
+    regexp: /^\/v2(.*)/,
+  });
+
   const server = createServer(app);
 
   const serverSockets = new Set<Socket>();

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -177,6 +177,10 @@ export async function startApiServer(datastore: DataStore, chainId: ChainID): Pr
     regexp: /^\/v2\/info(.*)/,
   });
   routes.push({
+    path: '/v2/accounts/*',
+    regexp: /^\/v2\/accounts(.*)/,
+  });
+  routes.push({
     path: '/v2/contracts/call-read/*',
     regexp: /^\/v2\/contracts\/call-read(.*)/,
   });

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -177,11 +177,11 @@ export async function startApiServer(datastore: DataStore, chainId: ChainID): Pr
     regexp: /^\/v2\/info(.*)/,
   });
   routes.push({
-    path: '/v2/contracts/call-read',
+    path: '/v2/contracts/call-read/*',
     regexp: /^\/v2\/contracts\/call-read(.*)/,
   });
   routes.push({
-    path: '/v2/map_entry',
+    path: '/v2/map_entry/*',
     regexp: /^\/v2\/map_entry(.*)/,
   });
   routes.push({


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/403

Make all `v2/*` routes report as a single metric. 