### PR TITLE
Fix: subdomain zone file

### DIFF
--- a/src/bns-helpers.ts
+++ b/src/bns-helpers.ts
@@ -24,6 +24,7 @@ import { StacksCoreRpcClient, getCoreNodeEndpoint } from './core-rpc/client';
 import { StacksMainnet, StacksTestnet } from '@stacks/network';
 import { URIType } from 'zone-file/dist/zoneFile';
 import { BnsContractIdentifier } from './bns-constants';
+import * as crypto from 'crypto';
 
 export interface Attachment {
   attachment: {
@@ -177,6 +178,7 @@ export interface ZoneFileTXT {
   seqn: string;
   parts: string;
   zoneFile: string;
+  zoneFileHash: string;
 }
 
 export function parseZoneFileTxt(txtEntries: string | string[]) {
@@ -186,6 +188,7 @@ export function parseZoneFileTxt(txtEntries: string | string[]) {
     seqn: '',
     parts: '',
     zoneFile: '',
+    zoneFileHash: '',
   };
 
   let zoneFile = '';
@@ -202,6 +205,14 @@ export function parseZoneFileTxt(txtEntries: string | string[]) {
     }
   }
   parsed.zoneFile = Buffer.from(zoneFile, 'base64').toString('ascii');
+  parsed.zoneFileHash =
+    '0x' +
+    crypto
+      .createHash('sha256')
+      .update(Buffer.from(zoneFile, 'base64'))
+      .digest()
+      .slice(16)
+      .toString('hex');
   return parsed;
 }
 

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -625,13 +625,13 @@ export async function startEventServer(opts: {
                   unresolvedSubdomain.result.name
                 ),
                 owner: parsedTxt.owner,
-                zonefile_hash: unresolvedSubdomain.result.zonefile_hash,
-                zonefile: attachment.content,
+                zonefile_hash: parsedTxt.zoneFileHash,
+                zonefile: parsedTxt.zoneFile,
                 latest: true,
                 tx_id: unresolvedSubdomain.result.tx_id,
                 index_block_hash: unresolvedSubdomain.result.index_block_hash,
                 canonical: unresolvedSubdomain.result.canonical,
-                parent_zonefile_hash: parsedTxt.zoneFile,
+                parent_zonefile_hash: unresolvedSubdomain.result.zonefile_hash,
                 parent_zonefile_index: 0, //TODO need to figure out this field
                 block_height: unresolvedSubdomain.result.block_height,
                 zonefile_offset: 1,


### PR DESCRIPTION
Use the following template to create your pull request

## Description
This PR fixes the improper zone file issue for subdomains.
The subdomain https://stacks-node-api.testnet.stacks.co/v1/names/second_test.test-registrar.id returns zone file for the name instead of subdomain. This PR extracts subdomain zonefile from parent `zonefile` and save only that in subdomains table. 
For details refer to issue #520 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review
