### PR TITLE
Redirect subdomains endpoint to resolve for missing subdomains

### DIFF
--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -401,6 +401,7 @@ export interface DbConfigState {
 }
 
 export interface DataStore extends DataStoreEventEmitter {
+  getSubdomainResolver(name: { name: string }): Promise<FoundOrNot<string>>;
   getUnresolvedSubdomain(tx_id: string): Promise<FoundOrNot<DbBnsSubdomain>>;
   getBlock(blockHash: string): Promise<FoundOrNot<DbBlock>>;
   getBlockByHeight(block_height: number): Promise<FoundOrNot<DbBlock>>;

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -557,4 +557,8 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
   getSubdomain(args: { subdomain: string }): Promise<FoundOrNot<DbBnsSubdomain>> {
     throw new Error('Method not implemented.');
   }
+
+  getSubdomainResolver(name: { name: string }): Promise<FoundOrNot<string>> {
+    throw new Error('Method not implemented.');
+  }
 }

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -3719,6 +3719,13 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     return { found: false } as const;
   }
 
+  async insertSubdomains(data: DbBnsSubdomain[]): Promise<void> {
+    if (data.length == 0) return;
+    await this.queryTx(async client => {
+      await this.updateBatchSubdomains(client, data);
+    });
+  }
+
   async close(): Promise<void> {
     await this.pool.end();
   }

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -3694,6 +3694,31 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
     }
     return { found: false } as const;
   }
+
+  async getSubdomainResolver(args: { name: string }): Promise<FoundOrNot<string>> {
+    const queryResult = await this.pool.query(
+      `
+      SELECT resolver
+      FROM subdomains
+      WHERE canonical = true
+      AND 
+      latest = true
+      AND 
+      name = $1
+      ORDER BY block_height
+      LIMIT 1
+      `,
+      [args.name]
+    );
+    if (queryResult.rowCount > 0) {
+      return {
+        found: true,
+        result: queryResult.rows[0].resolver,
+      };
+    }
+    return { found: false } as const;
+  }
+
   async close(): Promise<void> {
     await this.pool.end();
   }

--- a/src/migrations/1610030345948_bns-subdomain.ts
+++ b/src/migrations/1610030345948_bns-subdomain.ts
@@ -84,6 +84,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createIndex('subdomains', 'canonical');
   pgm.createIndex('subdomains', 'latest');
   pgm.createIndex('subdomains', 'atch_resolved');
+  pgm.createIndex('subdomains', 'resolver');
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {


### PR DESCRIPTION


## Description

This PR replicates behavior in stacks 1.0 for subdomains. It redirects the request to the subdomain registrar for missing subdomains the following way,  If a subdomain isn't found in the `stacks-blockchain-api` database, extract resolver(which should be the URL for subdomain registrar) from the latest subdomain for this Bns name and redirect the request to that.  This would allow users to resolve subdomains that aren't fully registered yet. 


For details refer to issue #517 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] @zone117x for review
@markmhx @jcnelson 
