### PR TITLE
fix: use `suggested_fee` info in rosetta

### DIFF
--- a/docs/entities/rosetta/rosetta-construction-options.schema.json
+++ b/docs/entities/rosetta/rosetta-construction-options.schema.json
@@ -23,7 +23,7 @@
     },
     "amount": {
       "type": "string",
-      "description": "Amount to be transfeered."
+      "description": "Amount to be transfered."
     },
     "symbol": {
       "type": "string",
@@ -52,6 +52,10 @@
     "fee": {
       "type": "string",
       "description": "Fee for this transaction"
+    },
+    "size": {
+      "type": "number",
+      "description": "Transaction approximative size (used to calculate total fee)."
     }
   }
 }

--- a/docs/entities/rosetta/rosetta-construction-options.schema.json
+++ b/docs/entities/rosetta/rosetta-construction-options.schema.json
@@ -54,7 +54,7 @@
       "description": "Fee for this transaction"
     },
     "size": {
-      "type": "number",
+      "type": "integer",
       "description": "Transaction approximative size (used to calculate total fee)."
     }
   }

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -1254,7 +1254,19 @@ export interface NftEvent {
   sender: string;
   recipient: string;
   asset_identifier: string;
-  value: { hex: string; repr: string };
+  /**
+   * Identifier of the NFT
+   */
+  value: {
+    /**
+     * Hex string representing the identifier of the NFT
+     */
+    hex: string;
+    /**
+     * Readable string of the NFT identifier
+     */
+    repr: string;
+  };
   tx_id: string;
   block_height: number;
 }
@@ -1520,7 +1532,7 @@ export interface RosettaOptions {
    */
   token_transfer_recipient_address?: string;
   /**
-   * Amount to be transfeered.
+   * Amount to be transfered.
    */
   amount?: string;
   /**
@@ -1551,6 +1563,10 @@ export interface RosettaOptions {
    * Fee for this transaction
    */
   fee?: string;
+  /**
+   * Transaction approximative size (used to calculate total fee).
+   */
+  size?: number;
 }
 
 /**
@@ -1816,7 +1832,7 @@ export interface RosettaSignature {
  */
 export interface SigningPayload {
   /**
-   * The network-specific address of the account that should sign the payload.
+   * [DEPRECATED by account_identifier in v1.4.4] The network-specific address of the account that should sign the payload.
    */
   address?: string;
   account_identifier?: RosettaAccount;

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -100,6 +100,7 @@ export enum RosettaErrorsTypes {
   needOnePublicKey,
   needOnlyOneSignature,
   signatureTypeNotSupported,
+  missingTransactionSize,
 }
 
 // All possible errors
@@ -299,6 +300,11 @@ export const RosettaErrors: Record<RosettaErrorsTypes, RosettaError> = {
   [RosettaErrorsTypes.signatureTypeNotSupported]: {
     code: 638,
     message: 'Signature type not supported.',
+    retriable: false,
+  },
+  [RosettaErrorsTypes.missingTransactionSize]: {
+    code: 638,
+    message: 'Transaction size required to calculate total fee.',
     retriable: false,
   },
 };

--- a/src/api/routes/debug.ts
+++ b/src/api/routes/debug.ts
@@ -70,7 +70,7 @@ export const testnetKeyMap: Record<
   ])
 );
 
-export function GetStacksTestnetNetwork() {
+export function getStacksTestnetNetwork() {
   const stacksNetwork = new StacksTestnet();
   stacksNetwork.coreApiUrl = `http://${getCoreNodeEndpoint()}`;
   return stacksNetwork;
@@ -78,7 +78,7 @@ export function GetStacksTestnetNetwork() {
 
 export function createDebugRouter(db: DataStore): RouterWithAsync {
   const defaultTxFee = 12345;
-  const stacksNetwork = GetStacksTestnetNetwork();
+  const stacksNetwork = getStacksTestnetNetwork();
 
   const router = addAsync(express.Router());
   router.use(express.urlencoded({ extended: true }));

--- a/src/api/routes/faucets.ts
+++ b/src/api/routes/faucets.ts
@@ -10,12 +10,12 @@ import { StacksNetwork } from '@stacks/network';
 import { makeBtcFaucetPayment, getBtcBalance } from '../../btc-faucet';
 import { DataStore, DbFaucetRequestCurrency } from '../../datastore/common';
 import { intMax, logger, stxToMicroStx } from '../../helpers';
-import { testnetKeys, GetStacksTestnetNetwork } from './debug';
+import { testnetKeys, getStacksTestnetNetwork } from './debug';
 import { StacksCoreRpcClient } from '../../core-rpc/client';
 import { RunFaucetResponse } from '@blockstack/stacks-blockchain-api-types';
 
 export function getStxFaucetNetworks(): StacksNetwork[] {
-  const networks: StacksNetwork[] = [GetStacksTestnetNetwork()];
+  const networks: StacksNetwork[] = [getStacksTestnetNetwork()];
   const faucetNodeHostOverride: string | undefined = process.env.STACKS_FAUCET_NODE_HOST;
   if (faucetNodeHostOverride) {
     const faucetNodePortOverride: string | undefined = process.env.STACKS_FAUCET_NODE_PORT;
@@ -24,7 +24,7 @@ export function getStxFaucetNetworks(): StacksNetwork[] {
       logger.error(error);
       throw new Error(error);
     }
-    const network = GetStacksTestnetNetwork();
+    const network = getStacksTestnetNetwork();
     network.coreApiUrl = `http://${faucetNodeHostOverride}:${faucetNodePortOverride}`;
     networks.push(network);
   }

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -59,7 +59,7 @@ import {
   publicKeyToBitcoinAddress,
   rawTxToBaseTx,
   rawTxToStacksTransaction,
-  GetStacksTestnetNetwork,
+  getStacksTestnetNetwork,
   makePresignHash,
   verifySignature,
 } from './../../../rosetta-helpers';
@@ -175,7 +175,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       fee: new BN(0),
       // placeholder public key
       publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
-      network: GetStacksTestnetNetwork(),
+      network: getStacksTestnetNetwork(),
       // We don't know the non yet but need a placeholder
       nonce: new BN(0),
     };
@@ -504,7 +504,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         amount: new BN(amount),
         fee: new BN(fee),
         publicKey: publicKeys[0].hex_bytes,
-        network: GetStacksTestnetNetwork(),
+        network: getStacksTestnetNetwork(),
         nonce: nonce,
       };
     }

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -180,7 +180,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       nonce: new BN(0),
     };
 
-    const transaction = await makeUnsignedSTXTokenTransfer(tokenTransferOptions);
+    const transaction = await makeUnsignedSTXTokenTransfer(dummyTokenTransferTx);
     const unsignedTransaction = transaction.serialize();
 
     options.size = unsignedTransaction.length;

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -283,7 +283,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     };
 
     const fee: RosettaAmount = {
-      value: (+feeInfo * txSize).toString(),
+      value: (BigInt(feeInfo) * BigInt(txSize)).toString(),
       currency,
     };
 

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -118,8 +118,8 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
 
     const operations: RosettaOperation[] = req.body.operations;
 
-    // We are only supporting transfer, we should have operations length = 3
-    if (operations.length != 3) {
+    // We are only supporting transfer, we should have operations length = 2
+    if (operations.length != 2) {
       res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
       return;
     }
@@ -449,11 +449,11 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       return;
     }
 
-    const fees = options.fee;
-    if (!fees) {
+    if (!req.body.metadata || typeof req.body.metadata.fee !== 'string') {
       res.status(400).json(RosettaErrors[RosettaErrorsTypes.invalidFees]);
       return;
     }
+    const fee: string = req.body.metadata.fee;
 
     const publicKeys: RosettaPublicKey[] = req.body.public_keys;
     if (!publicKeys) {
@@ -502,7 +502,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       tokenTransferOptions = {
         recipient: recipientAddress,
         amount: new BN(amount),
-        fee: new BN(fees),
+        fee: new BN(fee),
         publicKey: publicKeys[0].hex_bytes,
         network: GetStacksTestnetNetwork(),
         nonce: nonce,
@@ -514,7 +514,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
 
     const signer = new TransactionSigner(transaction);
 
-    const prehash = makeSigHashPreSign(signer.sigHash, AuthType.Standard, new BN(fees), nonce);
+    const prehash = makeSigHashPreSign(signer.sigHash, AuthType.Standard, new BN(fee), nonce);
     const accountIdentifier: RosettaAccountIdentifier = {
       address: senderAddress,
     };

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -117,7 +117,6 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     }
 
     const operations: RosettaOperation[] = req.body.operations;
-    const tokenTransferOptions: UnsignedTokenTransferOptions;
 
     // We are only supporting transfer, we should have operations length = 3
     if (operations.length != 3) {
@@ -169,7 +168,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     }
 
     // dummy transaction to calculate size
-    tokenTransferOptions = {
+    const tokenTransferOptions: UnsignedTokenTransferOptions = {
       recipient: options.token_transfer_recipient_address as string,
       amount: new BN(options.amount as string),
       // We don't know the fee yet but need a placeholder

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -168,7 +168,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     }
 
     // dummy transaction to calculate size
-    const tokenTransferOptions: UnsignedTokenTransferOptions = {
+    const dummyTokenTransferTx: UnsignedTokenTransferOptions = {
       recipient: options.token_transfer_recipient_address as string,
       amount: new BN(options.amount as string),
       // We don't know the fee yet but need a placeholder

--- a/src/core-rpc/client.ts
+++ b/src/core-rpc/client.ts
@@ -1,5 +1,6 @@
 import fetch, { RequestInit } from 'node-fetch';
 import { parsePort, stopwatch, logError, timeout } from '../helpers';
+import { CoreNodeFeeResponse } from '@blockstack/stacks-blockchain-api-types';
 
 export interface CoreRpcAccountInfo {
   /** Hex-prefixed uint128. */
@@ -172,6 +173,13 @@ export class StacksCoreRpcClient {
 
   async getNeighbors(): Promise<CoreRpcNeighbors> {
     const result = await this.fetchJson<CoreRpcNeighbors>(`v2/neighbors`, {
+      method: 'GET',
+    });
+    return result;
+  }
+
+  async getEstimatedTransferFee(): Promise<CoreNodeFeeResponse> {
+    const result = await this.fetchJson<CoreNodeFeeResponse>(`v2/fees/transfer`, {
       method: 'GET',
     });
     return result;

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -423,7 +423,7 @@ export function getSigners(transaction: StacksTransaction): RosettaAccountIdenti
   return account_identifier_signers;
 }
 
-export function GetStacksTestnetNetwork() {
+export function getStacksTestnetNetwork() {
   const stacksNetwork = new StacksTestnet();
   stacksNetwork.coreApiUrl = `http://${getCoreNodeEndpoint()}`;
   return stacksNetwork;

--- a/src/tests-rosetta-cli/validate-rosetta-construction.ts
+++ b/src/tests-rosetta-cli/validate-rosetta-construction.ts
@@ -96,7 +96,7 @@ const HOST = 'localhost';
 const PORT = 20443;
 const URL = `http://${HOST}:${PORT}`;
 
-const stacksNetwork = GetStacksTestnetNetwork();
+const stacksNetwork = getStacksTestnetNetwork();
 
 const isContainerRunning = async (name: string): Promise<boolean> =>
   new Promise((resolve, reject): void => {
@@ -263,7 +263,7 @@ async function sendCoreTx(
   return Promise.resolve({ txId: '' });
 }
 
-export function GetStacksTestnetNetwork() {
+export function getStacksTestnetNetwork() {
   const stacksNetwork = new StacksTestnet();
   stacksNetwork.coreApiUrl = getCoreNodeEndpoint({
     host: `http://${HOST}`,

--- a/src/tests-rosetta-cli/validate-rosetta.ts
+++ b/src/tests-rosetta-cli/validate-rosetta.ts
@@ -96,7 +96,7 @@ const HOST = 'localhost';
 const PORT = 20443;
 const URL = `http://${HOST}:${PORT}`;
 
-const stacksNetwork = GetStacksTestnetNetwork();
+const stacksNetwork = getStacksTestnetNetwork();
 
 const isContainerRunning = async (name: string): Promise<boolean> =>
   new Promise((resolve, reject): void => {
@@ -316,7 +316,7 @@ async function sendCoreTx(
   return Promise.resolve({ txId: '' });
 }
 
-export function GetStacksTestnetNetwork() {
+export function getStacksTestnetNetwork() {
   const stacksNetwork = new StacksTestnet();
   stacksNetwork.coreApiUrl = getCoreNodeEndpoint({
     host: `http://${HOST}`,

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -859,6 +859,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         fee: '-180',
         max_fee: '12380898',
+        size: 180,
       },
       required_public_keys: [
         {
@@ -984,6 +985,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         fee: '-180',
         max_fee: '12380898',
+        size: 180,
       },
       public_keys: [{ hex_bytes: publicKey, curve_type: 'secp256k1' }],
     };
@@ -992,9 +994,13 @@ describe('Rosetta API', () => {
       .post(`/rosetta/v1/construction/metadata`)
       .send(request);
 
+    console.log(result.text);
+
     expect(result.status).toBe(200);
     expect(result.type).toBe('application/json');
     expect(JSON.parse(result.text)).toHaveProperty('metadata');
+    expect(JSON.parse(result.text)).toHaveProperty('suggested_fee');
+    expect(JSON.parse(result.text).suggested_fee.value).toBe('180');
   });
 
   test('construction/metadata - failure invalid public key', async () => {
@@ -1016,6 +1022,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         fee: '-180',
         max_fee: '12380898',
+        size: 180,
       },
       public_keys: [
         {
@@ -1047,6 +1054,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         fee: '-180',
         max_fee: '12380898',
+        size: 180,
       },
     };
 
@@ -1085,6 +1093,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         fee: '-180',
         max_fee: '12380898',
+        size: 180,
       },
     };
 
@@ -1120,6 +1129,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         fee: '-180',
         max_fee: '12380898',
+        size: 180,
       },
     };
 
@@ -1155,6 +1165,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         fee: '-180',
         max_fee: '12380898',
+        size: 180,
       },
     };
 

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -769,27 +769,6 @@ describe('Rosetta API', () => {
             network_index: 0,
           },
           related_operations: [],
-          type: 'fee',
-          status: null,
-          account: {
-            address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
-            metadata: {},
-          },
-          amount: {
-            value: '-180',
-            currency: {
-              symbol: 'STX',
-              decimals: 6,
-            },
-            metadata: {},
-          },
-        },
-        {
-          operation_identifier: {
-            index: 1,
-            network_index: 0,
-          },
-          related_operations: [],
           type: 'token_transfer',
           status: null,
           account: {
@@ -807,7 +786,7 @@ describe('Rosetta API', () => {
         },
         {
           operation_identifier: {
-            index: 2,
+            index: 1,
             network_index: 0,
           },
           related_operations: [],
@@ -838,7 +817,7 @@ describe('Rosetta API', () => {
           metadata: {},
         },
       ],
-      suggested_fee_multiplier: 0,
+      suggested_fee_multiplier: 1,
     };
 
     const result = await supertest(api.server)
@@ -853,11 +832,11 @@ describe('Rosetta API', () => {
         sender_address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
         type: 'token_transfer',
         status: null,
+        suggested_fee_multiplier: 1,
         token_transfer_recipient_address: 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0',
         amount: '500000',
         symbol: 'STX',
         decimals: 6,
-        fee: '-180',
         max_fee: '12380898',
         size: 180,
       },
@@ -884,27 +863,6 @@ describe('Rosetta API', () => {
             network_index: 0,
           },
           related_operations: [],
-          type: 'fee',
-          status: null,
-          account: {
-            address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
-            metadata: {},
-          },
-          amount: {
-            value: '-180',
-            currency: {
-              symbol: 'STX',
-              decimals: 6,
-            },
-            metadata: {},
-          },
-        },
-        {
-          operation_identifier: {
-            index: 1,
-            network_index: 0,
-          },
-          related_operations: [],
           type: 'invalid operation type',
           status: null,
           account: {
@@ -922,7 +880,7 @@ describe('Rosetta API', () => {
         },
         {
           operation_identifier: {
-            index: 2,
+            index: 1,
             network_index: 0,
           },
           related_operations: [],
@@ -953,7 +911,7 @@ describe('Rosetta API', () => {
           metadata: {},
         },
       ],
-      suggested_fee_multiplier: 0,
+      suggested_fee_multiplier: 1,
     };
 
     const result2 = await supertest(api.server)
@@ -979,11 +937,11 @@ describe('Rosetta API', () => {
         sender_address: testnetKeys[0].stacksAddress,
         type: 'token_transfer',
         status: null,
+        suggested_fee_multiplier: 1,
         token_transfer_recipient_address: testnetKeys[1].stacksAddress,
         amount: '500000',
         symbol: 'STX',
         decimals: 6,
-        fee: '-180',
         max_fee: '12380898',
         size: 180,
       },
@@ -1020,7 +978,6 @@ describe('Rosetta API', () => {
         amount: '500000',
         symbol: 'STX',
         decimals: 6,
-        fee: '-180',
         max_fee: '12380898',
         size: 180,
       },
@@ -1052,7 +1009,6 @@ describe('Rosetta API', () => {
         amount: '500000',
         symbol: 'STX',
         decimals: 6,
-        fee: '-180',
         max_fee: '12380898',
         size: 180,
       },
@@ -1091,7 +1047,6 @@ describe('Rosetta API', () => {
         amount: '500000',
         symbol: 'STX',
         decimals: 6,
-        fee: '-180',
         max_fee: '12380898',
         size: 180,
       },
@@ -1163,7 +1118,6 @@ describe('Rosetta API', () => {
         amount: '500000',
         symbol: 'STX',
         decimals: 6,
-        fee: '-180',
         max_fee: '12380898',
         size: 180,
       },
@@ -1415,7 +1369,7 @@ describe('Rosetta API', () => {
     const publicKey = publicKeyToString(pubKeyfromPrivKey(testnetKeys[0].secretKey));
     const sender = testnetKeys[0].stacksAddress;
     const recipient = testnetKeys[1].stacksAddress;
-    const fee = '-180';
+    const fee = '180';
 
     const request: RosettaConstructionPayloadsRequest = {
       network_identifier: {
@@ -1426,27 +1380,6 @@ describe('Rosetta API', () => {
         {
           operation_identifier: {
             index: 0,
-            network_index: 0,
-          },
-          related_operations: [],
-          type: 'fee',
-          status: null,
-          account: {
-            address: sender,
-            metadata: {},
-          },
-          amount: {
-            value: fee,
-            currency: {
-              symbol: 'STX',
-              decimals: 6,
-            },
-            metadata: {},
-          },
-        },
-        {
-          operation_identifier: {
-            index: 1,
             network_index: 0,
           },
           related_operations: [],
@@ -1467,7 +1400,7 @@ describe('Rosetta API', () => {
         },
         {
           operation_identifier: {
-            index: 2,
+            index: 1,
             network_index: 0,
           },
           related_operations: [],
@@ -1487,6 +1420,9 @@ describe('Rosetta API', () => {
           },
         },
       ],
+      metadata: {
+        fee: fee,
+      },
       public_keys: [
         {
           hex_bytes: publicKey,
@@ -1544,7 +1480,7 @@ describe('Rosetta API', () => {
 
     const sender = testnetKeys[0].stacksAddress;
     const recipient = testnetKeys[1].stacksAddress;
-    const fee = '-180';
+    const fee = '180';
 
     const request: RosettaConstructionPayloadsRequest = {
       network_identifier: {
@@ -1555,27 +1491,6 @@ describe('Rosetta API', () => {
         {
           operation_identifier: {
             index: 0,
-            network_index: 0,
-          },
-          related_operations: [],
-          type: 'fee',
-          status: null,
-          account: {
-            address: sender,
-            metadata: {},
-          },
-          amount: {
-            value: fee,
-            currency: {
-              symbol: 'STX',
-              decimals: 6,
-            },
-            metadata: {},
-          },
-        },
-        {
-          operation_identifier: {
-            index: 1,
             network_index: 0,
           },
           related_operations: [],
@@ -1596,7 +1511,7 @@ describe('Rosetta API', () => {
         },
         {
           operation_identifier: {
-            index: 2,
+            index: 1,
             network_index: 0,
           },
           related_operations: [],
@@ -1616,6 +1531,9 @@ describe('Rosetta API', () => {
           },
         },
       ],
+      metadata: {
+        fee,
+      },
       public_keys: [
         {
           hex_bytes: publicKey1,
@@ -1653,27 +1571,6 @@ describe('Rosetta API', () => {
             network_index: 0,
           },
           related_operations: [],
-          type: 'fee',
-          status: null,
-          account: {
-            address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
-            metadata: {},
-          },
-          amount: {
-            value: '-180',
-            currency: {
-              symbol: 'STX',
-              decimals: 6,
-            },
-            metadata: {},
-          },
-        },
-        {
-          operation_identifier: {
-            index: 1,
-            network_index: 0,
-          },
-          related_operations: [],
           type: 'token_transfer',
           status: null,
           account: {
@@ -1691,7 +1588,7 @@ describe('Rosetta API', () => {
         },
         {
           operation_identifier: {
-            index: 2,
+            index: 1,
             network_index: 0,
           },
           related_operations: [],
@@ -1711,6 +1608,9 @@ describe('Rosetta API', () => {
           },
         },
       ],
+      metadata: {
+        fee: '180',
+      },
     };
 
     const result = await supertest(api.server)
@@ -1738,27 +1638,6 @@ describe('Rosetta API', () => {
             network_index: 0,
           },
           related_operations: [],
-          type: 'fee',
-          status: null,
-          account: {
-            address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
-            metadata: {},
-          },
-          amount: {
-            value: '-180',
-            currency: {
-              symbol: 'STX',
-              decimals: 6,
-            },
-            metadata: {},
-          },
-        },
-        {
-          operation_identifier: {
-            index: 1,
-            network_index: 0,
-          },
-          related_operations: [],
           type: 'token_transfer',
           status: null,
           account: {
@@ -1776,7 +1655,7 @@ describe('Rosetta API', () => {
         },
         {
           operation_identifier: {
-            index: 2,
+            index: 1,
             network_index: 0,
           },
           related_operations: [],
@@ -1796,6 +1675,9 @@ describe('Rosetta API', () => {
           },
         },
       ],
+      metadata: {
+        fee: '180',
+      },
       public_keys: [
         {
           hex_bytes: '025c13b2fc2261956d8a4ad07d481b1a3b2cbf93a24f992249a61c3a1c4de79c51',

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -59,7 +59,7 @@ import {
   RosettaOperationTypes,
   RosettaOperationStatuses,
 } from '../api/rosetta-constants';
-import { GetStacksTestnetNetwork, testnetKeys } from '../api/routes/debug';
+import { getStacksTestnetNetwork, testnetKeys } from '../api/routes/debug';
 import { getOptionsFromOperations, getSignature } from '../rosetta-helpers';
 import { makeSigHashPreSign, MessageSignature } from '@stacks/transactions';
 
@@ -323,7 +323,7 @@ describe('Rosetta API', () => {
       recipient: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
       amount: new BN(3852),
       senderKey: 'c71700b07d520a8c9731e4d0f095aa6efb91e16e25fb27ce2b72e7b698f8127a01',
-      network: GetStacksTestnetNetwork(),
+      network: getStacksTestnetNetwork(),
       memo: 'test1234',
     });
     expectedTxId = '0x' + transferTx.txid();
@@ -1233,7 +1233,7 @@ describe('Rosetta API', () => {
       amount: amount,
       fee: fee,
       senderKey: testnetKeys[0].secretKey,
-      network: GetStacksTestnetNetwork(),
+      network: getStacksTestnetNetwork(),
     };
     const testTransaction = await makeSTXTokenTransfer(options);
     const request: RosettaConstructionParseRequest = {
@@ -1276,7 +1276,7 @@ describe('Rosetta API', () => {
       amount: amount,
       fee: fee,
       publicKey: publicKey,
-      network: GetStacksTestnetNetwork(),
+      network: getStacksTestnetNetwork(),
     };
     const testTransaction = await makeUnsignedSTXTokenTransfer(tokenTransferOptions);
 
@@ -1309,7 +1309,7 @@ describe('Rosetta API', () => {
       senderKey: testnetKeys[0].secretKey,
       recipient: standardPrincipalCV(testnetKeys[1].stacksAddress),
       amount: new BigNum(12345),
-      network: GetStacksTestnetNetwork(),
+      network: getStacksTestnetNetwork(),
       memo: 'test memo',
       nonce: new BigNum(0),
       fee: new BigNum(200),
@@ -1337,7 +1337,7 @@ describe('Rosetta API', () => {
       recipient: standardPrincipalCV(testnetKeys[1].stacksAddress),
       amount: new BigNum(12345),
       publicKey: publicKeyToString(pubKeyfromPrivKey(testnetKeys[0].secretKey)),
-      network: GetStacksTestnetNetwork(),
+      network: getStacksTestnetNetwork(),
       memo: 'test memo',
       nonce: new BigNum(0),
       fee: new BigNum(200),
@@ -1436,7 +1436,7 @@ describe('Rosetta API', () => {
       amount: new BN('500000'),
       fee: new BN(fee),
       publicKey: publicKey,
-      network: GetStacksTestnetNetwork(),
+      network: getStacksTestnetNetwork(),
       nonce: new BN(0),
     };
 
@@ -1705,7 +1705,7 @@ describe('Rosetta API', () => {
       publicKey: publicKey,
       recipient: standardPrincipalCV(testnetKeys[1].stacksAddress),
       amount: new BigNum(12345),
-      network: GetStacksTestnetNetwork(),
+      network: getStacksTestnetNetwork(),
       memo: 'test memo',
       nonce: new BigNum(0),
       fee: new BigNum(200),
@@ -1897,7 +1897,7 @@ describe('Rosetta API', () => {
       publicKey: publicKey,
       recipient: standardPrincipalCV(testnetKeys[1].stacksAddress),
       amount: new BigNum(12345),
-      network: GetStacksTestnetNetwork(),
+      network: getStacksTestnetNetwork(),
       memo: 'test memo',
       nonce: new BigNum(0),
       fee: new BigNum(200),

--- a/src/tests/core-rpc-tests.ts
+++ b/src/tests/core-rpc-tests.ts
@@ -26,4 +26,9 @@ describe('core RPC tests', () => {
     const balance = await client.getAccountBalance('STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6');
     expect(balance).toBe(10000000000000000n);
   });
+
+  test('get estimated transfer fee', async () => {
+    const fee = await client.getEstimatedTransferFee();
+    expect(fee).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Use the following template to create your pull request

## Description

We now use `suggested_fee` to calculate the fee required for the transaction. We don't need the `fee` operation neither in order to create a transaction.

See https://github.com/blockstack/stacks-blockchain-api/issues/505

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
Yes. The api will return an error if `fee` operation is added when creating an transaction.

## Checklist
- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @kyranjamie or @zone117x for review
