### PR TITLE
Provide ability to fetch information for a pending contract

### DIFF
--- a/src/api/routes/search.ts
+++ b/src/api/routes/search.ts
@@ -162,6 +162,7 @@ export function createSearchRouter(db: DataStore): RouterWithAsync {
                 burn_block_time: txData.burn_block_time,
                 block_height: txData.block_height,
                 tx_type: getTxTypeString(txData.type_id),
+                tx_id: txData.tx_id,
               },
             };
             return { found: true, result: contractResult };
@@ -173,6 +174,7 @@ export function createSearchRouter(db: DataStore): RouterWithAsync {
               entity_type: entityType,
               tx_data: {
                 tx_type: getTxTypeString(txData.type_id),
+                tx_id: txData.tx_id,
               },
             };
             return { found: true, result: contractResult };

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -1456,6 +1456,7 @@ describe('api tests', () => {
           burn_block_time: 2837565,
           block_height: 1,
           tx_type: 'smart_contract',
+          tx_id: '0x1111880000000000000000000000000000000000000000000000000000000000',
         },
       },
     };
@@ -1488,7 +1489,10 @@ describe('api tests', () => {
       result: {
         entity_id: 'STSPS4JYDEYCPPCSHE3MM2NCEGR07KPBETNEZCBQ.contract-name',
         entity_type: 'contract_address',
-        tx_data: { tx_type: 'smart_contract' },
+        tx_data: {
+          tx_type: 'smart_contract',
+          tx_id: '0x1111882200000000000000000000000000000000000000000000000000000000',
+        },
       },
     };
     expect(JSON.parse(searchResult10.text)).toEqual(expectedResp10);


### PR DESCRIPTION

## Description
This PR provides transaction information for pending contract transactions. For consistency, I have added `tx_id` in the search result endpoint for contract_address for both pending and confirmed transactions. 
For details see:  #378 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review
