### PR TITLE
fix: Rosetta Construction api `/submit` signature format

### DIFF
--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -436,6 +436,17 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       transaction = '0x' + transaction;
     }
 
+    let tx = rawTxToStacksTransaction(transaction);
+    if (tx.auth && tx.auth.spendingCondition && 'signature' in tx.auth.spendingCondition) {
+      tx.auth.spendingCondition.signature.data =
+        tx.auth.spendingCondition.signature.data.slice(-2) +
+        tx.auth.spendingCondition.signature.data.slice(0,-2);
+      transaction = '0x' + tx.serialize().toString('hex');
+    } else {
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
+      return;
+    }
+
     try {
       buffer = hexToBuffer(transaction);
     } catch (error) {

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -436,11 +436,11 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       transaction = '0x' + transaction;
     }
 
-    let tx = rawTxToStacksTransaction(transaction);
+    const tx = rawTxToStacksTransaction(transaction);
     if (tx.auth && tx.auth.spendingCondition && 'signature' in tx.auth.spendingCondition) {
       tx.auth.spendingCondition.signature.data =
         tx.auth.spendingCondition.signature.data.slice(-2) +
-        tx.auth.spendingCondition.signature.data.slice(0,-2);
+        tx.auth.spendingCondition.signature.data.slice(0, -2);
       transaction = '0x' + tx.serialize().toString('hex');
     } else {
       res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -1254,8 +1254,6 @@ describe('Rosetta API', () => {
   });
 
   test('construction/submit', async () => {
-    console.log('SUBMIT CALL');
-
     const txOptions = {
       senderKey: testnetKeys[0].secretKey,
       recipient: standardPrincipalCV(testnetKeys[1].stacksAddress),

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -1273,7 +1273,7 @@ describe('Rosetta API', () => {
     if (tx.auth && tx.auth.spendingCondition && 'signature' in tx.auth.spendingCondition) {
       tx.auth.spendingCondition.signature.data =
         tx.auth.spendingCondition.signature.data.slice(2) +
-        tx.auth.spendingCondition.signature.data.slice(0,2);
+        tx.auth.spendingCondition.signature.data.slice(0, 2);
     }
 
     const request: RosettaConstructionHashRequest = {


### PR DESCRIPTION
## Description

Rosetta spec don't recognize `VRS` signature format and only give a signature under the format `RSV` when sending a request to `/submit`. This PR modify the signature format back to `VRS` before submitting it to the node.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No.

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @kyranjamie or @zone117x for review
