### PR TITLE
fix: rosetta no signature format modification

### DIFF
--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -437,7 +437,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       transaction = '0x' + transaction;
     }
 
-    const tx = rawTxToStacksTransaction(transaction);
+    /*const tx = rawTxToStacksTransaction(transaction);
     if (tx.auth && tx.auth.spendingCondition && 'signature' in tx.auth.spendingCondition) {
       tx.auth.spendingCondition.signature.data =
         tx.auth.spendingCondition.signature.data.slice(-2) +
@@ -446,7 +446,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     } else {
       res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
       return;
-    }
+    }*/
 
     try {
       buffer = hexToBuffer(transaction);

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -437,17 +437,6 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       transaction = '0x' + transaction;
     }
 
-    /*const tx = rawTxToStacksTransaction(transaction);
-    if (tx.auth && tx.auth.spendingCondition && 'signature' in tx.auth.spendingCondition) {
-      tx.auth.spendingCondition.signature.data =
-        tx.auth.spendingCondition.signature.data.slice(-2) +
-        tx.auth.spendingCondition.signature.data.slice(0, -2);
-      transaction = '0x' + tx.serialize().toString('hex');
-    } else {
-      res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidTransactionString]);
-      return;
-    }*/
-
     try {
       buffer = hexToBuffer(transaction);
     } catch (error) {

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -1267,12 +1267,12 @@ describe('Rosetta API', () => {
     const transaction = await makeSTXTokenTransfer(txOptions);
     const serializedTx = transaction.serialize().toString('hex');
 
-    const tx = rawTxToStacksTransaction('0x' + serializedTx);
+    /*const tx = rawTxToStacksTransaction('0x' + serializedTx);
     if (tx.auth && tx.auth.spendingCondition && 'signature' in tx.auth.spendingCondition) {
       tx.auth.spendingCondition.signature.data =
         tx.auth.spendingCondition.signature.data.slice(2) +
         tx.auth.spendingCondition.signature.data.slice(0, 2);
-    }
+    }*/
 
     const request: RosettaConstructionHashRequest = {
       network_identifier: {
@@ -1280,7 +1280,7 @@ describe('Rosetta API', () => {
         network: getRosettaNetworkName(ChainID.Testnet),
       },
       // signed transaction bytes
-      signed_transaction: '0x' + tx.serialize().toString('hex'),
+      signed_transaction: '0x' + serializedTx,
     };
     const result = await supertest(api.server)
       .post(`/rosetta/v1/construction/submit`)

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -1267,13 +1267,6 @@ describe('Rosetta API', () => {
     const transaction = await makeSTXTokenTransfer(txOptions);
     const serializedTx = transaction.serialize().toString('hex');
 
-    /*const tx = rawTxToStacksTransaction('0x' + serializedTx);
-    if (tx.auth && tx.auth.spendingCondition && 'signature' in tx.auth.spendingCondition) {
-      tx.auth.spendingCondition.signature.data =
-        tx.auth.spendingCondition.signature.data.slice(2) +
-        tx.auth.spendingCondition.signature.data.slice(0, 2);
-    }*/
-
     const request: RosettaConstructionHashRequest = {
       network_identifier: {
         blockchain: RosettaConstants.blockchain,


### PR DESCRIPTION
## Description

Reverse Rosetta Construction api signature modification. 

See old PR https://github.com/blockstack/stacks-blockchain-api/pull/572

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @kyranjamie or @zone117x for review
