### PR TITLE
fix: use common clarity value type in NFTEvent

### DIFF
--- a/docs/api/address/get-address-nft-events.example.json
+++ b/docs/api/address/get-address-nft-events.example.json
@@ -7,7 +7,7 @@
       "sender": "none",
       "recipient": "ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4",
       "asset_identifier": "some-asset",
-      "value": "0x00"
-    } 
+      "value": { "hex": "0x00", "repr": "0" }
+    }
   ]
 }

--- a/docs/entities/nft-events/nft-event.schema.json
+++ b/docs/entities/nft-events/nft-event.schema.json
@@ -9,7 +9,6 @@
     "value",
     "tx_id",
     "block_height",
-    "value_repr"
   ],
   "properties": {
     "sender": {
@@ -22,16 +21,26 @@
       "type": "string"
     },
     "value": {
-      "type": "string"
+      "type": "object",
+      "required": ["hex", "repr"],
+      "description": "Identifier of the NFT",
+      "additionalProperties": false,
+      "properties": {
+        "hex": {
+          "type": "string",
+          "description": "Hex string representing the identifier of the NFT"
+        },
+        "repr": {
+          "type": "string",
+          "description": "Readable string of the NFT identifier"
+        }
+      }
     },
     "tx_id": {
       "type": "string"
     },
     "block_height": {
       "type": "number"
-    },
-    "value_repr": {
-      "type": "string"
     }
   }
 }

--- a/docs/entities/nft-events/nft-event.schema.json
+++ b/docs/entities/nft-events/nft-event.schema.json
@@ -8,7 +8,7 @@
     "asset_identifier",
     "value",
     "tx_id",
-    "block_height",
+    "block_height"
   ],
   "properties": {
     "sender": {

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -1254,10 +1254,9 @@ export interface NftEvent {
   sender: string;
   recipient: string;
   asset_identifier: string;
-  value: string;
+  value: { hex: string; repr: string };
   tx_id: string;
   block_height: number;
-  value_repr: string;
 }
 
 export interface PostConditionStx {

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -255,10 +255,12 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
       sender: row.sender,
       recipient: row.recipient,
       asset_identifier: row.asset_identifier,
-      value: bufferToHexPrefixString(row.value),
+      value: {
+        hex: bufferToHexPrefixString(row.value),
+        repr: cvToString(deserializeCV(row.value)),
+      },
       tx_id: bufferToHexPrefixString(row.tx_id),
       block_height: row.block_height,
-      value_repr: cvToString(deserializeCV(row.value)),
     }));
     const nftListResponse: AddressNftListResponse = {
       nft_events: nft_events,

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -2802,7 +2802,7 @@ describe('api tests', () => {
       '0x1111000000000000000000000000000000000000000000000000000000000000'
     );
     expect(result.body.nft_events[0].block_height).toBe(1);
-    expect(result.body.nft_events[0].value_repr).toBe('0');
+    expect(result.body.nft_events[0].value.repr).toBe('0');
 
     const stxTx1: DbTx = {
       tx_id: '0x1111100000000000000000000000000000000000000000000000000000000000',
@@ -2853,7 +2853,7 @@ describe('api tests', () => {
       '0x1111100000000000000000000000000000000000000000000000000000000000'
     );
     expect(result1.body.nft_events[0].block_height).toBe(2);
-    expect(result.body.nft_events[0].value_repr).toBe('0');
+    expect(result.body.nft_events[0].value.repr).toBe('0');
 
     //check ownership for addr
     const result2 = await supertest(api.server).get(`/extended/v1/address/${addr1}/nft_events`);


### PR DESCRIPTION
## Description
This PR 
* replaces the `value` and `value_repr` properties of `NFTEvent` by the common clarity value type `{hex:string, repr: string}`
* towards #506 

Another update for `value` and `asset_identifier` should follow (#432).

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
As this feature was only introduce a day ago, it is still new enough.

## Are documentation updates required?
Self-documenting

- [x] Tag 1 of @kyranjamie or @zone117x for review
