### PR TITLE
[Rosetta-api] - Adding vesting info & remove public keys requierement in /metadata

### DIFF
--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -114,6 +114,7 @@ export enum RosettaErrorsTypes {
   missingTransactionSize,
   stackingEligibityError,
   invalidSubAccount,
+  missingSenderAddress,
 }
 
 // All possible errors
@@ -328,6 +329,11 @@ export const RosettaErrors: Record<RosettaErrorsTypes, RosettaError> = {
   [RosettaErrorsTypes.invalidSubAccount]: {
     code: 641,
     message: 'Invalid sub-account',
+    retriable: false,
+  },
+  [RosettaErrorsTypes.missingSenderAddress]: {
+    code: 642,
+    message: 'Missing sender address',
     retriable: false,
   },
 };

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -12,8 +12,11 @@ export const RosettaConstants = {
   rosettaVersion: '1.4.6',
   symbol: 'STX',
   decimals: 6,
-  lockedBalance: 'LockedBalance',
-  spendableBalance: 'SpendableBalance',
+  StakedBalance: 'StakedBalance',
+  SpendableBalance: 'SpendableBalance',
+  VestingLockedBalance: 'VestingLockedBalance',
+  VestingUnlockedBalance: 'VestingUnlockedBalance',
+  VestingSchedule: 'VestingSchedule',
 };
 
 export const ReferenceNodes: { [key: string]: any } = {
@@ -47,6 +50,7 @@ export const RosettaOperationTypes = [
   'mint',
   'burn',
   'miner_reward',
+  'stx_lock',
 ];
 
 export const RosettaOperationStatuses = [
@@ -109,6 +113,7 @@ export enum RosettaErrorsTypes {
   signatureTypeNotSupported,
   missingTransactionSize,
   stackingEligibityError,
+  invalidSubAccount,
 }
 
 // All possible errors
@@ -318,6 +323,11 @@ export const RosettaErrors: Record<RosettaErrorsTypes, RosettaError> = {
   [RosettaErrorsTypes.stackingEligibityError]: {
     code: 640,
     message: 'Account not eligible for stacking.',
+    retriable: false,
+  },
+  [RosettaErrorsTypes.invalidSubAccount]: {
+    code: 641,
+    message: 'Invalid sub-account',
     retriable: false,
   },
 };

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -12,7 +12,7 @@ export const RosettaConstants = {
   rosettaVersion: '1.4.6',
   symbol: 'STX',
   decimals: 6,
-  StakedBalance: 'StakedBalance',
+  StackedBalance: 'StackedBalance',
   SpendableBalance: 'SpendableBalance',
   VestingLockedBalance: 'VestingLockedBalance',
   VestingUnlockedBalance: 'VestingUnlockedBalance',

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -9,6 +9,7 @@ import {
   RosettaAccountBalanceResponse,
   RosettaSubAccount,
   AddressTokenOfferingLocked,
+  AddressUnlockSchedule,
 } from '@blockstack/stacks-blockchain-api-types';
 import { RosettaErrors, RosettaConstants, RosettaErrorsTypes } from '../../rosetta-constants';
 import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
@@ -125,10 +126,16 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
   return router;
 }
 
-function getVestingInfo(info: AddressTokenOfferingLocked): any {
-  const vestingData: any = {};
+function getVestingInfo(info: AddressTokenOfferingLocked): { [key: string]: string | string[] } {
+  const vestingData: { [key: string]: string | string[] } = {};
+  const jsonVestingSchedule: string[] = [];
+  info.unlock_schedule.forEach(schedule => {
+    const item = { amount: schedule.amount, unlock_height: schedule.block_height };
+    jsonVestingSchedule.push(JSON.stringify(item));
+  });
+
   vestingData[RosettaConstants.VestingLockedBalance] = info.total_locked;
   vestingData[RosettaConstants.VestingUnlockedBalance] = info.total_unlocked;
-  vestingData[RosettaConstants.VestingSchedule] = info.unlock_schedule;
+  vestingData[RosettaConstants.VestingSchedule] = jsonVestingSchedule;
   return vestingData;
 }

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -7,7 +7,8 @@ import {
   RosettaAccount,
   RosettaBlockIdentifier,
   RosettaAccountBalanceResponse,
-  RosettaSubAccount, AddressTokenOfferingLocked
+  RosettaSubAccount,
+  AddressTokenOfferingLocked,
 } from '@blockstack/stacks-blockchain-api-types';
 import { RosettaErrors, RosettaConstants, RosettaErrorsTypes } from '../../rosetta-constants';
 import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
@@ -80,7 +81,10 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
           break;
         case RosettaConstants.VestingLockedBalance:
         case RosettaConstants.VestingUnlockedBalance:
-          const stxVesting = await db.getTokenOfferingLocked(accountIdentifier.address, block.block_height);
+          const stxVesting = await db.getTokenOfferingLocked(
+            accountIdentifier.address,
+            block.block_height
+          );
           if (stxVesting.found) {
             const vestingInfo = getVestingInfo(stxVesting.result);
             balance = vestingInfo[subAccountIdentifier.address].toString();

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -71,7 +71,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
 
     if (subAccountIdentifier !== undefined) {
       switch (subAccountIdentifier.address) {
-        case RosettaConstants.StakedBalance:
+        case RosettaConstants.StackedBalance:
           const lockedBalance = stxBalance.locked;
           balance = lockedBalance.toString();
           break;

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -61,6 +61,7 @@ import {
   getStacksNetwork,
   makePresignHash,
   verifySignature,
+  stxAddressToBitcoinAddress,
 } from './../../../rosetta-helpers';
 import { makeRosettaError, rosettaValidateRequest, ValidSchema } from './../../rosetta-validate';
 
@@ -283,37 +284,11 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         return;
     }
 
-    if (!request.public_keys || request.public_keys.length != 1) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+    if (typeof options.sender_address === 'undefined') {
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingSenderAddress]);
       return;
     }
-
-    const publicKey: RosettaPublicKey = request.public_keys[0];
-
-    if (has0xPrefix(publicKey.hex_bytes)) {
-      publicKey.hex_bytes = publicKey.hex_bytes.replace('0x', '');
-    }
-
-    let stxAddress;
-    try {
-      const btcAddress = publicKeyToBitcoinAddress(
-        publicKey.hex_bytes,
-        request.network_identifier.network
-      );
-      if (btcAddress === undefined) {
-        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
-        return;
-      }
-      stxAddress = bitcoinAddressToSTXAddress(btcAddress);
-
-      if (stxAddress !== options.sender_address) {
-        res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
-        return;
-      }
-    } catch (e) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
-      return;
-    }
+    const stxAddress = options.sender_address;
 
     // Getting nonce info
     const accountInfo = await new StacksCoreRpcClient().getAccount(stxAddress);

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -61,7 +61,6 @@ import {
   getStacksNetwork,
   makePresignHash,
   verifySignature,
-  stxAddressToBitcoinAddress,
 } from './../../../rosetta-helpers';
 import { makeRosettaError, rosettaValidateRequest, ValidSchema } from './../../rosetta-validate';
 

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -142,6 +142,8 @@ export function processEvents(events: DbEvent[], baseTx: BaseTx, operations: Ros
         }
         break;
       case DbEventTypeId.StxLock:
+        const stxLockEvent = event as DbStxLockEvent;
+        operations.push(makeStakeLockOperation(stxLockEvent, baseTx, operations.length));
         break;
       case DbEventTypeId.NonFungibleTokenAsset:
         break;
@@ -153,6 +155,23 @@ export function processEvents(events: DbEvent[], baseTx: BaseTx, operations: Ros
         throw new Error(`Unexpected DbEventTypeId: ${txEventType}`);
     }
   });
+}
+
+function makeStakeLockOperation(
+  tx: DbStxLockEvent,
+  baseTx: BaseTx,
+  index: number
+): RosettaOperation {
+  const stake: RosettaOperation = {
+    operation_identifier: { index: index },
+    type: getEventTypeString(tx.event_type),
+    status: getTxStatus(baseTx.status),
+    account: {
+      address: unwrapOptional(tx.locked_address, () => 'Unexpected nullish locked_address'),
+    },
+  };
+
+  return stake;
 }
 
 export function getMinerOperations(minerRewards: DbMinerReward[], operations: RosettaOperation[]) {

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -286,6 +286,7 @@ describe('Rosetta API', () => {
         network_identifier: { blockchain: 'stacks', network: 'testnet' },
         block_identifier: {},
       });
+
     expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
     expect(JSON.parse(query1.text)).toEqual({
@@ -916,9 +917,6 @@ describe('Rosetta API', () => {
   });
 
   test('construction/metadata - success', async () => {
-    const publicKey = publicKeyToString(
-      getPublicKey(createStacksPrivateKey(testnetKeys[0].secretKey))
-    );
     const request: RosettaConstructionMetadataRequest = {
       network_identifier: {
         blockchain: 'stacks',
@@ -935,7 +933,6 @@ describe('Rosetta API', () => {
         max_fee: '12380898',
         size: 180,
       },
-      public_keys: [{ hex_bytes: publicKey, curve_type: 'secp256k1' }],
     };
 
     const result = await supertest(api.server)
@@ -949,43 +946,6 @@ describe('Rosetta API', () => {
     expect(JSON.parse(result.text)).toHaveProperty('metadata');
     expect(JSON.parse(result.text)).toHaveProperty('suggested_fee');
     expect(JSON.parse(result.text).suggested_fee[0].value).toBe('180');
-  });
-
-  test('construction/metadata - failure invalid public key', async () => {
-    const publicKey = publicKeyToString(
-      getPublicKey(createStacksPrivateKey(testnetKeys[2].secretKey))
-    );
-    const request: RosettaConstructionMetadataRequest = {
-      network_identifier: {
-        blockchain: 'stacks',
-        network: 'testnet',
-      },
-      options: {
-        sender_address: testnetKeys[0].stacksAddress,
-        type: 'token_transfer',
-        token_transfer_recipient_address: testnetKeys[1].stacksAddress,
-        amount: '500000',
-        symbol: 'STX',
-        decimals: 6,
-        max_fee: '12380898',
-        size: 180,
-      },
-      public_keys: [
-        {
-          hex_bytes: publicKey,
-          curve_type: 'secp256k1',
-        },
-      ],
-    };
-
-    const result = await supertest(api.server)
-      .post(`/rosetta/v1/construction/metadata`)
-      .send(request);
-
-    expect(result.status).toBe(500);
-    expect(result.type).toBe('application/json');
-
-    expect(JSON.parse(result.text)).toEqual(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
   });
 
   test('construction/metadata - empty network identifier', async () => {


### PR DESCRIPTION
## Description

This PR add `vesting` info in the Rosetta api. Locked balance now consider stacking and vesting. In Construction API, we removed the requierement for the `public_keys` when calling `/metadata` and instead use the data given in options.

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No.

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @kyranjamie or @zone117x for review
