### PR TITLE
[rosetta] prioritize blockhash over index for /block and fix -0 amount values

### DIFF
--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -268,10 +268,10 @@ export async function getRosettaBlockFromDataStore(
   blockHeight?: number
 ): Promise<FoundOrNot<RosettaBlock>> {
   let query;
-  if (blockHeight && blockHeight > 0) {
-    query = db.getBlockByHeight(blockHeight);
-  } else if (blockHash) {
+  if (blockHash) {
     query = db.getBlock(blockHash);
+  } else if (blockHeight && blockHeight > 0) {
+    query = db.getBlockByHeight(blockHeight);
   } else {
     query = db.getCurrentBlock();
   }

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -210,7 +210,7 @@ function makeFeeOperation(tx: BaseTx): RosettaOperation {
     status: getTxStatus(DbTxStatus.Success),
     account: { address: tx.sender_address },
     amount: {
-      value: (0n - tx.fee_rate).toString(10),
+      value: (0n - unwrapOptional(tx.fee_rate, () => 'Unexpected nullish amount')).toString(10),
       currency: getStxCurrencyMetadata(),
     },
   };
@@ -227,7 +227,7 @@ function makeBurnOperation(tx: DbStxEvent, baseTx: BaseTx, index: number): Roset
       address: unwrapOptional(baseTx.sender_address, () => 'Unexpected nullish sender_address'),
     },
     amount: {
-      value: '-' + unwrapOptional(tx.amount, () => 'Unexpected nullish amount').toString(10),
+      value: (0n - unwrapOptional(tx.amount, () => 'Unexpected nullish amount')).toString(10),
       currency: getStxCurrencyMetadata(),
     },
   };
@@ -263,12 +263,10 @@ function makeSenderOperation(tx: BaseTx, index: number): RosettaOperation {
       address: unwrapOptional(tx.sender_address, () => 'Unexpected nullish sender_address'),
     },
     amount: {
-      value:
-        '-' +
-        unwrapOptional(
-          tx.token_transfer_amount,
-          () => 'Unexpected nullish token_transfer_amount'
-        ).toString(10),
+      value: (
+        0n -
+        unwrapOptional(tx.token_transfer_amount, () => 'Unexpected nullish token_transfer_amount')
+      ).toString(10),
       currency: getStxCurrencyMetadata(),
     },
     coin_change: {


### PR DESCRIPTION
This PR fixes two things:
1. prioritize using the `blockhash` over `index` when both are provided for `rosetta/v1/block` endpoint
2. fix `-0` value in amount for rosetta operations that caused rosetta-sdk-go to error when parsing

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @kyranjamie or @zone117x for review
