### PR TITLE
fix: handle transient postgres connection errors #497

### DIFF
--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -345,6 +345,9 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         if (error.code === 'ECONNREFUSED') {
           logger.warn(`Postgres connection ECONNREFUSED, will retry, attempt #${retryAttempts}`);
           await timeout(1000);
+        } else if (error.code === 'ETIMEDOUT') {
+          logger.warn(`Postgres connection ETIMEDOUT, will retry, attempt #${retryAttempts}`);
+          await timeout(1000);
         } else if (error.message === 'the database system is starting up') {
           logger.warn(
             `Postgres connection failed while database system is restarting, will retry, attempt #${retryAttempts}`


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/497

Transient pg connection errors are not handled by the postgres lib's connection pool. This is somewhat unexpected, see https://github.com/brianc/node-postgres/issues/1789.

This PR adds connection try/catch retry logic for the errors that occur when the postgres service is restarting.