### PR TITLE
fix: bundling issues

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -1,0 +1,1 @@
+// empty file to satisfy module bundlers

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "access": "public",
   "description": "TypeScript descriptions of Stacks 2.0 blockchain API entities",
-  "main": "index.d.ts",
+  "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "npm run generate:schemas",
     "test": "npm run build && npm run lint:json && npm run lint:yaml && npm run validate:schemas && npm run deploy:docs",


### PR DESCRIPTION
This is a bit of an odd fix, but we need to either:

- Export the types as a regular typescript file, not a declaration
- Trick module bundlers into thinking it's a legit module

One of the later TS versions introduces the inability to import `.d.ts` files. Declaration files are generated to describe the contents of compiled output, and thus shouldn't be imported.

The contents of this package may only be typings, but it describes our API, not the contents of a compiled script. 

See https://github.com/octokit/types.ts for another example of a type-only package.