### PR TITLE
Clean up and lint markdown for api node instructions

### DIFF
--- a/running_an_api.md
+++ b/running_an_api.md
@@ -5,6 +5,25 @@ There are several components involved here to have a working setup, and we'll go
 We'll focus on the **easy** path to get the services running, which today is using Docker.  
 Please note that the following guide is meant for a Unix-like OS (Linux/MacOS) - the commands *may* work on Windows but will likely need some adjustments (PR's welcome!).
 
+- [Running a stacks-blockchain API instance with Docker](#running-a-stacks-blockchain-api-instance-with-docker)
+  - [Requirements](#requirements)
+    - [Important](#important)
+    - [Firewalling](#firewalling)
+    - [Initial Setup](#initial-setup)
+  - [Postgres](#postgres)
+    - [Starting postgres](#starting-postgres)
+    - [Stopping Postgres](#stopping-postgres)
+  - [Stacks Blockchain API](#stacks-blockchain-api)
+    - [Starting stacks-blockchain-api](#starting-stacks-blockchain-api)
+    - [Stopping stacks-blockchain-api](#stopping-stacks-blockchain-api)
+  - [Stacks Blockchain](#stacks-blockchain)
+    - [Starting stacks-blockchain](#starting-stacks-blockchain)
+    - [Stopping stacks-blockchain](#stopping-stacks-blockchain)
+  - [Verify Everything is running correctly](#verify-everything-is-running-correctly)
+    - [Postgres testing](#postgres-testing)
+    - [stacks-blockchain testing](#stacks-blockchain-testing)
+    - [stacks-blockchain-api testing](#stacks-blockchain-api-testing)
+
 ## Requirements
 
 1. [Docker](https://docs.docker.com/engine/install/)
@@ -91,9 +110,9 @@ done
 
 The `postgres:alpine` image can be run with default settings, the only requirement is that a password Environment Variable is set for the `postgres` user: `POSTGRES_PASSWORD=postgres`
 
-### Starting postgres:
+### Starting postgres
 
-```
+```bash
 docker run -d --rm \
     --name postgres \
     --net=stacks-blockchain \
@@ -104,6 +123,7 @@ docker run -d --rm \
 ```
 
 There should now be a running postgres instance running on port `5432`:
+
 ```bash
 $ docker ps --filter name=postgres
 CONTAINER ID   IMAGE             COMMAND                  CREATED          STATUS          PORTS                                       NAMES
@@ -156,7 +176,7 @@ The other Environment Variables to pay attention to:
 - `PG_HOST`: Set this to your **postgres** instance. In this guide, we'll be using a container named `postgres`.
 - `STACKS_CORE_RPC_HOST`: Set this to your **stacks blockchain** node. In this guide, we'll be using a container named `stacks-blockchain`.
 
-### Starting stacks-blockchain-api:
+### Starting stacks-blockchain-api
 
 ```bash
 docker run -d --rm \
@@ -177,11 +197,12 @@ CONTAINER ID   IMAGE                              COMMAND                  CREAT
 a86a26da6c5a   blockstack/stacks-blockchain-api   "docker-entrypoint.s…"   1 minute ago   Up 1 minute   0.0.0.0:3700->3700/tcp, :::3700->3700/tcp, 0.0.0.0:3999->3999/tcp, :::3999->3999/tcp   stacks-blockchain-api
 ```
 
-**Note**: on initial sync, it will take several minutes for port `3999` to become available. 
+**Note**: on initial sync, it will take several minutes for port `3999` to become available.
 
 ### Stopping stacks-blockchain-api
 
 To stop the stacks-blockchain-api service (this will also remove the container):
+
 ```bash
 $ docker stop stacks-blockchain-api
 ```
@@ -233,9 +254,9 @@ read_only_call_limit_read_count = 30
 read_only_call_limit_runtime = 1000000000
 ```
 
-### Starting stacks-blockchain:
+### Starting stacks-blockchain
 
-```
+```bash
 docker run -d --rm \
     --name stacks-blockchain \
     --net=stacks-blockchain \
@@ -265,7 +286,7 @@ $ docker stop stacks-blockchain
 
 ## Verify Everything is running correctly
 
-### Postgres
+### Postgres testing
 
 To verfiy the database is ready:
 
@@ -275,7 +296,7 @@ To verfiy the database is ready:
 2. List current databases: `\l`
 3. Disconnect from the DB : `\q`
 
-### stacks-blockchain
+### stacks-blockchain testing
 
 Verify the stacks-blockchain tip height is progressing:
 
@@ -300,7 +321,7 @@ $ curl -sL localhost:20443/v2/info | jq
 }
 ```
 
-### stacks-blockchain-api
+### stacks-blockchain-api testing
 
 Verify the stacks-blockchain-api is receiving data from the stacks-blockchain:
 

--- a/running_api_from_source.md
+++ b/running_api_from_source.md
@@ -4,6 +4,26 @@ In this document, we'll go over how to run a [stacks-blockchain-api](https://git
 There are several components involved here to have a working setup, and we'll go over each.  
 Please note that the following guide is targetted for Debian based systems - that in mind, most of the commands will work on other Unix systems with some small adjustments.
 
+- [Running a stacks-blockchain API instance from source](#running-a-stacks-blockchain-api-instance-from-source)
+  - [Requirements](#requirements)
+    - [Initial Setup](#initial-setup)
+  - [Install Requirements](#install-requirements)
+  - [postgres](#postgres)
+    - [postgres permissions](#postgres-permissions)
+    - [stopping postgres](#stopping-postgres)
+  - [stacks-blockchain-api](#stacks-blockchain-api)
+    - [building stacks-blockchain-api](#building-stacks-blockchain-api)
+    - [starting stacks-blockchain-api](#starting-stacks-blockchain-api)
+    - [stopping stacks-blockchain-api](#stopping-stacks-blockchain-api)
+  - [stacks-blockchain](#stacks-blockchain)
+    - [stacks-blockchain binaries](#stacks-blockchain-binaries)
+    - [starting stacks-blockchain](#starting-stacks-blockchain)
+    - [stopping stacks-blockchain](#stopping-stacks-blockchain)
+  - [Verify Everything is running correctly](#verify-everything-is-running-correctly)
+    - [Postgres](#postgres-1)
+    - [stacks-blockchain testing](#stacks-blockchain-testing)
+    - [stacks-blockchain-api testing](#stacks-blockchain-api-testing)
+
 ## Requirements
 
 1. `bash` or some other Unix-like shell (i.e. `zsh`)
@@ -222,7 +242,7 @@ To verfiy the database is ready:
 2. List current databases: `\l`
 3. Disconnect from the DB : `\q`
 
-### stacks-blockchain
+### stacks-blockchain testing
 
 ```bash
 $ curl localhost:20443/v2/info | jq
@@ -245,7 +265,7 @@ $ curl localhost:20443/v2/info | jq
 }
 ```
 
-### stacks-blockchain-api
+### stacks-blockchain-api testing
 
 ```bash
 $ curl -sL localhost:3999/v2/info | jq

--- a/running_api_from_source.md
+++ b/running_api_from_source.md
@@ -1,17 +1,19 @@
 # Running a stacks-blockchain API instance from source
+
 In this document, we'll go over how to run a [stacks-blockchain-api](https://github.com/blockstack/stacks-blockchain-api) instance.  
 There are several components involved here to have a working setup, and we'll go over each.  
-Please note that the following guide is targetted for Debian based systems - that in mind, most of the commands will work on other Unix systems with some small adjustments.  
-  
-  
-## Requirements
-2. `bash` or some other Unix-like shell (i.e. `zsh`)
-4. `sudo` or root level access to the system
+Please note that the following guide is targetted for Debian based systems - that in mind, most of the commands will work on other Unix systems with some small adjustments.
 
+## Requirements
+
+1. `bash` or some other Unix-like shell (i.e. `zsh`)
+2. `sudo` or root level access to the system
 
 ### Initial Setup
+
 Since we'll need to create some files/dirs for persistent data,  
 we'll first create a base directory structure and set some permissions:
+
 ```bash
 $ sudo mkdir -p /stacks-node/{persistent-data/stacks-blockchain,bns,config,binaries}
 $ sudo chown -R $(whoami) /stacks-node 
@@ -19,7 +21,8 @@ $ cd /stacks-node
 ```
 
 ## Install Requirements
-```bash 
+
+```bash
 $ PG_VERSION=12
 $ NODE_VERSION=14
 $ sudo apt-get update 
@@ -43,12 +46,15 @@ $ sudo apt-get update
 ```
 
 **Optional but recommended** - If you want the V1 BNS data, there are going to be a few extra steps:
+
 1. Download the BNS data:  
 `curl -L https://storage.googleapis.com/blockstack-v1-migration-data/export-data.tar.gz -o ./bns/export-data.tar.gz`
 2. Extract the data:  
 `tar -xzvf ./bns/export-data.tar.gz -C ./bns/`
-3. Each file in `./bns` will have a corresponding `sha256` value.  
+3. Each file in `./bns` will have a corresponding `sha256` value.
+
 To Verify, run a script like the following to check the sha256sum:
+
 ```bash
 for file in `ls ./bns/* | grep -v sha256 | grep -v .tar.gz`; do
     if [ $(sha256sum $file | awk {'print $1'}) == $(cat ${file}.sha256 ) ]; then
@@ -60,9 +66,12 @@ done
 ```
 
 ## postgres
+
 ### postgres permissions
+
 We'll need to set a basic role, database to store data, and a password for the role.  
 Clearly, this password is **insecure** so modify `password` to something stronger before creating the role.  
+
 ```bash
 $ cd /stacks-node
 $ cat <<EOF> /tmp/file.sql
@@ -78,15 +87,16 @@ $ echo "local   all             stacks                                  md5" | s
 $ sudo systemctl restart postgresql
 ```
 
-
 ### stopping postgres
+
 ```bash
 $ sudo systemctl stop postgresql
 ```
 
-
 ## stacks-blockchain-api
+
 ### building stacks-blockchain-api
+
 ```bash
 $ cd /stacks-node
 $ git clone https://github.com/blockstack/stacks-blockchain-api stacks-blockchain-api && cd stacks-blockchain-api \
@@ -97,11 +107,12 @@ $ git clone https://github.com/blockstack/stacks-blockchain-api stacks-blockchai
   && npm prune --production
 ```
 
-
 ### starting stacks-blockchain-api
+
 The stacks blockchain api requires several Environment Variables to be set in order to run properly.  
 To reduce complexity, we're going to create a `.env` file that we'll use for these env vars.  
 Create a new file: `/stacks-node/stacks-blockchain-api/.env` with the following content:
+
 ```bash
 $ cat <<EOF> /stacks-node/stacks-blockchain-api/.env
 NODE_ENV=production
@@ -127,25 +138,28 @@ $ nohup node ./lib/index.js &
 ```
 
 ### stopping stacks-blockchain-api
+
 ```bash
 $ ps -ef | grep "lib/index.js" | grep -v grep
 user   17788   827 39 18:14 pts/0    00:07:55 node ./lib/index.js
 $ sudo kill 17788
 ```
 
-
 ## stacks-blockchain
-In order to have a **usable** API instance, it needs to have data from a running [stacks-blockchain](https://github.com/blockstack/stacks-blockchain) instance.  
-You will need to have the following in your `Config.toml` - this config block will send blockchain events to the API instance that was previously started: 
+
+In order to have a **usable** API instance, it needs to have data from a running [stacks-blockchain](https://github.com/blockstack/stacks-blockchain) instance.
+
+You will need to have the following in your `Config.toml` - this config block will send blockchain events to the API instance that was previously started:
+
 ```toml
 [[events_observer]]
 endpoint = "<fqdn>:3700"
 retry_count = 255
 events_keys = ["*"]
 ```
-  
-  
+
 Here is an example `Config.toml` that you can use - create this file as `/stacks-node/config/Config.toml`:
+
 ```toml
 [node]
 working_dir = "/stacks-node/persistent-data/stacks-blockchain"
@@ -176,37 +190,40 @@ read_only_call_limit_read_count = 30
 read_only_call_limit_runtime = 1000000000
 ```
 
-
 ### stacks-blockchain binaries
+
 1. Download latest release binary from https://github.com/blockstac./stacks-node/releases
   - Linux archive for [v2.0.11.0.0](https://github.com/blockstack/stacks-blockchain/releases/tag/2.0.11.0.0): `curl -sL https://github.com/blockstack/stacks-blockchain/releases/download/2.0.11.0.0/linux-x64.zip -o /tmp/linux-x64.zip`
 2. Extract the zip archive: `unzip /tmp/linux-x64.zip -d /stacks-node/binaries/`
 
-
 ### starting stacks-blockchain
+
 ```bash
 $ cd /stacks-node
 $ nohup /stacks-node/binaries/stacks-node start --config /stacks-node/config/Config.toml &
 ```
 
 ### stopping stacks-blockchain
+
 ```bash
 $ ps -ef | grep "/stacks-node/binaries/stacks-node" | grep -v grep
 user   17835 17834 99 18:17 pts/0    00:20:23 /stacks-node/binaries/stacks-node start --config /stacks-node/config/Config.toml
 $ sudo kill 17835
 ```
 
-
 ## Verify Everything is running correctly
+
 ### Postgres
-To verfiy the database is ready:  
+
+To verfiy the database is ready:
+
 1. Connect to the DB instance:  `psql -h localhost -U stacks stacks_db -P`
     - use the password from the [Postgres Permissions Step](#postgres-permissions)
 2. List current databases: `\l`
 3. Disconnect from the DB : `\q`
 
-
 ### stacks-blockchain
+
 ```bash
 $ curl localhost:20443/v2/info | jq
 {
@@ -228,8 +245,8 @@ $ curl localhost:20443/v2/info | jq
 }
 ```
 
-
 ### stacks-blockchain-api
+
 ```bash
 $ curl -sL localhost:3999/v2/info | jq
 {

--- a/running_api_from_source.md
+++ b/running_api_from_source.md
@@ -212,8 +212,8 @@ read_only_call_limit_runtime = 1000000000
 
 ### stacks-blockchain binaries
 
-1. Download latest release binary from https://github.com/blockstac./stacks-node/releases
-  - Linux archive for [v2.0.11.0.0](https://github.com/blockstack/stacks-blockchain/releases/tag/2.0.11.0.0): `curl -sL https://github.com/blockstack/stacks-blockchain/releases/download/2.0.11.0.0/linux-x64.zip -o /tmp/linux-x64.zip`
+1. Download latest release binary from https://github.com/blockstack/stacks-node/releases/latest
+  - Linux archive for [v2.0.11.1.0](https://github.com/blockstack/stacks-blockchain/releases/tag/2.0.11.1.0): `curl -sL https://github.com/blockstack/stacks-blockchain/releases/download/2.0.11.1.0/linux-x64.zip -o /tmp/linux-x64.zip`
 2. Extract the zip archive: `unzip /tmp/linux-x64.zip -d /stacks-node/binaries/`
 
 ### starting stacks-blockchain


### PR DESCRIPTION
## Description

This PR updates some of the spacing, layout, and content per the [markdownlint extension](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) specifications.

This PR intentionally avoids removing the `$` from commands, although this is recommended if an input is not shown below. For now, it seemed better to leave everything consistent to what was there before.

This PR also adds a TOC to each file, generated by the VSCode extension. If using the same extension, the TOC is updated on save.

1. Motivation for change: after following the instructions saw a typo, and thought I'd give it a full once over
2. What was changed: mostly spacing, some headers, detailed notes in commits
3. How does this impact application developers: makes the document more accessible

No related issue filed, but main motivator for the changes was this typo:

```none
### stacks-blockchain binaries
1. Download latest release binary from https://github.com/blockstac./stacks-node/releases
```

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [x] Other: markdownlint cleanup

## Does this introduce a breaking change?

Nope.

## Are documentation updates required?

Nope, updates are relevant to these files only.

## Testing information

No testing required.

## Checklist

Left blank - can fill in but a very minor change overall.

- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated - is this necessary?
- [ ] Tag 1 of @kyranjamie or @zone117x for review
