### PR TITLE
fix: issue with client doc generation in gh actions

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -30,7 +30,7 @@
     "prep-openapi": "rimraf ./.tmp && rimraf ./src/generated && swagger-cli bundle --dereference -o ./.tmp/openapi-temp.json ../docs/openapi.yaml && shx sed -i '^.*\\$schema.*$' '' ./.tmp/openapi-temp.json > ./.tmp/openapi.json",
     "generate-openapi": "npm run prep-openapi && openapi-generator-cli generate --skip-validate-spec -g typescript-fetch --additional-properties=withInterfaces=true,typescriptThreePlus=true,supportsES6=true,legacyDiscriminatorBehavior=false,enumPropertyNaming=original,modelPropertyNaming=original -i ./.tmp/openapi.json -o ./src/generated > ./.tmp/gen.log",
     "openapi-generator-version": "openapi-generator-cli version-manager list",
-    "generate:docs": "typedoc"
+    "generate:docs": "npm run generate-openapi && typedoc src/**/*.ts"
   },
   "prettier": "@stacks/prettier-config",
   "files": [

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -14,8 +14,6 @@
   },
   "include": ["./src/**/*.ts"],
   "typedocOptions": {
-    "inputFiles": ["./src"],
-    "mode": "file",
     "out": "../docs/.tmp/client"
   }
 }


### PR DESCRIPTION
Fixes issue with the gh-pages action failing while building client package docs, like here: https://github.com/blockstack/stacks-blockchain-api/runs/2621973076