### PR TITLE
fix: do not re-import Stacks 1.0 BNS data

### DIFF
--- a/.env
+++ b/.env
@@ -33,3 +33,6 @@ BTC_FAUCET_PK=29c028009a8331358adcc61bb6397377c995d327ac0343ed8e8f1d4d3ef85c27
 # The contracts used to query for inbound transactions
 TESTNET_SEND_MANY_CONTRACT_ID=STR8P3RD1EHA8AA37ERSSSZSWKS9T2GYQFGXNA4C.send-many-memo
 MAINNET_SEND_MANY_CONTRACT_ID=SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-many-memo
+
+# Directory containing Stacks 1.0 BNS data extracted from https://storage.googleapis.com/blockstack-v1-migration-data/export-data.tar.gz
+# BNS_IMPORT_DIR=/extracted/export-data-dir/

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -395,6 +395,11 @@ export interface DbBnsSubdomain {
   atch_resolved?: boolean;
 }
 
+export interface DbConfigState {
+  bns_names_onchain_imported: boolean;
+  bns_subdomains_imported: boolean;
+}
+
 export interface DataStore extends DataStoreEventEmitter {
   getUnresolvedSubdomain(tx_id: string): Promise<FoundOrNot<DbBnsSubdomain>>;
   getBlock(blockHash: string): Promise<FoundOrNot<DbBlock>>;
@@ -524,6 +529,9 @@ export interface DataStore extends DataStoreEventEmitter {
     limit: number;
     offset: number;
   }): Promise<{ results: AddressNftEventIdentifier[]; total: number }>;
+
+  getConfigState(): Promise<DbConfigState>;
+  updateConfigState(configState: DbConfigState): Promise<void>;
 
   getNamespaceList(): Promise<{
     results: string[];

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -26,6 +26,7 @@ import {
   DbBnsNamespace,
   DbBnsZoneFile,
   DbBnsSubdomain,
+  DbConfigState,
 } from './common';
 import { logger, FoundOrNot } from '../helpers';
 import { TransactionType } from '@blockstack/stacks-blockchain-api-types';
@@ -497,6 +498,17 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     limit: number;
     offset: number;
   }): Promise<{ results: AddressNftEventIdentifier[]; total: number }> {
+    throw new Error('Method not implemented.');
+  }
+
+  getConfigState(): Promise<DbConfigState> {
+    return Promise.resolve({
+      bns_names_onchain_imported: false,
+      bns_subdomains_imported: false,
+    });
+  }
+
+  updateConfigState(configState: DbConfigState): Promise<void> {
     throw new Error('Method not implemented.');
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,10 +78,10 @@ async function init(): Promise<void> {
 
   if (db instanceof PgDataStore) {
     if (isProdEnv && !process.env.BNS_IMPORT_DIR) {
-      // TODO: log error for now, but do not throw
-      logger.error(`Production mode requires 'BNS_IMPORT_DIR' to be set`);
+      logger.warn(`Notice: full BNS functionality requires 'BNS_IMPORT_DIR' to be set.`);
+    } else if (process.env.BNS_IMPORT_DIR){
+      await importV1(db, process.env.BNS_IMPORT_DIR);
     }
-    await importV1(db, process.env.BNS_IMPORT_DIR);
   }
 
   const eventServer = await startEventServer({ db, chainId: configuredChainID });

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ async function init(): Promise<void> {
   if (db instanceof PgDataStore) {
     if (isProdEnv && !process.env.BNS_IMPORT_DIR) {
       logger.warn(`Notice: full BNS functionality requires 'BNS_IMPORT_DIR' to be set.`);
-    } else if (process.env.BNS_IMPORT_DIR){
+    } else if (process.env.BNS_IMPORT_DIR) {
       await importV1(db, process.env.BNS_IMPORT_DIR);
     }
   }

--- a/src/migrations/1616752858364_config_state.ts
+++ b/src/migrations/1616752858364_config_state.ts
@@ -25,3 +25,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   // Create the single row
   pgm.sql('INSERT INTO config_state VALUES(DEFAULT)');
 }
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable('config_state');
+}

--- a/src/migrations/1616752858364_config_state.ts
+++ b/src/migrations/1616752858364_config_state.ts
@@ -1,0 +1,27 @@
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('config_state', {
+    id: {
+      type: 'bool',
+      primaryKey: true,
+      default: true,
+    },
+    bns_names_onchain_imported: {
+      type: 'bool',
+      notNull: true,
+      default: false,
+    },
+    bns_subdomains_imported: {
+      type: 'bool',
+      notNull: true,
+      default: false,
+    },
+  });
+
+  // Ensure only a single row can exist
+  pgm.addConstraint('config_state', 'config_state_one_row', 'CHECK(id)');
+
+  // Create the single row
+  pgm.sql('INSERT INTO config_state VALUES(DEFAULT)');
+}


### PR DESCRIPTION
Fixes https://github.com/blockstack/stacks-blockchain-api/issues/504
Related to https://github.com/blockstack/stacks-blockchain-api/issues/500

Once this is merged, the BNS PR https://github.com/blockstack/stacks-blockchain-api/pull/483 can be merged without breaking API restart capabilities.