### PR TITLE
Fix rosetta network/status api issue

### DIFF
--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -20,17 +20,6 @@ export const RosettaConstants = {
   VestingSchedule: 'VestingSchedule',
 };
 
-export const ReferenceNodes: { [key: string]: any } = {
-  mainnet: {
-    host: 'seed-2.mainnet.stacks.co',
-    port: '20443',
-  },
-  testnet: {
-    host: 'testnet.stacks.co',
-    port: '20443',
-  },
-};
-
 export function getRosettaNetworkName(chainId: ChainID): string {
   if (chainId === ChainID.Mainnet) {
     return RosettaNetworks.mainnet;


### PR DESCRIPTION
## Description
This removes the hardcoded `stacks.co` URLs  in `rosetta` `network/status` api and uses `STACKS_CORE_RPC_HOST`  and `STACKS_CORE_RPC_PORT` environment variables instead.

closes #656 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review
