### PR TITLE
Singular TX with STX transfer endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.62.0](https://github.com/blockstack/stacks-blockchain-api/compare/v0.61.0...v0.62.0) (2021-06-24)
+
+
+### Features
+
+* adding regtest network ([d333d30](https://github.com/blockstack/stacks-blockchain-api/commit/d333d3071fe2da365bed987b3efe17a471c189a9))
+
 # [0.61.0](https://github.com/blockstack/stacks-blockchain-api/compare/v0.60.0...v0.61.0) (2021-05-19)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.62.1](https://github.com/blockstack/stacks-blockchain-api/compare/v0.62.0...v0.62.1) (2021-06-29)
+
+
+### Bug Fixes
+
+* prioritize blockhash over block index when both are provided ([feab6a6](https://github.com/blockstack/stacks-blockchain-api/commit/feab6a65ea037c9c85bfc30fe6718251f681af01))
+* remove possibility of -0 amount ([b28d890](https://github.com/blockstack/stacks-blockchain-api/commit/b28d8900d31e858f7f3d2ce077fe9331f9eeb346))
+
 # [0.62.0](https://github.com/blockstack/stacks-blockchain-api/compare/v0.61.0...v0.62.0) (2021-06-24)
 
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4,6 +4,8 @@ servers:
     description: Mainnet
   - url: https://stacks-node-api.testnet.stacks.co/
     description: Testnet
+  - url: https://stacks-node-api.regtest.stacks.co/
+    description: Regtest
   - url: http://localhost:3999/
     description: Local
 info:
@@ -2144,7 +2146,7 @@ paths:
                 $ref: ./api/bns/errors/bns-error.schema.json
               example:
                 $ref: ./api/bns/errors/bns-invalid-tx-id.example.json
-  
+
   /extended/v1/tx/block/{block_hash}:
     get:
       operationId: get_transactions_by_block_hash
@@ -2252,6 +2254,3 @@ paths:
                 $ref: ./api/transaction/get-mempool-transactions.schema.json
               example:
                 $ref: ./api/transaction/get-mempool-transactions.example.json
-
-                
-

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -887,7 +887,7 @@ paths:
               example:
                 $ref: ./api/address/get-address-transactions.example.json
   
-  /extended/v1/address/{principal}/{txs_id}/tranasactions_with_transfer:
+  /extended/v1/address/{principal}/{tx_id}/transactions_with_transfer:
     get:
       summary: Get account transaction information for specific transaction
       tags:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -886,8 +886,28 @@ paths:
                 $ref: ./api/address/get-address-transactions.schema.json
               example:
                 $ref: ./api/address/get-address-transactions.example.json
+  
+  /extended/v1/address/{principal}/{txs_id}/tranasctions_with_transfer:
+    get:
+      summary: Get account transaction information for specific transaction
+      tags:
+        - Accounts
+      operationId: get_single_transaction_with_transfers
+      parameters:
+        - name: principal
+          in: path
+          description: Stacks address or a contract identifier
+          required: true
+          schema: 
+            type: string
+        - name: txs_id
+          in: path
+          description: Transaction id
+          required: true
+          schema:
+            type: string
 
-  /extended/v1/address/{principal}/transactions_with_transfers:
+  /extended/v1/address/{principal}/{txs_address}/transactions_with_transfers:
     get:
       summary: Get account transactions including STX transfers for each transaction.
       tags:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -887,7 +887,7 @@ paths:
               example:
                 $ref: ./api/address/get-address-transactions.example.json
   
-  /extended/v1/address/{principal}/{txs_id}/tranasctions_with_transfer:
+  /extended/v1/address/{principal}/{txs_id}/tranasactions_with_transfer:
     get:
       summary: Get account transaction information for specific transaction
       tags:
@@ -900,7 +900,7 @@ paths:
           required: true
           schema: 
             type: string
-        - name: txs_id
+        - name: tx_id
           in: path
           description: Transaction id
           required: true

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -907,7 +907,7 @@ paths:
           schema:
             type: string
 
-  /extended/v1/address/{principal}/{txs_address}/transactions_with_transfers:
+  /extended/v1/address/{principal}/transactions_with_transfers:
     get:
       summary: Get account transactions including STX transfers for each transaction.
       tags:

--- a/running_an_api.md
+++ b/running_an_api.md
@@ -5,6 +5,25 @@ There are several components involved here to have a working setup, and we'll go
 We'll focus on the **easy** path to get the services running, which today is using Docker.  
 Please note that the following guide is meant for a Unix-like OS (Linux/MacOS) - the commands *may* work on Windows but will likely need some adjustments (PR's welcome!).
 
+- [Running a stacks-blockchain API instance with Docker](#running-a-stacks-blockchain-api-instance-with-docker)
+  - [Requirements](#requirements)
+    - [Important](#important)
+    - [Firewalling](#firewalling)
+    - [Initial Setup](#initial-setup)
+  - [Postgres](#postgres)
+    - [Starting postgres](#starting-postgres)
+    - [Stopping Postgres](#stopping-postgres)
+  - [Stacks Blockchain API](#stacks-blockchain-api)
+    - [Starting stacks-blockchain-api](#starting-stacks-blockchain-api)
+    - [Stopping stacks-blockchain-api](#stopping-stacks-blockchain-api)
+  - [Stacks Blockchain](#stacks-blockchain)
+    - [Starting stacks-blockchain](#starting-stacks-blockchain)
+    - [Stopping stacks-blockchain](#stopping-stacks-blockchain)
+  - [Verify Everything is running correctly](#verify-everything-is-running-correctly)
+    - [Postgres testing](#postgres-testing)
+    - [stacks-blockchain testing](#stacks-blockchain-testing)
+    - [stacks-blockchain-api testing](#stacks-blockchain-api-testing)
+
 ## Requirements
 
 1. [Docker](https://docs.docker.com/engine/install/)
@@ -91,9 +110,9 @@ done
 
 The `postgres:alpine` image can be run with default settings, the only requirement is that a password Environment Variable is set for the `postgres` user: `POSTGRES_PASSWORD=postgres`
 
-### Starting postgres:
+### Starting postgres
 
-```
+```bash
 docker run -d --rm \
     --name postgres \
     --net=stacks-blockchain \
@@ -104,6 +123,7 @@ docker run -d --rm \
 ```
 
 There should now be a running postgres instance running on port `5432`:
+
 ```bash
 $ docker ps --filter name=postgres
 CONTAINER ID   IMAGE             COMMAND                  CREATED          STATUS          PORTS                                       NAMES
@@ -156,7 +176,7 @@ The other Environment Variables to pay attention to:
 - `PG_HOST`: Set this to your **postgres** instance. In this guide, we'll be using a container named `postgres`.
 - `STACKS_CORE_RPC_HOST`: Set this to your **stacks blockchain** node. In this guide, we'll be using a container named `stacks-blockchain`.
 
-### Starting stacks-blockchain-api:
+### Starting stacks-blockchain-api
 
 ```bash
 docker run -d --rm \
@@ -177,11 +197,12 @@ CONTAINER ID   IMAGE                              COMMAND                  CREAT
 a86a26da6c5a   blockstack/stacks-blockchain-api   "docker-entrypoint.s…"   1 minute ago   Up 1 minute   0.0.0.0:3700->3700/tcp, :::3700->3700/tcp, 0.0.0.0:3999->3999/tcp, :::3999->3999/tcp   stacks-blockchain-api
 ```
 
-**Note**: on initial sync, it will take several minutes for port `3999` to become available. 
+**Note**: on initial sync, it will take several minutes for port `3999` to become available.
 
 ### Stopping stacks-blockchain-api
 
 To stop the stacks-blockchain-api service (this will also remove the container):
+
 ```bash
 $ docker stop stacks-blockchain-api
 ```
@@ -233,9 +254,9 @@ read_only_call_limit_read_count = 30
 read_only_call_limit_runtime = 1000000000
 ```
 
-### Starting stacks-blockchain:
+### Starting stacks-blockchain
 
-```
+```bash
 docker run -d --rm \
     --name stacks-blockchain \
     --net=stacks-blockchain \
@@ -265,7 +286,7 @@ $ docker stop stacks-blockchain
 
 ## Verify Everything is running correctly
 
-### Postgres
+### Postgres testing
 
 To verfiy the database is ready:
 
@@ -275,7 +296,7 @@ To verfiy the database is ready:
 2. List current databases: `\l`
 3. Disconnect from the DB : `\q`
 
-### stacks-blockchain
+### stacks-blockchain testing
 
 Verify the stacks-blockchain tip height is progressing:
 
@@ -300,7 +321,7 @@ $ curl -sL localhost:20443/v2/info | jq
 }
 ```
 
-### stacks-blockchain-api
+### stacks-blockchain-api testing
 
 Verify the stacks-blockchain-api is receiving data from the stacks-blockchain:
 

--- a/running_api_from_source.md
+++ b/running_api_from_source.md
@@ -4,6 +4,26 @@ In this document, we'll go over how to run a [stacks-blockchain-api](https://git
 There are several components involved here to have a working setup, and we'll go over each.  
 Please note that the following guide is targetted for Debian based systems - that in mind, most of the commands will work on other Unix systems with some small adjustments.
 
+- [Running a stacks-blockchain API instance from source](#running-a-stacks-blockchain-api-instance-from-source)
+  - [Requirements](#requirements)
+    - [Initial Setup](#initial-setup)
+  - [Install Requirements](#install-requirements)
+  - [postgres](#postgres)
+    - [postgres permissions](#postgres-permissions)
+    - [stopping postgres](#stopping-postgres)
+  - [stacks-blockchain-api](#stacks-blockchain-api)
+    - [building stacks-blockchain-api](#building-stacks-blockchain-api)
+    - [starting stacks-blockchain-api](#starting-stacks-blockchain-api)
+    - [stopping stacks-blockchain-api](#stopping-stacks-blockchain-api)
+  - [stacks-blockchain](#stacks-blockchain)
+    - [stacks-blockchain binaries](#stacks-blockchain-binaries)
+    - [starting stacks-blockchain](#starting-stacks-blockchain)
+    - [stopping stacks-blockchain](#stopping-stacks-blockchain)
+  - [Verify Everything is running correctly](#verify-everything-is-running-correctly)
+    - [Postgres](#postgres-1)
+    - [stacks-blockchain testing](#stacks-blockchain-testing)
+    - [stacks-blockchain-api testing](#stacks-blockchain-api-testing)
+
 ## Requirements
 
 1. `bash` or some other Unix-like shell (i.e. `zsh`)
@@ -222,7 +242,7 @@ To verfiy the database is ready:
 2. List current databases: `\l`
 3. Disconnect from the DB : `\q`
 
-### stacks-blockchain
+### stacks-blockchain testing
 
 ```bash
 $ curl localhost:20443/v2/info | jq
@@ -245,7 +265,7 @@ $ curl localhost:20443/v2/info | jq
 }
 ```
 
-### stacks-blockchain-api
+### stacks-blockchain-api testing
 
 ```bash
 $ curl -sL localhost:3999/v2/info | jq

--- a/running_api_from_source.md
+++ b/running_api_from_source.md
@@ -1,17 +1,19 @@
 # Running a stacks-blockchain API instance from source
+
 In this document, we'll go over how to run a [stacks-blockchain-api](https://github.com/blockstack/stacks-blockchain-api) instance.  
 There are several components involved here to have a working setup, and we'll go over each.  
-Please note that the following guide is targetted for Debian based systems - that in mind, most of the commands will work on other Unix systems with some small adjustments.  
-  
-  
-## Requirements
-2. `bash` or some other Unix-like shell (i.e. `zsh`)
-4. `sudo` or root level access to the system
+Please note that the following guide is targetted for Debian based systems - that in mind, most of the commands will work on other Unix systems with some small adjustments.
 
+## Requirements
+
+1. `bash` or some other Unix-like shell (i.e. `zsh`)
+2. `sudo` or root level access to the system
 
 ### Initial Setup
+
 Since we'll need to create some files/dirs for persistent data,  
 we'll first create a base directory structure and set some permissions:
+
 ```bash
 $ sudo mkdir -p /stacks-node/{persistent-data/stacks-blockchain,bns,config,binaries}
 $ sudo chown -R $(whoami) /stacks-node 
@@ -19,7 +21,8 @@ $ cd /stacks-node
 ```
 
 ## Install Requirements
-```bash 
+
+```bash
 $ PG_VERSION=12
 $ NODE_VERSION=14
 $ sudo apt-get update 
@@ -43,12 +46,15 @@ $ sudo apt-get update
 ```
 
 **Optional but recommended** - If you want the V1 BNS data, there are going to be a few extra steps:
+
 1. Download the BNS data:  
 `curl -L https://storage.googleapis.com/blockstack-v1-migration-data/export-data.tar.gz -o ./bns/export-data.tar.gz`
 2. Extract the data:  
 `tar -xzvf ./bns/export-data.tar.gz -C ./bns/`
-3. Each file in `./bns` will have a corresponding `sha256` value.  
+3. Each file in `./bns` will have a corresponding `sha256` value.
+
 To Verify, run a script like the following to check the sha256sum:
+
 ```bash
 for file in `ls ./bns/* | grep -v sha256 | grep -v .tar.gz`; do
     if [ $(sha256sum $file | awk {'print $1'}) == $(cat ${file}.sha256 ) ]; then
@@ -60,9 +66,12 @@ done
 ```
 
 ## postgres
+
 ### postgres permissions
+
 We'll need to set a basic role, database to store data, and a password for the role.  
 Clearly, this password is **insecure** so modify `password` to something stronger before creating the role.  
+
 ```bash
 $ cd /stacks-node
 $ cat <<EOF> /tmp/file.sql
@@ -78,15 +87,16 @@ $ echo "local   all             stacks                                  md5" | s
 $ sudo systemctl restart postgresql
 ```
 
-
 ### stopping postgres
+
 ```bash
 $ sudo systemctl stop postgresql
 ```
 
-
 ## stacks-blockchain-api
+
 ### building stacks-blockchain-api
+
 ```bash
 $ cd /stacks-node
 $ git clone https://github.com/blockstack/stacks-blockchain-api stacks-blockchain-api && cd stacks-blockchain-api \
@@ -97,11 +107,12 @@ $ git clone https://github.com/blockstack/stacks-blockchain-api stacks-blockchai
   && npm prune --production
 ```
 
-
 ### starting stacks-blockchain-api
+
 The stacks blockchain api requires several Environment Variables to be set in order to run properly.  
 To reduce complexity, we're going to create a `.env` file that we'll use for these env vars.  
 Create a new file: `/stacks-node/stacks-blockchain-api/.env` with the following content:
+
 ```bash
 $ cat <<EOF> /stacks-node/stacks-blockchain-api/.env
 NODE_ENV=production
@@ -127,25 +138,28 @@ $ nohup node ./lib/index.js &
 ```
 
 ### stopping stacks-blockchain-api
+
 ```bash
 $ ps -ef | grep "lib/index.js" | grep -v grep
 user   17788   827 39 18:14 pts/0    00:07:55 node ./lib/index.js
 $ sudo kill 17788
 ```
 
-
 ## stacks-blockchain
-In order to have a **usable** API instance, it needs to have data from a running [stacks-blockchain](https://github.com/blockstack/stacks-blockchain) instance.  
-You will need to have the following in your `Config.toml` - this config block will send blockchain events to the API instance that was previously started: 
+
+In order to have a **usable** API instance, it needs to have data from a running [stacks-blockchain](https://github.com/blockstack/stacks-blockchain) instance.
+
+You will need to have the following in your `Config.toml` - this config block will send blockchain events to the API instance that was previously started:
+
 ```toml
 [[events_observer]]
 endpoint = "<fqdn>:3700"
 retry_count = 255
 events_keys = ["*"]
 ```
-  
-  
+
 Here is an example `Config.toml` that you can use - create this file as `/stacks-node/config/Config.toml`:
+
 ```toml
 [node]
 working_dir = "/stacks-node/persistent-data/stacks-blockchain"
@@ -176,37 +190,40 @@ read_only_call_limit_read_count = 30
 read_only_call_limit_runtime = 1000000000
 ```
 
-
 ### stacks-blockchain binaries
+
 1. Download latest release binary from https://github.com/blockstac./stacks-node/releases
   - Linux archive for [v2.0.11.0.0](https://github.com/blockstack/stacks-blockchain/releases/tag/2.0.11.0.0): `curl -sL https://github.com/blockstack/stacks-blockchain/releases/download/2.0.11.0.0/linux-x64.zip -o /tmp/linux-x64.zip`
 2. Extract the zip archive: `unzip /tmp/linux-x64.zip -d /stacks-node/binaries/`
 
-
 ### starting stacks-blockchain
+
 ```bash
 $ cd /stacks-node
 $ nohup /stacks-node/binaries/stacks-node start --config /stacks-node/config/Config.toml &
 ```
 
 ### stopping stacks-blockchain
+
 ```bash
 $ ps -ef | grep "/stacks-node/binaries/stacks-node" | grep -v grep
 user   17835 17834 99 18:17 pts/0    00:20:23 /stacks-node/binaries/stacks-node start --config /stacks-node/config/Config.toml
 $ sudo kill 17835
 ```
 
-
 ## Verify Everything is running correctly
+
 ### Postgres
-To verfiy the database is ready:  
+
+To verfiy the database is ready:
+
 1. Connect to the DB instance:  `psql -h localhost -U stacks stacks_db -P`
     - use the password from the [Postgres Permissions Step](#postgres-permissions)
 2. List current databases: `\l`
 3. Disconnect from the DB : `\q`
 
-
 ### stacks-blockchain
+
 ```bash
 $ curl localhost:20443/v2/info | jq
 {
@@ -228,8 +245,8 @@ $ curl localhost:20443/v2/info | jq
 }
 ```
 
-
 ### stacks-blockchain-api
+
 ```bash
 $ curl -sL localhost:3999/v2/info | jq
 {

--- a/running_api_from_source.md
+++ b/running_api_from_source.md
@@ -212,8 +212,8 @@ read_only_call_limit_runtime = 1000000000
 
 ### stacks-blockchain binaries
 
-1. Download latest release binary from https://github.com/blockstac./stacks-node/releases
-  - Linux archive for [v2.0.11.0.0](https://github.com/blockstack/stacks-blockchain/releases/tag/2.0.11.0.0): `curl -sL https://github.com/blockstack/stacks-blockchain/releases/download/2.0.11.0.0/linux-x64.zip -o /tmp/linux-x64.zip`
+1. Download latest release binary from https://github.com/blockstack/stacks-node/releases/latest
+  - Linux archive for [v2.0.11.1.0](https://github.com/blockstack/stacks-blockchain/releases/tag/2.0.11.1.0): `curl -sL https://github.com/blockstack/stacks-blockchain/releases/download/2.0.11.1.0/linux-x64.zip -o /tmp/linux-x64.zip`
 2. Extract the zip archive: `unzip /tmp/linux-x64.zip -d /stacks-node/binaries/`
 
 ### starting stacks-blockchain

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -268,10 +268,10 @@ export async function getRosettaBlockFromDataStore(
   blockHeight?: number
 ): Promise<FoundOrNot<RosettaBlock>> {
   let query;
-  if (blockHeight && blockHeight > 0) {
-    query = db.getBlockByHeight(blockHeight);
-  } else if (blockHash) {
+  if (blockHash) {
     query = db.getBlock(blockHash);
+  } else if (blockHeight && blockHeight > 0) {
+    query = db.getBlockByHeight(blockHeight);
   } else {
     query = db.getCurrentBlock();
   }

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -193,14 +193,12 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
     res.json(response);
   });
 
-  router.getAsync('/:stx_address/:txs_id/transactions_with_transfers', async (req, res) => {
+  router.getAsync('/:stx_address/:tx_id/transactions_with_transfers', async (req, res) => {
     const stxAddress = req.params['stx_address'];
-    const txsId = req.params['txs_id'];
+    const txsId = req.params['tx_id'];
     if (!isValidPrincipal(stxAddress)) {
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
     }
-    // check if txs_id is valid too
-
     const results = await db.getInformationTxsWithStxTransfers({ stxAddress, txsId });
     if (results && results.tx) {
       const txQuery = await getTxFromDataStore(db, { txId: results.tx.tx_id });

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -7,6 +7,7 @@ import {
   bufferToHexPrefixString,
   formatMapToObject,
   getSendManyContract,
+  has0xPrefix,
   isProdEnv,
   isValidC32Address,
   isValidPrincipal,
@@ -195,11 +196,14 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
 
   router.getAsync('/:stx_address/:tx_id/transactions_with_transfers', async (req, res) => {
     const stxAddress = req.params['stx_address'];
-    const txsId = req.params['tx_id'];
+    let tx_id = req.params['tx_id'];
     if (!isValidPrincipal(stxAddress)) {
       return res.status(400).json({ error: `invalid STX address "${stxAddress}"` });
     }
-    const results = await db.getInformationTxsWithStxTransfers({ stxAddress, txsId });
+    if (!has0xPrefix(tx_id)) {
+      tx_id = '0x' + tx_id;
+    }
+    const results = await db.getInformationTxsWithStxTransfers({ stxAddress, tx_id });
     if (results && results.tx) {
       const txQuery = await getTxFromDataStore(db, { txId: results.tx.tx_id });
       if (!txQuery.found) {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -536,7 +536,7 @@ export interface DataStore extends DataStoreEventEmitter {
 
   getInformationTxsWithStxTransfers(args: {
     stxAddress: string;
-    txsId: string;
+    tx_id: string;
   }): Promise<DbTxWithStxTransfers>;
 
   getAddressAssetEvents(args: {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -534,6 +534,11 @@ export interface DataStore extends DataStoreEventEmitter {
     height?: number;
   }): Promise<{ results: DbTxWithStxTransfers[]; total: number }>;
 
+  getInformationTxsWithStxTransfers(args: {
+    stxAddress: string;
+    txsId: string;
+  }): Promise<DbTxWithStxTransfers>;
+
   getAddressAssetEvents(args: {
     stxAddress: string;
     limit: number;

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -443,7 +443,7 @@ export class MemoryDataStore
 
   getInformationTxsWithStxTransfers(args: {
     stxAddress: string;
-    txsId: string;
+    tx_id: string;
   }): Promise<DbTxWithStxTransfers> {
     throw new Error('not yet implemented');
   }

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -441,6 +441,13 @@ export class MemoryDataStore
     throw new Error('not yet implemented');
   }
 
+  getInformationTxsWithStxTransfers(args: {
+    stxAddress: string;
+    txsId: string;
+  }): Promise<DbTxWithStxTransfers> {
+    throw new Error('not yet implemented');
+  }
+
   getAddressTxsWithStxTransfers(args: {
     stxAddress: string;
     limit: number;

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -3231,13 +3231,13 @@ export class PgDataStore
               token_transfer_recipient_address = $1 OR
               contract_call_contract_id = $1 OR
               smart_contract_contract_id = $1
-            ) 
+            )
             UNION
             SELECT txs.* FROM txs
             LEFT OUTER JOIN stx_events
             ON txs.tx_id = stx_events.tx_id
             WHERE 
-              txs.canonical = true AND
+              txs.canonical = true AND 
               (stx_events.sender = $1 OR stx_events.recipient = $1)
           )
           SELECT ${TX_COLUMNS}, (COUNT(*) OVER())::integer as count

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -3079,6 +3079,114 @@ export class PgDataStore
     });
   }
 
+  async getInformationTxsWithStxTransfers({
+    stxAddress,
+    txsId,
+  }: {
+    stxAddress: string;
+    txsId: string;
+  }): Promise<DbTxWithStxTransfers> {
+    return this.query(async client => {
+      const queryParams: (string | Buffer)[] = [stxAddress, hexToBuffer(txsId)];
+      const resultQuery = await client.query<
+        TxQueryResult & {
+          count: number;
+          event_index?: number;
+          event_type?: number;
+          event_amount?: string;
+          event_sender?: string;
+          event_recipient?: string;
+        }
+      >(
+        `
+      SELECT 
+        tx_results.*, 
+        events.event_index as event_index, 
+        events.asset_event_type_id as event_type,
+        events.amount as event_amount,
+        events.sender as event_sender,
+        events.recipient as event_recipient
+      FROM (
+        WITH transactions AS (
+          SELECT *
+          FROM txs
+          WHERE canonical = true AND txs.tx_id = $2 AND (
+            sender_address = $1 OR
+            token_transfer_recipient_address = $1 OR
+            contract_call_contract_id = $1 OR
+            smart_contract_contract_id = $1
+          ) 
+          UNION
+          SELECT txs.* FROM txs
+          LEFT OUTER JOIN stx_events
+          ON txs.tx_id = stx_events.tx_id
+          WHERE 
+            txs.canonical = true AND txs.tx_id = $2 AND 
+            (stx_events.sender = $1 OR stx_events.recipient = $1)
+        )
+        SELECT ${TX_COLUMNS}, (COUNT(*) OVER())::integer as count
+        FROM transactions
+        ORDER BY block_height DESC, tx_index DESC
+      ) tx_results
+      LEFT JOIN (
+        SELECT *
+        FROM stx_events
+        WHERE canonical = true AND (sender = $1 OR recipient = $1)
+      ) events
+      ON tx_results.tx_id = events.tx_id AND tx_results.tx_id = $2
+      ORDER BY block_height DESC, tx_index DESC, event_index DESC
+      `,
+        queryParams
+      );
+      const txs = new Map<
+        string,
+        {
+          tx: DbTx;
+          stx_sent: bigint;
+          stx_received: bigint;
+          stx_transfers: {
+            amount: bigint;
+            sender?: string;
+            recipient?: string;
+          }[];
+        }
+      >();
+
+      for (const r of resultQuery.rows) {
+        const txId = bufferToHexPrefixString(r.tx_id);
+        let txResult = txs.get(txId);
+        if (!txResult) {
+          txResult = {
+            tx: this.parseTxQueryResult(r),
+            stx_sent: 0n,
+            stx_received: 0n,
+            stx_transfers: [],
+          };
+          if (txResult.tx.sender_address === stxAddress) {
+            txResult.stx_sent += txResult.tx.fee_rate;
+          }
+          txs.set(txId, txResult);
+        }
+        if (r.event_index !== undefined && r.event_index !== null) {
+          const eventAmount = BigInt(r.event_amount as string);
+          txResult.stx_transfers.push({
+            amount: eventAmount,
+            sender: r.event_sender,
+            recipient: r.event_recipient,
+          });
+          if (r.event_sender === stxAddress) {
+            txResult.stx_sent += eventAmount;
+          }
+          if (r.event_recipient === stxAddress) {
+            txResult.stx_received += eventAmount;
+          }
+        }
+      }
+      const txTransfers = [...txs.values()];
+      return txTransfers[0];
+    });
+  }
+
   async getAddressTxsWithStxTransfers({
     stxAddress,
     limit,
@@ -3123,13 +3231,13 @@ export class PgDataStore
               token_transfer_recipient_address = $1 OR
               contract_call_contract_id = $1 OR
               smart_contract_contract_id = $1
-            )
+            ) 
             UNION
             SELECT txs.* FROM txs
             LEFT OUTER JOIN stx_events
             ON txs.tx_id = stx_events.tx_id
             WHERE 
-              txs.canonical = true AND 
+              txs.canonical = true AND
               (stx_events.sender = $1 OR stx_events.recipient = $1)
           )
           SELECT ${TX_COLUMNS}, (COUNT(*) OVER())::integer as count

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -3081,13 +3081,13 @@ export class PgDataStore
 
   async getInformationTxsWithStxTransfers({
     stxAddress,
-    txsId,
+    tx_id,
   }: {
     stxAddress: string;
-    txsId: string;
+    tx_id: string;
   }): Promise<DbTxWithStxTransfers> {
     return this.query(async client => {
-      const queryParams: (string | Buffer)[] = [stxAddress, hexToBuffer(txsId)];
+      const queryParams: (string | Buffer)[] = [stxAddress, hexToBuffer(tx_id)];
       const resultQuery = await client.query<
         TxQueryResult & {
           count: number;

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -210,7 +210,7 @@ function makeFeeOperation(tx: BaseTx): RosettaOperation {
     status: getTxStatus(DbTxStatus.Success),
     account: { address: tx.sender_address },
     amount: {
-      value: (0n - tx.fee_rate).toString(10),
+      value: (0n - unwrapOptional(tx.fee_rate, () => 'Unexpected nullish amount')).toString(10),
       currency: getStxCurrencyMetadata(),
     },
   };
@@ -227,7 +227,7 @@ function makeBurnOperation(tx: DbStxEvent, baseTx: BaseTx, index: number): Roset
       address: unwrapOptional(baseTx.sender_address, () => 'Unexpected nullish sender_address'),
     },
     amount: {
-      value: '-' + unwrapOptional(tx.amount, () => 'Unexpected nullish amount').toString(10),
+      value: (0n - unwrapOptional(tx.amount, () => 'Unexpected nullish amount')).toString(10),
       currency: getStxCurrencyMetadata(),
     },
   };
@@ -263,12 +263,10 @@ function makeSenderOperation(tx: BaseTx, index: number): RosettaOperation {
       address: unwrapOptional(tx.sender_address, () => 'Unexpected nullish sender_address'),
     },
     amount: {
-      value:
-        '-' +
-        unwrapOptional(
-          tx.token_transfer_amount,
-          () => 'Unexpected nullish token_transfer_amount'
-        ).toString(10),
+      value: (
+        0n -
+        unwrapOptional(tx.token_transfer_amount, () => 'Unexpected nullish token_transfer_amount')
+      ).toString(10),
       currency: getStxCurrencyMetadata(),
     },
     coin_change: {

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -1883,6 +1883,7 @@ describe('api tests', () => {
     const testAddr2 = 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4';
     const testContractAddr = 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world';
     const testAddr4 = 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C';
+    const testTxsId = '0x12340006';
 
     const block: DbBlock = {
       block_hash: '0x1234',
@@ -2093,6 +2094,60 @@ describe('api tests', () => {
     };
     expect(JSON.parse(fetch1.text)).toEqual(expected1);
 
+    // testing single txs information based on given tx_id
+    const fetchSingleTxsInformation = await supertest(api.server).get(
+      `/extended/v1/address/${testAddr4}/${testTxsId}/transactions_with_transfers`
+    );
+    expect(fetchSingleTxsInformation.status).toBe(200);
+    expect(fetchSingleTxsInformation.type).toBe('application/json');
+    const expectedSingleTxsInformation = {
+      tx: {
+        tx_id: '0x12340006',
+        tx_type: 'token_transfer',
+        nonce: 0,
+        fee_rate: '1234',
+        sender_address: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
+        sponsored: false,
+        post_condition_mode: 'allow',
+        tx_status: 'success',
+        block_hash: '0x9876',
+        block_height: 68456,
+        burn_block_time: 1594647994,
+        burn_block_time_iso: '2020-07-13T13:46:34.000Z',
+        canonical: true,
+        tx_index: 6,
+        tx_result: { hex: '0x0100000000000000000000000000000001', repr: 'u1' },
+        token_transfer: {
+          recipient_address: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
+          amount: '35',
+          memo: '0x6869',
+        },
+        events: [],
+        event_count: 0,
+      },
+      stx_sent: '0',
+      stx_received: '105',
+      stx_transfers: [
+        {
+          amount: '35',
+          sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
+          recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
+        },
+        {
+          amount: '35',
+          sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
+          recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
+        },
+        {
+          amount: '35',
+          sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
+          recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
+        },
+      ],
+    };
+    expect(JSON.parse(fetchSingleTxsInformation.text)).toEqual(expectedSingleTxsInformation);
+
+    // testing for multiple tx_ids given a single stx addr
     const fetch2 = await supertest(api.server).get(
       `/extended/v1/address/${testAddr4}/transactions_with_transfers`
     );

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -1883,7 +1883,7 @@ describe('api tests', () => {
     const testAddr2 = 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4';
     const testContractAddr = 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world';
     const testAddr4 = 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C';
-    const testTxsId = '0x12340006';
+    const testTxId = '0x12340006';
 
     const block: DbBlock = {
       block_hash: '0x1234',
@@ -2095,12 +2095,12 @@ describe('api tests', () => {
     expect(JSON.parse(fetch1.text)).toEqual(expected1);
 
     // testing single txs information based on given tx_id
-    const fetchSingleTxsInformation = await supertest(api.server).get(
-      `/extended/v1/address/${testAddr4}/${testTxsId}/transactions_with_transfers`
+    const fetchSingleTxInformation = await supertest(api.server).get(
+      `/extended/v1/address/${testAddr4}/${testTxId}/transactions_with_transfers`
     );
-    expect(fetchSingleTxsInformation.status).toBe(200);
-    expect(fetchSingleTxsInformation.type).toBe('application/json');
-    const expectedSingleTxsInformation = {
+    expect(fetchSingleTxInformation.status).toBe(200);
+    expect(fetchSingleTxInformation.type).toBe('application/json');
+    const expectedSingleTxInformation = {
       tx: {
         tx_id: '0x12340006',
         tx_type: 'token_transfer',
@@ -2145,7 +2145,7 @@ describe('api tests', () => {
         },
       ],
     };
-    expect(JSON.parse(fetchSingleTxsInformation.text)).toEqual(expectedSingleTxsInformation);
+    expect(JSON.parse(fetchSingleTxInformation.text)).toEqual(expectedSingleTxInformation);
 
     // testing for multiple tx_ids given a single stx addr
     const fetch2 = await supertest(api.server).get(


### PR DESCRIPTION
## Description

This feature includes fetching information regarding a single transaction based on their tx_id. It adds a new API that can respond with transaction info such that tx_id and principle are given to it. The test case for this functionality has also been merged with the previously added test case for transaction with transfers. 

```
const principle = 'ST000000000000000000002AMW42H';
const tx_id = '0xcba511741b230bd85cb5b3b10d26e0b92695d4a83f95c260cad82a40cd764235';

const api = `/extended/v1/address/${principle}/${tx_id}/transactions_with_transfers/`;
```
For more details, refer to the following issue
https://github.com/blockstack/stacks-blockchain-api/issues/622

## Type of Change
- [x] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
This is a separate feature that doesn't have any impact on the previously developed features.

## Testing information
Upon calling the API with valid principle and tx_id, it should return the information for that particular transaction. If either of the two fields is incorrect, an error will be returned.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @kyranjamie or @zone117x for review