### PR TITLE
Fix subdomain name part

### DIFF
--- a/src/import-v1/index.ts
+++ b/src/import-v1/index.ts
@@ -223,8 +223,9 @@ class SubdomainTransform extends stream.Transform {
       const fqn = parts[2]; // fully qualified name
       const dots = fqn.split('.');
       const namespace = dots[dots.length - 1];
+      const namePart = fqn.split('.').slice(1).join('.');
       const subdomain: DbBnsSubdomain = {
-        name: fqn,
+        name: namePart,
         namespace_id: namespace,
         zonefile_hash: parts[0],
         zonefile: '',

--- a/src/tests-bns/bns-integration-tests.ts
+++ b/src/tests-bns/bns-integration-tests.ts
@@ -25,6 +25,7 @@ import BigNum = require('bn.js');
 import { logger } from '../helpers';
 import { testnetKeys } from '../api/routes/debug';
 import { importV1 } from '../import-v1';
+import { query } from 'winston';
 
 function hash160(bfr: Buffer): Buffer {
   const hash160 = new ripemd160().update(new shajs.sha256().update(bfr).digest()).digest('hex');
@@ -516,6 +517,10 @@ describe('BNS API', () => {
         '$ORIGIN flushreset.id.blockstack\n$TTL 3600\n_http._tcp	IN	URI	10	1	"https://gaia.blockstack.org/hub/1HEznKZ7mK5fmibweM7eAk8SwRgJ1bWY92/profile.json"\n\n',
       zonefile_hash: '14dc091ebce8ea117e1276d802ee903cc0fdde81',
     });
+
+    const dbquery = await db.getSubdomain({ subdomain: `flushreset.id.blockstack` });
+    expect(dbquery.found).toBe(true);
+    expect(dbquery.result.name).toBe('id.blockstack');
   });
 
   afterAll(async () => {

--- a/src/tests-bns/bns-integration-tests.ts
+++ b/src/tests-bns/bns-integration-tests.ts
@@ -25,7 +25,6 @@ import BigNum = require('bn.js');
 import { logger } from '../helpers';
 import { testnetKeys } from '../api/routes/debug';
 import { importV1 } from '../import-v1';
-import { query } from 'winston';
 
 function hash160(bfr: Buffer): Buffer {
   const hash160 = new ripemd160().update(new shajs.sha256().update(bfr).digest()).digest('hex');


### PR DESCRIPTION

## Description
This PR addresses the small fix in the v1-import script, It assigns the name part to the `name` field of `subdomains` instead of `fqn`

fixes #554 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] @zone117x for review
