### PR TITLE
Fix/ include tx data for block and address

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2103,3 +2103,76 @@ paths:
                 $ref: ./api/bns/errors/bns-error.schema.json
               example:
                 $ref: ./api/bns/errors/bns-invalid-tx-id.example.json
+  
+  /extended/v1/tx/block/{block_hash}:
+    get:
+      summary: Transactions in a block
+      description: Get all transactions in block
+      tags:
+        - Transactions
+      parameters:
+        - name: block_hash
+          in: path
+          description: Hash of block
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: max number of transactions to fetch
+          required: false
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          description: index of first transaction to fetch
+          required: false
+          schema:
+            type: integer
+      responses:
+        200:
+          description: List of Transactions
+          content:
+            application/json:
+              schema:
+                $ref: ./api/transaction/get-transactions.schema.json
+              example:
+                $ref: ./api/transaction/get-transactions.example.json
+
+  /extended/v1/address/{address}/mempool:
+    get:
+      summary: Transactions for address
+      description: Get all transactions for address in mempool
+      tags:
+        - Transactions
+      parameters:
+        - name: address
+          in: path
+          description: Transactions for the address
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: max number of transactions to fetch
+          required: false
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          description: index of first transaction to fetch
+          required: false
+          schema:
+            type: integer
+      responses:
+        200:
+          description: List of Transactions
+          content:
+            application/json:
+              schema:
+                $ref: ./api/transaction/get-mempool-transactions.schema.json
+              example:
+                $ref: ./api/transaction/get-mempool-transactions.example.json
+
+                
+

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -287,8 +287,6 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
     const { results: txResults, total } = await db.getMempoolTxList({
       offset,
       limit,
-      senderAddress: undefined,
-      recipientAddress: undefined,
       address,
     });
 

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -22,6 +22,7 @@ import {
   TransactionResults,
   MempoolTransactionListResponse,
   GetRawTransactionResult,
+  Transaction,
 } from '@blockstack/stacks-blockchain-api-types';
 
 const MAX_TXS_PER_REQUEST = 200;
@@ -224,6 +225,39 @@ export function createTxRouter(db: DataStore): RouterWithAsync {
     } else {
       res.status(404).json({ error: `could not find transaction by ID ${tx_id}` });
     }
+  });
+
+  router.getAsync('/block/:block_hash', async (req, res) => {
+    const { block_hash } = req.params;
+    const limit = parseTxQueryEventsLimit(req.query['limit'] ?? 96);
+    const offset = parsePagingQueryInput(req.query['offset'] ?? 0);
+    const blockQuery = await db.getBlock(block_hash);
+    if (!blockQuery.found) {
+      return { found: false };
+    }
+    const dbTxs = await db.getTxsFromBlock(blockQuery.result.index_block_hash, limit, offset);
+
+    const results = await Bluebird.mapSeries(dbTxs.results, async tx => {
+      const txQuery = await getTxFromDataStore(db, { txId: tx.tx_id });
+      if (!txQuery.found) {
+        throw new Error('unexpected tx not found -- fix tx enumeration query');
+      }
+      return txQuery.result;
+    });
+
+    const response: TransactionResults = {
+      limit: limit,
+      offset: offset,
+      results: results,
+      total: dbTxs.total,
+    };
+    if (!isProdEnv) {
+      const schemaPath = require.resolve(
+        '@blockstack/stacks-blockchain-api-types/api/transaction/get-transactions.schema.json'
+      );
+      await validate(schemaPath, response);
+    }
+    res.json(response);
   });
 
   return router;

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -231,11 +231,7 @@ export function createTxRouter(db: DataStore): RouterWithAsync {
     const { block_hash } = req.params;
     const limit = parseTxQueryEventsLimit(req.query['limit'] ?? 96);
     const offset = parsePagingQueryInput(req.query['offset'] ?? 0);
-    const blockQuery = await db.getBlock(block_hash);
-    if (!blockQuery.found) {
-      return { found: false };
-    }
-    const dbTxs = await db.getTxsFromBlock(blockQuery.result.index_block_hash, limit, offset);
+    const dbTxs = await db.getTxsFromBlock(block_hash, limit, offset);
 
     const results = await Bluebird.mapSeries(dbTxs.results, async tx => {
       const txQuery = await getTxFromDataStore(db, { txId: tx.tx_id });

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -412,6 +412,11 @@ export interface DataStore extends DataStoreEventEmitter {
   }): Promise<{ results: DbBlock[]; total: number }>;
   getBlockTxs(indexBlockHash: string): Promise<{ results: string[] }>;
   getBlockTxsRows(blockHash: string): Promise<FoundOrNot<DbTx[]>>;
+  getTxsFromBlock(
+    indexBlockHash: string,
+    limit: number,
+    offset: number
+  ): Promise<{ results: DbTx[]; total: number }>;
 
   getMempoolTx(args: { txId: string; includePruned?: boolean }): Promise<FoundOrNot<DbMempoolTx>>;
   getMempoolTxList(args: {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -413,7 +413,7 @@ export interface DataStore extends DataStoreEventEmitter {
   getBlockTxs(indexBlockHash: string): Promise<{ results: string[] }>;
   getBlockTxsRows(blockHash: string): Promise<FoundOrNot<DbTx[]>>;
   getTxsFromBlock(
-    indexBlockHash: string,
+    blockHash: string,
     limit: number,
     offset: number
   ): Promise<{ results: DbTx[]; total: number }>;

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -563,7 +563,7 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
   }
 
   getTxsFromBlock(
-    indexBlockHash: string,
+    blockHash: string,
     limit: number,
     offset: number
   ): Promise<{ results: DbTx[]; total: number }> {

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -561,4 +561,12 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
   getSubdomainResolver(name: { name: string }): Promise<FoundOrNot<string>> {
     throw new Error('Method not implemented.');
   }
+
+  getTxsFromBlock(
+    indexBlockHash: string,
+    limit: number,
+    offset: number
+  ): Promise<{ results: DbTx[]; total: number }> {
+    throw new Error('Method not implemented');
+  }
 }

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1438,26 +1438,26 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     });
   }
 
-  async getTxsFromBlock(indexBlockHash: string, limit: number, offset: number) {
+  async getTxsFromBlock(blockHash: string, limit: number, offset: number) {
     return this.query(async client => {
       const totalQuery = await client.query<{ count: number }>(
         `
         SELECT COUNT(*)::integer
         FROM txs
-        WHERE index_block_hash = $1
+        WHERE block_hash = $1
         `,
-        [hexToBuffer(indexBlockHash)]
+        [hexToBuffer(blockHash)]
       );
 
       const result = await client.query<TxQueryResult>(
         `
         SELECT ${TX_COLUMNS}
         FROM txs
-        WHERE index_block_hash = $1
+        WHERE block_hash = $1
         LIMIT $2
         OFFSET $3
         `,
-        [hexToBuffer(indexBlockHash), limit, offset]
+        [hexToBuffer(blockHash), limit, offset]
       );
       let total = 0;
       if (totalQuery.rowCount > 0) {

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1444,7 +1444,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         `
         SELECT COUNT(*)::integer
         FROM txs
-        WHERE block_hash = $1
+        WHERE canonical = true AND block_hash = $1
         `,
         [hexToBuffer(blockHash)]
       );
@@ -1453,7 +1453,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
         `
         SELECT ${TX_COLUMNS}
         FROM txs
-        WHERE block_hash = $1
+        WHERE canonical = true AND block_hash = $1
         LIMIT $2
         OFFSET $3
         `,


### PR DESCRIPTION

## Description

A couple of endpoints are added

1. `/tx/block/[block_hash]`
Returns the transactions in a block
2. `/address/[address]/mempool`
Returns the mempool transactions for the address

For details refer to issue #307 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No


## Testing information

Tests added for new endpoints

## Checklist
- [ ] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] @zone117x for review
