### PR TITLE
[Rosetta][Construction-API] fix constructing stacking tx using /preprocess

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12282,8 +12282,7 @@
     "lodash.set": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
-      "dev": true
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -12876,6 +12875,32 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nock": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.1.1.tgz",
+      "integrity": "sha512-YKTR9MjfK3kS9/l4nuTxyYm30cgOExRHzkLNhL8nhEUyU4f8Za/dRxOqjhVT1vGs0svWo3dDnJTUX1qxYeWy5w==",
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -14315,6 +14340,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag=="
     },
     "proxy-addr": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "jsonc-parser": "^3.0.0",
     "jsonrpc-lite": "^2.1.0",
     "micro-base58": "^0.5.0",
+    "nock": "^13.1.1",
     "node-fetch": "^2.6.0",
     "node-pg-migrate": "^5.9.0",
     "p-queue": "^6.3.0",

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -181,7 +181,6 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           fee: new BN(0),
           // placeholder public key
           publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
-          network: getStacksNetwork(),
           // We don't know the non yet but need a placeholder
           nonce: new BN(0),
         };
@@ -208,8 +207,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           functionName: 'stack-stx',
           publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
           functionArgs: [uintCV(options.amount), poxAddressCV, uintCV(0), uintCV(0)],
-          validateWithAbi: true,
-          network: getStacksNetwork(),
+          validateWithAbi: false,
         };
         transaction = await makeUnsignedContractCall(dummyStackingTx);
         break;
@@ -231,8 +229,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
             noneCV(),
             noneCV(),
           ],
-          validateWithAbi: true,
-          network: getStacksNetwork(),
+          validateWithAbi: false,
         };
         transaction = await makeUnsignedContractCall(dummyStackingTx);
         break;

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -181,6 +181,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           fee: new BN(0),
           // placeholder public key
           publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
+          network: getStacksNetwork(),
           // We don't know the non yet but need a placeholder
           nonce: new BN(0),
         };
@@ -208,6 +209,9 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
           functionArgs: [uintCV(options.amount), poxAddressCV, uintCV(0), uintCV(0)],
           validateWithAbi: false,
+          network: getStacksNetwork(),
+          fee: new BN(0),
+          nonce: new BN(0),
         };
         transaction = await makeUnsignedContractCall(dummyStackingTx);
         break;
@@ -230,6 +234,9 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
             noneCV(),
           ],
           validateWithAbi: false,
+          network: getStacksNetwork(),
+          fee: new BN(0),
+          nonce: new BN(0),
         };
         transaction = await makeUnsignedContractCall(dummyStackingTx);
         break;

--- a/src/tests-rosetta/offline-api-tests.ts
+++ b/src/tests-rosetta/offline-api-tests.ts
@@ -45,6 +45,7 @@ import {
 import { OfflineDummyStore } from '../datastore/offline-dummy-store';
 import { getStacksTestnetNetwork, testnetKeys } from '../api/routes/debug';
 import { getSignature, getStacksNetwork } from '../rosetta-helpers';
+import * as nock from 'nock';
 describe('Rosetta API', () => {
   let db: DataStore;
   let api: ApiServer;
@@ -52,6 +53,8 @@ describe('Rosetta API', () => {
   beforeAll(async () => {
     db = OfflineDummyStore;
     api = await startApiServer({ datastore: db, chainId: ChainID.Testnet });
+    nock.disableNetConnect();
+    nock.enableNetConnect('127.0.0.1:3999');
   });
 
   test('Success: offline - network/list', async () => {
@@ -295,11 +298,13 @@ describe('Rosetta API', () => {
     const recipientAddr = 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0';
     const amount = new BN(1000);
     const fee = new BN(180);
+    const nonce = new BN(0);
     const options: SignedTokenTransferOptions = {
       recipient: recipientAddr,
       amount: amount,
       fee: fee,
       senderKey: testnetKeys[0].secretKey,
+      nonce: nonce,
       network: getStacksTestnetNetwork(),
     };
     const testTransaction = await makeSTXTokenTransfer(options);
@@ -338,10 +343,12 @@ describe('Rosetta API', () => {
     const recipientAddr = 'STDE7Y8HV3RX8VBM2TZVWJTS7ZA1XB0SSC3NEVH0';
     const amount = new BN(1000);
     const fee = new BN(180);
+    const nonce = new BN(0);
     const tokenTransferOptions: UnsignedTokenTransferOptions = {
       recipient: recipientAddr,
       amount: amount,
       fee: fee,
+      nonce: nonce,
       publicKey: publicKey,
       network: getStacksTestnetNetwork(),
     };
@@ -718,5 +725,6 @@ describe('Rosetta API', () => {
 
   afterAll(async () => {
     await api.terminate();
+    nock.enableNetConnect()
   });
 });


### PR DESCRIPTION
## Description
This PR fixes the bug for rosetta `construction/preprocess`. The PR was making an api request to the node where it was supposed to work offline. 

fixes #674 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
_NO_
## Are documentation updates required?
_NO_

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x]  @zone117x for review
