### PR TITLE
fix: [Rosetta] fix unintentional global error object mutations

### DIFF
--- a/docs/api/rosetta/rosetta-network-options-response.schema.json
+++ b/docs/api/rosetta/rosetta-network-options-response.schema.json
@@ -56,7 +56,7 @@
           "type": "array",
           "description": "All Errors that this implementation could return. Any error that is returned during parsing that is not listed here will cause client validation to error.",
           "items": {
-            "$ref": "./../../entities/rosetta/rosetta-error.schema.json"
+            "$ref": "./../../entities/rosetta/rosetta-error-no-details.schema.json"
           }
         },
         "historical_balance_lookup": {

--- a/docs/entities/rosetta/rosetta-error-no-details.schema.json
+++ b/docs/entities/rosetta/rosetta-error-no-details.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "Rosetta-errors-no-details",
+  "type": "object",
+  "title": "RosettaErrorNoDetails",
+  "description": "Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields.",
+  "required": ["code", "message", "retriable"],
+  "additionalProperties": false,
+  "properties": {
+    "code": {
+      "type": "integer",
+      "description": "Code is a network-specific error code. If desired, this code can be equivalent to an HTTP status code."
+    },
+    "message": {
+      "type": "string",
+      "description": "Message is a network-specific error message. The message MUST NOT change for a given code. In particular, this means that any contextual information should be included in the details field."
+    },
+    "retriable": {
+      "type": "boolean",
+      "description": "An error is retriable if the same request may succeed if submitted again."
+    }
+  }
+}

--- a/docs/entities/rosetta/rosetta-error.schema.json
+++ b/docs/entities/rosetta/rosetta-error.schema.json
@@ -3,21 +3,8 @@
   "$id": "Rosetta-errors",
   "type": "object",
   "title": "RosettaError",
-  "description": "Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields.",
-  "required": ["code", "message", "retriable"],
+  "allOf": [{ "$ref": "./rosetta-error-no-details.schema.json" }],
   "properties": {
-    "code": {
-      "type": "integer",
-      "description": "Code is a network-specific error code. If desired, this code can be equivalent to an HTTP status code."
-    },
-    "message": {
-      "type": "string",
-      "description": "Message is a network-specific error message. The message MUST NOT change for a given code. In particular, this means that any contextual information should be included in the details field."
-    },
-    "retriable": {
-      "type": "boolean",
-      "description": "An error is retriable if the same request may succeed if submitted again."
-    },
     "details": {
       "type": "object",
       "description": "Often times it is useful to return context specific to the request that caused the error (i.e. a sample of the stack trace or impacted account) in addition to the standard error message.",

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -984,7 +984,7 @@ export interface RosettaNetworkOptionsResponse {
     /**
      * All Errors that this implementation could return. Any error that is returned during parsing that is not listed here will cause client validation to error.
      */
-    errors: RosettaError[];
+    errors: RosettaErrorNoDetails[];
     /**
      * Any Rosetta implementation that supports querying the balance of an account at any height in the past should set this to true.
      */
@@ -1874,7 +1874,7 @@ export interface RosettaCurrency {
 /**
  * Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields.
  */
-export interface RosettaError {
+export interface RosettaErrorNoDetails {
   /**
    * Code is a network-specific error code. If desired, this code can be equivalent to an HTTP status code.
    */
@@ -1887,6 +1887,12 @@ export interface RosettaError {
    * An error is retriable if the same request may succeed if submitted again.
    */
   retriable: boolean;
+}
+
+/**
+ * Instead of utilizing HTTP status codes to describe node errors (which often do not have a good analog), rich errors are returned using this object. Both the code and message fields can be individually used to correctly identify an error. Implementations MUST use unique values for both fields.
+ */
+export interface RosettaError {
   /**
    * Often times it is useful to return context specific to the request that caused the error (i.e. a sample of the stack trace or impacted account) in addition to the standard error message.
    */
@@ -1895,6 +1901,18 @@ export interface RosettaError {
     error?: string;
     [k: string]: unknown | undefined;
   };
+  /**
+   * Code is a network-specific error code. If desired, this code can be equivalent to an HTTP status code.
+   */
+  code: number;
+  /**
+   * Message is a network-specific error message. The message MUST NOT change for a given code. In particular, this means that any contextual information should be included in the details field.
+   */
+  message: string;
+  /**
+   * An error is retriable if the same request may succeed if submitted again.
+   */
+  retriable: boolean;
 }
 
 /**

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -126,7 +126,7 @@ export interface RosettaError {
   details?: Record<string, string>;
 }
 
-export const RosettaErrors: Record<RosettaErrorsTypes, RosettaError> = {
+export const RosettaErrors: Record<RosettaErrorsTypes, Readonly<RosettaError>> = {
   [RosettaErrorsTypes.invalidAccount]: {
     code: 601,
     message: 'Invalid Account.',

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -1,4 +1,5 @@
 import * as T from '@stacks/stacks-blockchain-api-types';
+import { RosettaErrorNoDetails } from '@stacks/stacks-blockchain-api-types';
 import { ChainID } from '@stacks/transactions';
 import { testnet } from 'bitcoinjs-lib/types/networks';
 
@@ -118,15 +119,7 @@ export enum RosettaErrorsTypes {
   missingNonce,
 }
 
-// All possible errors
-export interface RosettaError {
-  code: number;
-  message: string;
-  retriable: boolean;
-  details?: Record<string, string>;
-}
-
-export const RosettaErrors: Record<RosettaErrorsTypes, Readonly<RosettaError>> = {
+export const RosettaErrors: Record<RosettaErrorsTypes, Readonly<RosettaErrorNoDetails>> = {
   [RosettaErrorsTypes.invalidAccount]: {
     code: 601,
     message: 'Invalid Account.',

--- a/src/api/rosetta-validate.ts
+++ b/src/api/rosetta-validate.ts
@@ -2,7 +2,6 @@ import * as Ajv from 'ajv';
 import { hexToBuffer, logger, has0xPrefix, isValidC32Address, isValidPrincipal } from '../helpers';
 import {
   RosettaConstants,
-  RosettaError,
   RosettaErrors,
   RosettaSchemas,
   SchemaFiles,
@@ -114,7 +113,7 @@ function validHexId(
 }
 
 // TODO: there has to be a better way to go from ajv errors to rosetta errors.
-export function makeRosettaError(notValid: ValidSchema): Readonly<RosettaError> {
+export function makeRosettaError(notValid: ValidSchema): Readonly<T.RosettaError> {
   const error = notValid.error || '';
   if (error.search(/network_identifier/) != -1) {
     return {

--- a/src/api/rosetta-validate.ts
+++ b/src/api/rosetta-validate.ts
@@ -114,36 +114,49 @@ function validHexId(
 }
 
 // TODO: there has to be a better way to go from ajv errors to rosetta errors.
-export function makeRosettaError(notValid: ValidSchema): RosettaError {
-  let resp: RosettaError = RosettaErrors[RosettaErrorsTypes.unknownError];
+export function makeRosettaError(notValid: ValidSchema): Readonly<RosettaError> {
+  const error = notValid.error || '';
+  if (error.search(/network_identifier/) != -1) {
+    return {
+      ...RosettaErrors[RosettaErrorsTypes.emptyNetworkIdentifier],
+      details: { message: error },
+    };
+  } else if (error.search(/blockchain/) != -1) {
+    return {
+      ...RosettaErrors[RosettaErrorsTypes.emptyBlockchain],
+      details: { message: error },
+    };
+  } else if (error.search(/network/) != -1) {
+    return {
+      ...RosettaErrors[RosettaErrorsTypes.emptyNetwork],
+      details: { message: error },
+    };
+  } else if (error.search(/block_identifier/) != -1) {
+    return {
+      ...RosettaErrors[RosettaErrorsTypes.invalidBlockIdentifier],
+      details: { message: error },
+    };
+  } else if (error.search(/transaction_identifier/) != -1) {
+    return {
+      ...RosettaErrors[RosettaErrorsTypes.invalidTransactionIdentifier],
+      details: { message: error },
+    };
+  } else if (error.search(/operations/) != -1) {
+    return {
+      ...RosettaErrors[RosettaErrorsTypes.invalidOperation],
+      details: { message: error },
+    };
+  } else if (error.search(/should have required property/) != -1) {
+    return {
+      ...RosettaErrors[RosettaErrorsTypes.invalidParams],
+      details: { message: error },
+    };
+  }
 
   // we've already identified the problem
   if (notValid.errorType !== undefined) {
-    resp = RosettaErrors[notValid.errorType];
+    return RosettaErrors[notValid.errorType];
   }
 
-  const error = notValid.error || '';
-  if (error.search(/network_identifier/) != -1) {
-    resp = RosettaErrors[RosettaErrorsTypes.emptyNetworkIdentifier];
-    resp.details = { message: error };
-  } else if (error.search(/blockchain/) != -1) {
-    resp = RosettaErrors[RosettaErrorsTypes.emptyBlockchain];
-    resp.details = { message: error };
-  } else if (error.search(/network/) != -1) {
-    resp = RosettaErrors[RosettaErrorsTypes.emptyNetwork];
-    resp.details = { message: error };
-  } else if (error.search(/block_identifier/) != -1) {
-    resp = RosettaErrors[RosettaErrorsTypes.invalidBlockIdentifier];
-    resp.details = { message: error };
-  } else if (error.search(/transaction_identifier/) != -1) {
-    resp = RosettaErrors[RosettaErrorsTypes.invalidTransactionIdentifier];
-    resp.details = { message: error };
-  } else if (error.search(/operations/) != -1) {
-    resp = RosettaErrors[RosettaErrorsTypes.invalidOperation];
-    resp.details = { message: error };
-  } else if (error.search(/should have required property/) != -1) {
-    resp = RosettaErrors[RosettaErrorsTypes.invalidParams];
-    resp.details = { message: error };
-  }
-  return resp;
+  return RosettaErrors[RosettaErrorsTypes.unknownError];
 }

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -21,6 +21,7 @@ import {
   RosettaAmount,
   RosettaCurrency,
   RosettaTransaction,
+  RosettaError,
 } from '@stacks/stacks-blockchain-api-types';
 import {
   createMessageSignature,
@@ -462,7 +463,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       };
       res.status(200).json(response);
     } catch (e) {
-      const err = {
+      const err: RosettaError = {
         ...RosettaErrors[RosettaErrorsTypes.invalidTransactionString],
         details: { message: e.message },
       };

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -462,9 +462,9 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       };
       res.status(200).json(response);
     } catch (e) {
-      const err = RosettaErrors[RosettaErrorsTypes.invalidTransactionString];
-      err.details = {
-        message: e.message,
+      const err = {
+        ...RosettaErrors[RosettaErrorsTypes.invalidTransactionString],
+        details: { message: e.message },
       };
       res.status(500).json(err);
     }

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -1319,7 +1319,7 @@ describe('Rosetta API', () => {
 
     console.log(expectedResponse);
 
-    expect(JSON.parse(result.text)).toEqual(expectedResponse);
+    expect(JSON.parse(result.text)).toMatchObject(expectedResponse);
   });
 
   test('payloads single sign success', async () => {


### PR DESCRIPTION
Fixes https://github.com/blockstack/stacks-blockchain-api/issues/591

Global Rosetta error constants were being mutated in various API response handlers, for example:
```ts
const err = RosettaErrors[RosettaErrorsTypes.invalidTransactionString];
err.details = { message: e.message }; // <-- BAD
res.status(500).json(err);
```

This caused the list of errors returned by `/rosetta/v1/network/options` to seemingly randomly include extra error details, and break clients like the Rosetta Go SDK.

This was fixed with applying Typescript's `Readonly<T>` to the error consts, then fixing the various mutation violations provided by the Typescript compiler. 
```ts
// Previous, unsafe const definition:
const RosettaErrors: Record<RosettaErrorsTypes, RosettaError>;

// New, safe readonly const definition:
const RosettaErrors: Record<RosettaErrorsTypes, Readonly<RosettaError>>;
```