### PR TITLE
Use correct package name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# @blockstack/stacks-blockchain-api
+# @stacks/blockchain-api-client
 
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fblockstack%2Fstacks-blockchain-api%2Fbadge%3Fref%3Dmaster&style=flat)](https://actions-badge.atrox.dev/blockstack/stacks-blockchain-api/goto?ref=master)
 


### PR DESCRIPTION
This PR replaces the package name with `@stacks/blockchain-api-client` in the readme.