### PR TITLE
fix: STACKS_CHAIN_ID mismatch

### DIFF
--- a/follower.Dockerfile
+++ b/follower.Dockerfile
@@ -87,6 +87,10 @@ ENV STACKS_CORE_RPC_PORT=20443
 
 ### Startup script & coordinator
 RUN printf '#!/bin/bash\n\
+MAINNET_ID=0x00000001\n\
+MOCKNET_ID=0x80000000\n\
+[ $1 = "mocknet" ] && STACKS_CHAIN_ID="${MOCKNET_ID}" || STACKS_CHAIN_ID="${MAINNET_ID}"\n\
+export STACKS_CHAIN_ID\n\
 trap "exit" INT TERM\n\
 trap "kill 0" EXIT\n\
 echo Your container args are: "$@"\n\


### PR DESCRIPTION
## Description

Fixes `The configured STACKS_CHAIN_ID does not match` error by setting up correct environment variable `STACKS_CHAIN_ID` value.

fix #523

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
no

## Are documentation updates required?
no

## Testing information

Provide context on how tests should be performed.
1) Build standalone docker image `$ docker build -f follower.Dockerfile -t standalone-api .`
2) Run with mocknet `$ docker run --rm standalone-api mocknet` and wait until it manage to mine 2-3 blocks
3) Run with mainnet `$ docker run --rm standalone-api` and wait until it synchronizes few stacks blocks.


## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @kyranjamie or @zone117x for review
