### PR TITLE
feat: address transactions with stx transfers endpoint

### DIFF
--- a/docs/api/address/get-address-transactions-with-transfers.example.json
+++ b/docs/api/address/get-address-transactions-with-transfers.example.json
@@ -1,0 +1,107 @@
+{
+  "limit": 20,
+  "offset": 0,
+  "total": 2,
+  "results": [
+    {
+      "tx": {
+        "tx_id": "0x34d79c7cfc2fe525438736733e501a4bf0308a5556e3e080d1e2c0858aad7448",
+        "tx_type": "contract_call",
+        "nonce": 11,
+        "fee_rate": "346",
+        "sender_address": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
+        "sponsored": false,
+        "post_condition_mode": "deny",
+        "tx_status": "success",
+        "block_hash": "0x13d1b4ad35c95bca209397420fb8af104d2929d91993ba056d7a1ca5470095f9",
+        "block_height": 3246,
+        "burn_block_time": 1613009951,
+        "burn_block_time_iso": "2021-02-11T02:19:11.000Z",
+        "canonical": true,
+        "tx_index": 1,
+        "tx_result": {
+          "hex": "0x0703",
+          "repr": "(ok true)"
+        },
+        "post_conditions": [
+          {
+            "type": "stx",
+            "condition_code": "sent_equal_to",
+            "amount": "350",
+            "principal": {
+              "type_id": "principal_standard",
+              "address": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE"
+            }
+          }
+        ],
+        "contract_call": {
+          "contract_id": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.send-many-memo",
+          "function_name": "send-many",
+          "function_signature": "(define-public (send-many (recipients (list 200 (tuple (memo (buff 34)) (to principal) (ustx uint))))))",
+          "function_args": [
+            {
+              "hex": "0x0b000000020c00000003046d656d6f020000000966697273746d656d6f02746f05168c031b2db5895ece0cdfbf76e0b0e8af67226a6f047573747801000000000000000000000000000000960c00000003046d656d6f020000000a7365636f6e646d656d6f02746f05168974da696d74a16d0955bc8e55720dfd39e789cf047573747801000000000000000000000000000000c8",
+              "repr": "(list (tuple (memo 0x66697273746d656d6f) (to SP26066SDPP4NXKGCVYZQDR5GX2QPE8KADZ0YK2J7) (ustx u150)) (tuple (memo 0x7365636f6e646d656d6f) (to SP24Q9PK9DNTA2V89APY8WNBJ1QYKKSW9SWB04RJP) (ustx u200)))",
+              "name": "recipients",
+              "type": "(list 200 (tuple (memo (buff 34)) (to principal) (ustx uint)))"
+            }
+          ]
+        },
+        "events": [],
+        "event_count": 4
+      },
+      "stx_sent": "696",
+      "stx_received": "0",
+      "stx_transfers": [
+        {
+          "amount": "200",
+          "sender": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
+          "recipient": "SP24Q9PK9DNTA2V89APY8WNBJ1QYKKSW9SWB04RJP"
+        },
+        {
+          "amount": "150",
+          "sender": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
+          "recipient": "SP26066SDPP4NXKGCVYZQDR5GX2QPE8KADZ0YK2J7"
+        }
+      ]
+    },
+    {
+      "tx": {
+        "tx_id": "0x628045bff13658396277d618e9a3e4d468a4b3876eff4941d2f13ed88cd7abb7",
+        "tx_type": "token_transfer",
+        "nonce": 8,
+        "fee_rate": "180",
+        "sender_address": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
+        "sponsored": false,
+        "post_condition_mode": "deny",
+        "tx_status": "success",
+        "block_hash": "0x2b8599696f64e2456c67b1ab5e63078f99d87bd1d903c37fdcfd73b1890a7551",
+        "block_height": 1761,
+        "burn_block_time": 1611968237,
+        "burn_block_time_iso": "2021-01-30T00:57:17.000Z",
+        "canonical": true,
+        "tx_index": 2,
+        "tx_result": {
+          "hex": "0x0703",
+          "repr": "(ok true)"
+        },
+        "token_transfer": {
+          "recipient_address": "SPRSM0R2JZWBCZ39NQBARWTMX9TE99K3JK8D5KMX",
+          "amount": "100000",
+          "memo": "0x57656c636f6d6520746f20426f6f6d2e000000000000000000000000000000000000"
+        },
+        "events": [],
+        "event_count": 1
+      },
+      "stx_sent": "100180",
+      "stx_received": "0",
+      "stx_transfers": [
+        {
+          "amount": "100000",
+          "sender": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
+          "recipient": "SPRSM0R2JZWBCZ39NQBARWTMX9TE99K3JK8D5KMX"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/api/address/get-address-transactions-with-transfers.schema.json
+++ b/docs/api/address/get-address-transactions-with-transfers.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "GET request that returns account transactions",
+  "title": "AddressTransactionsWithTransfersListResponse",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["results", "limit", "offset", "total"],
+  "properties": {
+    "limit": {
+      "type": "integer",
+      "maximum": 30
+    },
+    "offset": {
+      "type": "integer"
+    },
+    "total": {
+      "type": "integer"
+    },
+    "results": {
+      "type": "array",
+      "items": {
+        "$ref": "../../entities/address/transaction-with-transfers.schema.json"
+      }
+    }
+  }
+}

--- a/docs/entities/address/transaction-with-transfers.schema.json
+++ b/docs/entities/address/transaction-with-transfers.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AddressTransactionWithTransfers",
+  "description": "Transaction with STX transfers for a given address",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "tx",
+    "stx_sent",
+    "stx_received",
+    "stx_transfers"
+  ],
+  "properties": {
+    "tx": {
+      "$ref": "../transactions/transaction.schema.json"
+    },
+    "stx_sent": {
+      "type": "string",
+      "description": "Total sent from the given address, including the tx fee, in micro-STX as an integer string."
+    },
+    "stx_received": {
+      "type": "string",
+      "description": "Total received by the given address in micro-STX as an integer string."
+    },
+    "stx_transfers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "amount"
+        ],
+        "properties": {
+          "amount": {
+            "type": "string",
+            "description": "Amount transferred in micro-STX as an integer string."
+          },
+          "sender": {
+            "type": "string",
+            "description": "Principal that sent STX. This is unspecified if the STX were minted."
+          },
+          "recipient": {
+            "type": "string",
+            "description": "Principal that received STX. This is unspecified if the STX were burned."
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -129,6 +129,16 @@ export interface AddressStxInboundListResponse {
 /**
  * GET request that returns account transactions
  */
+export interface AddressTransactionsWithTransfersListResponse {
+  limit: number;
+  offset: number;
+  total: number;
+  results: AddressTransactionWithTransfers[];
+}
+
+/**
+ * GET request that returns account transactions
+ */
 export interface AddressTransactionsListResponse {
   limit: number;
   offset: number;
@@ -1072,6 +1082,35 @@ export interface PostCoreNodeTransactionsError {
    * The relevant transaction id
    */
   txid: string;
+}
+
+/**
+ * Transaction with STX transfers for a given address
+ */
+export interface AddressTransactionWithTransfers {
+  tx: Transaction;
+  /**
+   * Total STX sent from the given address, including the tx fee
+   */
+  stx_sent: string;
+  /**
+   * Total STX received by the given address
+   */
+  stx_received: string;
+  stx_transfers: {
+    /**
+     * STX amount transferred
+     */
+    amount: string;
+    /**
+     * Principal that sent STX. This is unspecified if the STX were minted.
+     */
+    sender?: string;
+    /**
+     * Principal that received STX. This is unspecified if the STX were burned.
+     */
+    recipient?: string;
+  }[];
 }
 
 /**

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -885,6 +885,45 @@ paths:
               example:
                 $ref: ./api/address/get-address-transactions.example.json
 
+  /extended/v1/address/{principal}/transactions_with_transfers:
+    get:
+      summary: Get account transactions including STX transfers for each transaction.
+      operationId: get_account_transactions_with_transfers
+      parameters:
+        - name: limit
+          in: query
+          description: max number of account transactions to fetch
+          required: false
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          description: index of first account transaction to fetch
+          required: false
+          schema:
+            type: integer
+        - name: principal
+          in: path
+          description: Stacks address or a Contract identifier (e.g. `SP31DA6FTSJX2WGTZ69SFY11BH51NZMB0ZW97B5P0.get-info`)
+          required: true
+          schema:
+            type: string
+        - name: height
+          in: query
+          description: Filter for transactions only at this given block height
+          required: false
+          schema:
+            type: number
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: ./api/address/get-address-transactions-with-transfers.schema.json
+              example:
+                $ref: ./api/address/get-address-transactions-with-transfers.example.json
+
   /extended/v1/address/{principal}/assets:
     get:
       summary: Get account assets

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -256,6 +256,17 @@ export interface DbNftEvent extends DbContractAssetEvent {
 
 export type DbEvent = DbSmartContractEvent | DbStxEvent | DbStxLockEvent | DbFtEvent | DbNftEvent;
 
+export interface DbTxWithStxTransfers {
+  tx: DbTx;
+  stx_sent: bigint;
+  stx_received: bigint;
+  stx_transfers: {
+    amount: bigint;
+    sender?: string;
+    recipient?: string;
+  }[];
+}
+
 export interface AddressTxUpdateInfo {
   address: string;
   txs: DbTx[];
@@ -514,6 +525,13 @@ export interface DataStore extends DataStoreEventEmitter {
     offset: number;
     height?: number;
   }): Promise<{ results: DbTx[]; total: number }>;
+
+  getAddressTxsWithStxTransfers(args: {
+    stxAddress: string;
+    limit: number;
+    offset: number;
+    height?: number;
+  }): Promise<{ results: DbTxWithStxTransfers[]; total: number }>;
 
   getAddressAssetEvents(args: {
     stxAddress: string;

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -28,6 +28,7 @@ import {
   DbBnsSubdomain,
   DbConfigState,
   DbMinerReward,
+  DbTxWithStxTransfers,
 } from './common';
 import { logger, FoundOrNot } from '../helpers';
 import { TokenOfferingLocked, TransactionType } from '@blockstack/stacks-blockchain-api-types';
@@ -428,6 +429,15 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     limit: number;
     offset: number;
   }): Promise<{ results: DbTx[]; total: number }> {
+    throw new Error('not yet implemented');
+  }
+
+  getAddressTxsWithStxTransfers(args: {
+    stxAddress: string;
+    limit: number;
+    offset: number;
+    height?: number;
+  }): Promise<{ results: DbTxWithStxTransfers[]; total: number }> {
     throw new Error('not yet implemented');
   }
 


### PR DESCRIPTION
Closes #369

Implements a new endpoint `/extended/v1/address/{principal}/transactions_with_transfers`. This is similar to the `/extended/v1/address/{principal}/transactions` endpoint, but adds STX transfer data to each transaction entry.

This allows the explorer and wallets to easily show STX transfer amounts for tx types other than simple stx-transfer txs. For example:
* The genesis block transaction for addresses in the Stacks 1.0 import.
* Coinbase transactions where STX are minted for addresses with an unlocking schedule.
* Contract-call transactions, for example the `send-many` contract used by exchanges.

Here's the interface for the items returned in the response:
https://github.com/blockstack/stacks-blockchain-api/blob/e8becd488bddc99da32c6306a5320c4772d16645/docs/index.d.ts#L1085-L1112

And here's some sample example for `/extended/v1/address/SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE/transactions_with_transfers/`:
https://github.com/blockstack/stacks-blockchain-api/blob/e8becd488bddc99da32c6306a5320c4772d16645/docs/api/address/get-address-transactions-with-transfers.example.json#L1-L107