### PR TITLE
Stricter error handling and more explicit shutdown behavior

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -46,7 +46,8 @@
         "STACKS_CHAIN_ID": "0x80000000",
         "NODE_ENV": "development",
         "TS_NODE_SKIP_IGNORE": "true"
-      }
+      },
+      "killBehavior": "polite",
     },
     {
       "type": "node",

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -609,6 +609,7 @@ export interface DataStore extends DataStoreEventEmitter {
     address: string,
     blockHeight: number
   ): Promise<FoundOrNot<AddressTokenOfferingLocked>>;
+  close(): Promise<void>;
 }
 
 export function getAssetEventId(event_index: number, event_tx_id: string): string {

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -606,4 +606,8 @@ export class MemoryDataStore
   ): Promise<FoundOrNot<AddressTokenOfferingLocked>> {
     throw new Error('Method not implemented');
   }
+
+  close() {
+    return Promise.resolve();
+  }
 }

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -537,35 +537,40 @@ function createMessageProcessorQueue(): EventMessageHandler {
       return processorQueue
         .add(() => handleClientMessage(chainId, msg, db))
         .catch(e => {
-          logError(`Error processing core node block message`, e);
+          logError(`Error processing core node block message`, e, msg);
+          throw e;
         });
     },
     handleBurnBlock: (msg: CoreNodeBurnBlockMessage, db: DataStore) => {
       return processorQueue
         .add(() => handleBurnBlockMessage(msg, db))
         .catch(e => {
-          logError(`Error processing core node burn block message`, e);
+          logError(`Error processing core node burn block message`, e, msg);
+          throw e;
         });
     },
     handleMempoolTxs: (rawTxs: string[], db: DataStore) => {
       return processorQueue
         .add(() => handleMempoolTxsMessage(rawTxs, db))
         .catch(e => {
-          logError(`Error processing core node mempool message`, e);
+          logError(`Error processing core node mempool message`, e, rawTxs);
+          throw e;
         });
     },
     handleDroppedMempoolTxs: (msg: CoreNodeDropMempoolTxMessage, db: DataStore) => {
       return processorQueue
         .add(() => handleDroppedMempoolTxsMessage(msg, db))
         .catch(e => {
-          logError(`Error processing core node dropped mempool txs message`, e);
+          logError(`Error processing core node dropped mempool txs message`, e, msg);
+          throw e;
         });
     },
     handleNewAttachment: (msg: CoreNodeAttachmentMessage[], db: DataStore) => {
       return processorQueue
         .add(() => handleNewAttachmentMessage(msg, db))
         .catch(e => {
-          logError(`Error processing new attachment message`, e);
+          logError(`Error processing new attachment message`, e, msg);
+          throw e;
         });
     },
   };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -131,15 +131,15 @@ export const logger = winston.createLogger({
   ],
 });
 
-export function logError(message: string, error?: Error) {
+export function logError(message: string, ...errorData: any[]) {
   if (isDevEnv) {
     console.error(message);
-    if (error) {
-      console.error(error);
+    if (errorData?.length > 0) {
+      errorData.forEach(e => console.error(e));
     }
   } else {
-    if (error) {
-      logger.error(message, error);
+    if (errorData?.length > 0) {
+      logger.error(message, ...errorData);
     } else {
       logger.error(message);
     }

--- a/src/shutdown-handler.ts
+++ b/src/shutdown-handler.ts
@@ -44,10 +44,9 @@ function registerShutdownSignals() {
     });
   });
   process.once('unhandledRejection', error => {
-    // TODO: This should be enabled in a standalone update, as it may cause previously ignored non-critical errors to exit the program.
-    // In the meantime, log the error without propagated it to uncaughtException.
-    // throw error;
     logError(`unhandledRejection ${(error as any)?.message ?? error}`, error as Error);
+    logger.error(`Shutting down... received unhandledRejection.`);
+    void startShutdown();
   });
   process.once('uncaughtException', error => {
     logError(`Received uncaughtException: ${error}`, error);


### PR DESCRIPTION
This PR addresses two things:
* Adds explicit shutdown requests for a couple global services that previously were either force-closed or delayed app shutdown: the prometheus http server, and the persistent postgres client pool. Also added a bunch more logging around this area.
* Stricter error handling in a couple areas that were previously logged but ignored: certain types of errors thrown while processing event observer message, and global `unhandledRejection` events.