### PR TITLE
fix: remove stack call on /payload

### DIFF
--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -115,6 +115,7 @@ export enum RosettaErrorsTypes {
   stackingEligibityError,
   invalidSubAccount,
   missingSenderAddress,
+  missingNonce,
 }
 
 // All possible errors
@@ -334,6 +335,11 @@ export const RosettaErrors: Record<RosettaErrorsTypes, RosettaError> = {
   [RosettaErrorsTypes.missingSenderAddress]: {
     code: 642,
     message: 'Missing sender address',
+    retriable: false,
+  },
+  [RosettaErrorsTypes.missingNonce]: {
+    code: 643,
+    message: 'Missing transaction nonce',
     retriable: false,
   },
 };

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -515,7 +515,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     }
 
     if (!('metadata' in req.body) || !('account_sequence' in req.body.metadata)) {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingNonce]);
       return;
     }
 

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -514,14 +514,12 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       return;
     }
 
-    const accountInfo = await new StacksCoreRpcClient().getAccount(senderAddress);
-    let nonce = new BN(0);
-
-    if ('metadata' in req.body && 'account_sequence' in req.body.metadata) {
-      nonce = new BN(req.body.metadata.account_sequence);
-    } else if (accountInfo.nonce) {
-      nonce = new BN(accountInfo.nonce);
+    if (!('metadata' in req.body) || !('account_sequence' in req.body.metadata)) {
+      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidSender]);
+      return;
     }
+
+    const nonce = new BN(req.body.metadata.account_sequence);
 
     if (publicKeys.length !== 1) {
       //TODO support multi-sig in the future.

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -1526,6 +1526,7 @@ describe('Rosetta API', () => {
       ],
       metadata: {
         fee,
+        account_sequence: 0,
       },
       public_keys: [
         {
@@ -1621,6 +1622,7 @@ describe('Rosetta API', () => {
       ],
       metadata: {
         fee: '180',
+        account_sequence: 0,
       },
     };
 
@@ -1704,7 +1706,9 @@ describe('Rosetta API', () => {
           },
         },
       ],
-      metadata: {},
+      metadata: {
+        account_sequence: 0,
+      },
       public_keys: [
         {
           hex_bytes: '025c13b2fc2261956d8a4ad07d481b1a3b2cbf93a24f992249a61c3a1c4de79c51',

--- a/src/tests-rosetta/offline-api-tests.ts
+++ b/src/tests-rosetta/offline-api-tests.ts
@@ -446,6 +446,7 @@ describe('Rosetta API', () => {
       ],
       metadata: {
         fee: fee,
+        account_sequence: 0,
       },
       public_keys: [
         {
@@ -575,6 +576,7 @@ describe('Rosetta API', () => {
       ],
       metadata: {
         fee,
+        account_sequence: 0,
       },
       public_keys: [
         {


### PR DESCRIPTION
Remove rpc calls for nonce and add a proper error if nonce is missing instead of fallback on getting nonce from node.