### PR TITLE
Convert Btc address to Stx address for subdomain

### DIFF
--- a/src/import-v1/index.ts
+++ b/src/import-v1/index.ts
@@ -4,6 +4,7 @@ import * as stream from 'stream';
 import * as util from 'util';
 import * as readline from 'readline';
 import * as path from 'path';
+import * as c32check from 'c32check';
 
 import { DbBnsName, DbBnsNamespace, DbBnsSubdomain, DbConfigState } from '../datastore/common';
 import { PgDataStore } from '../datastore/postgres-store';
@@ -220,7 +221,7 @@ class SubdomainTransform extends stream.Transform {
         zonefile: '',
         parent_zonefile_hash: parts[1],
         fully_qualified_subdomain: parts[2],
-        owner: parts[3],
+        owner: c32check.b58ToC32(parts[3]), //convert btc address to stx,
         block_height: parseInt(parts[4], 10),
         parent_zonefile_index: parseInt(parts[5], 10),
         zonefile_offset: parseInt(parts[6], 10),

--- a/src/tests-bns/bns-integration-tests.ts
+++ b/src/tests-bns/bns-integration-tests.ts
@@ -507,7 +507,7 @@ describe('BNS API', () => {
     expect(query2.status).toBe(200);
     expect(query2.type).toBe('application/json');
     expect(query2.body).toEqual({
-      address: '1HEznKZ7mK5fmibweM7eAk8SwRgJ1bWY92',
+      address: 'SP2S2F9TCAT43KEJT02YTG2NXVCPZXS1426T63D9H',
       blockchain: 'stacks',
       last_txid: '0x',
       resolver: 'https://registrar.blockstack.org',


### PR DESCRIPTION
## Description
This PR converts BTC address to STX address before saving it in db for stacks 1.0 subdomains. 

For details refer to issue #541 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Testing information

## Checklist
- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] @zone117x for review
