### PR TITLE
Fix empty subdomains

### DIFF
--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -423,7 +423,7 @@ export interface DbTokenOfferingLocked {
 
 export interface DataStore extends DataStoreEventEmitter {
   getSubdomainResolver(name: { name: string }): Promise<FoundOrNot<string>>;
-  getUnresolvedSubdomain(txId: string, indexBlockHash: string): Promise<FoundOrNot<DbBnsSubdomain>>;
+  getNameCanonical(txId: string, indexBlockHash: string): Promise<FoundOrNot<boolean>>;
   getBlock(blockHash: string): Promise<FoundOrNot<DbBlock>>;
   getBlockByHeight(block_height: number): Promise<FoundOrNot<DbBlock>>;
   getCurrentBlock(): Promise<FoundOrNot<DbBlock>>;

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -95,10 +95,7 @@ export class MemoryDataStore extends (EventEmitter as { new (): DataStoreEventEm
     });
   }
 
-  getUnresolvedSubdomain(
-    txId: string,
-    indexBlockHash: string
-  ): Promise<FoundOrNot<DbBnsSubdomain>> {
+  getNameCanonical(txId: string, indexBlockHash: string): Promise<FoundOrNot<boolean>> {
     throw new Error('Method not implemented.');
   }
   resolveBnsNames(zonefile: string, atch_resolved: boolean, tx_id: string): Promise<void> {

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -3952,7 +3952,7 @@ export class PgDataStore extends (EventEmitter as { new (): DataStoreEventEmitte
       latest = true
       AND 
       name = $1
-      ORDER BY block_height
+      ORDER BY block_height DESC
       LIMIT 1
       `,
       [args.name]

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -474,12 +474,12 @@ async function handleNewAttachmentMessage(msg: CoreNodeAttachmentMessage[], db: 
         if (zoneFileTxt) {
           // get unresolved subdomain
           let isCanonical = true;
-          const unresolvedSubdomain = await db.getUnresolvedSubdomain(
+          const unresolvedSubdomain = await db.getNameCanonical(
             attachment.tx_id,
             attachment.index_block_hash
           );
           if (unresolvedSubdomain.found) {
-            isCanonical = unresolvedSubdomain.result.canonical;
+            isCanonical = unresolvedSubdomain.result;
           }
           // case for subdomain
           const subdomains: DbBnsSubdomain[] = [];

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -275,31 +275,6 @@ async function handleClientMessage(
           const functionName = getFunctionName(event.txid, parsedMsg.parsed_transactions);
           if (nameFunctions.includes(functionName)) {
             const attachment = parseNameRawValue(event.contract_event.raw_value);
-            if (functionName === 'name-update') {
-              //subdomain will be resolved in /attachments/new
-              const subdomain: DbBnsSubdomain = {
-                name: attachment.attachment.metadata.name.concat(
-                  '.',
-                  attachment.attachment.metadata.namespace
-                ),
-                namespace_id: attachment.attachment.metadata.namespace,
-                fully_qualified_subdomain: '',
-                owner: '',
-                zonefile_hash: attachment.attachment.hash,
-                zonefile: '',
-                latest: true,
-                tx_id: event.txid,
-                index_block_hash: parsedMsg.index_block_hash,
-                canonical: true,
-                parent_zonefile_hash: '',
-                parent_zonefile_index: 0,
-                block_height: parsedMsg.block_height,
-                zonefile_offset: 1,
-                resolver: '',
-                atch_resolved: false,
-              };
-              dbTx.subdomains.push(subdomain);
-            }
             const name: DbBnsName = {
               name: attachment.attachment.metadata.name.concat(
                 '.',


### PR DESCRIPTION
## Description
There were empty subdomains being stored in the subdomains table.  This PR fixes that. 

Closes #564.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] @zone117x for review
