### PR TITLE
fix: add a no-op handler for `/new_microblocks` events

### DIFF
--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -676,6 +676,11 @@ export async function startEventServer(opts: {
     }
   });
 
+  app.post('/new_microblocks', (req, res) => {
+    logger.info(`Ignoring /new_microblocks payload from event emitter, not yet supported.`);
+    res.status(200).json({ result: 'ok' });
+  });
+
   app.post('*', (req, res, next) => {
     res.status(404).json({ error: `no route handler for ${req.path}` });
     logError(`Unexpected event on path ${req.path}`);


### PR DESCRIPTION
Needed to support running the API with stacks-node 2.0.12.0.0