### PR TITLE
Fix/payload stacking contract details

### DIFF
--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -117,6 +117,8 @@ export enum RosettaErrorsTypes {
   invalidSubAccount,
   missingSenderAddress,
   missingNonce,
+  missingContractAddress,
+  missingContractName,
 }
 
 export const RosettaErrors: Record<RosettaErrorsTypes, Readonly<RosettaErrorNoDetails>> = {
@@ -333,6 +335,16 @@ export const RosettaErrors: Record<RosettaErrorsTypes, Readonly<RosettaErrorNoDe
   [RosettaErrorsTypes.missingNonce]: {
     code: 643,
     message: 'Missing transaction nonce',
+    retriable: false,
+  },
+  [RosettaErrorsTypes.missingContractAddress]: {
+    code: 644,
+    message: 'Missing contract address',
+    retriable: false,
+  },
+  [RosettaErrorsTypes.missingContractName]: {
+    code: 645,
+    message: 'Missing contract name',
     retriable: false,
   },
 };

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -630,7 +630,9 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
             uintCV(options.burn_block_height),
             uintCV(options.number_of_cycles),
           ],
-          validateWithAbi: true,
+          fee: new BN(options.fee),
+          nonce: nonce,
+          validateWithAbi: false,
           network: getStacksNetwork(),
         };
         transaction = await makeUnsignedContractCall(stackingTx);
@@ -683,7 +685,9 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
             uintCV(options.burn_block_height),
             poxAddressCV,
           ],
-          validateWithAbi: true,
+          fee: new BN(options.fee),
+          nonce: nonce,
+          validateWithAbi: false,
           network: getStacksNetwork(),
         };
         transaction = await makeUnsignedContractCall(stackingTx);

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -603,15 +603,15 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
-        if (!options.contract_address) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+        if (!req.body.metadata.contract_address) {
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingContractAddress]);
           return;
         }
-        if (!options.contract_name) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+        if (!req.body.metadata.contract_name) {
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingContractName]);
           return;
         }
-        if (!options.burn_block_height) {
+        if (!req.body.metadata.burn_block_height) {
           res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
@@ -620,14 +620,14 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           return;
         }
         const stackingTx: UnsignedContractCallOptions = {
-          contractAddress: options.contract_address,
-          contractName: options.contract_name,
+          contractAddress: req.body.metadata.contract_address,
+          contractName: req.body.metadata.contract_name,
           functionName: 'stack-stx',
           publicKey: publicKeys[0].hex_bytes,
           functionArgs: [
             uintCV(options.amount),
             poxAddressCV,
-            uintCV(options.burn_block_height),
+            uintCV(req.body.metadata.burn_block_height),
             uintCV(options.number_of_cycles),
           ],
           fee: new BN(options.fee),
@@ -658,15 +658,15 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
-        if (!options.contract_address) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+        if (!req.body.metadata.contract_address) {
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingContractAddress]);
           return;
         }
-        if (!options.contract_name) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+        if (!req.body.metadata.contract_name) {
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.missingContractName]);
           return;
         }
-        if (!options.burn_block_height) {
+        if (!req.body.metadata.burn_block_height) {
           res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
@@ -675,14 +675,14 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           return;
         }
         const stackingTx: UnsignedContractCallOptions = {
-          contractAddress: options.contract_address,
-          contractName: options.contract_name,
+          contractAddress: req.body.metadata.contract_address,
+          contractName: req.body.metadata.contract_name,
           functionName: 'delegate-stx',
           publicKey: publicKeys[0].hex_bytes,
           functionArgs: [
             uintCV(options.amount),
             standardPrincipalCV(options.delegate_to),
-            uintCV(options.burn_block_height),
+            uintCV(req.body.metadata.burn_block_height),
             poxAddressCV,
           ],
           fee: new BN(options.fee),

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -418,13 +418,9 @@ export function getOptionsFromOperations(operations: RosettaOperation[]): Rosett
         options.sender_address = operation.account?.address;
         options.type = operation.type;
         options.number_of_cycles = operation.metadata.number_of_cycles;
-        options.burn_block_height = operation.metadata?.burn_block_height as number;
         options.amount = operation.amount?.value.replace('-', '');
         options.symbol = operation.amount?.currency.symbol;
         options.decimals = operation.amount?.currency.decimals;
-        options.contract_address = operation.metadata?.contract_address as string;
-        options.contract_name = operation.metadata?.contract_name as string;
-
         break;
       case 'delegate-stacking':
         if (operation.amount && BigInt(operation.amount.value) > 0) {
@@ -436,12 +432,9 @@ export function getOptionsFromOperations(operations: RosettaOperation[]): Rosett
         options.sender_address = operation.account?.address;
         options.type = operation.type;
         options.delegate_to = operation.metadata?.delegate_to;
-        options.burn_block_height = operation.metadata?.burn_block_height as number;
         options.amount = operation.amount?.value.replace('-', '');
         options.symbol = operation.amount?.currency.symbol;
         options.decimals = operation.amount?.currency.decimals;
-        options.contract_address = operation.metadata?.contract_address as string;
-        options.contract_name = operation.metadata?.contract_name as string;
         break;
       default:
         return null;

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -422,6 +422,8 @@ export function getOptionsFromOperations(operations: RosettaOperation[]): Rosett
         options.amount = operation.amount?.value.replace('-', '');
         options.symbol = operation.amount?.currency.symbol;
         options.decimals = operation.amount?.currency.decimals;
+        options.contract_address = operation.metadata?.contract_address as string;
+        options.contract_name = operation.metadata?.contract_name as string;
 
         break;
       case 'delegate-stacking':
@@ -438,6 +440,8 @@ export function getOptionsFromOperations(operations: RosettaOperation[]): Rosett
         options.amount = operation.amount?.value.replace('-', '');
         options.symbol = operation.amount?.currency.symbol;
         options.decimals = operation.amount?.currency.decimals;
+        options.contract_address = operation.metadata?.contract_address as string;
+        options.contract_name = operation.metadata?.contract_name as string;
         break;
       default:
         return null;

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -1614,16 +1614,18 @@ describe('Rosetta API', () => {
             },
           },
           metadata: {
-            number_of_cycles: number_of_cycles, 
-            contract_address: contract_address, 
-            contract_name: contract_name,
-            burn_block_height: burn_block_height, 
+            number_of_cycles: number_of_cycles,
 
           }
         },
       ],
       metadata: {
         account_sequence: 0,
+        number_of_cycles: number_of_cycles, 
+        contract_address: contract_address, 
+        contract_name: contract_name,
+        burn_block_height: burn_block_height, 
+
       },
       public_keys: [
         {

--- a/src/tests-rosetta/offline-api-tests.ts
+++ b/src/tests-rosetta/offline-api-tests.ts
@@ -4,11 +4,13 @@ import * as supertest from 'supertest';
 import { DataStore } from '../datastore/common';
 import {
   AuthType,
+  bufferCV,
   ChainID,
   createStacksPrivateKey,
   getPublicKey,
   makeSigHashPreSign,
   makeSTXTokenTransfer,
+  makeUnsignedContractCall,
   makeUnsignedSTXTokenTransfer,
   MessageSignature,
   pubKeyfromPrivKey,
@@ -16,6 +18,9 @@ import {
   SignedTokenTransferOptions,
   standardPrincipalCV,
   TransactionSigner,
+  tupleCV,
+  uintCV,
+  UnsignedContractCallOptions,
   UnsignedTokenTransferOptions,
 } from '@stacks/transactions';
 import * as BN from 'bn.js';
@@ -44,8 +49,9 @@ import {
 } from '../api/rosetta-constants';
 import { OfflineDummyStore } from '../datastore/offline-dummy-store';
 import { getStacksTestnetNetwork, testnetKeys } from '../api/routes/debug';
-import { getSignature, getStacksNetwork } from '../rosetta-helpers';
+import { getSignature, getStacksNetwork, publicKeyToBitcoinAddress } from '../rosetta-helpers';
 import * as nock from 'nock';
+import { decodeBtcAddress } from '@stacks/stacking';
 describe('Rosetta API', () => {
   let db: DataStore;
   let api: ApiServer;
@@ -605,6 +611,147 @@ describe('Rosetta API', () => {
     expect(result.type).toBe('application/json');
 
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.needOnePublicKey];
+
+    expect(JSON.parse(result.text)).toEqual(expectedResponse);
+  });
+
+
+  test('payloads single sign - stacking', async () => {
+    const publicKey = publicKeyToString(pubKeyfromPrivKey(testnetKeys[0].secretKey));
+    const sender = testnetKeys[0].stacksAddress;
+    const fee = '180';
+    const contract_address = 'ST000000000000000000002AMW42H';
+    const contract_name = 'pox';
+    const stacking_amount = 5000;
+    const burn_block_height = 200;
+    const number_of_cycles = 5;
+
+    const request: RosettaConstructionPayloadsRequest = {
+      network_identifier: {
+        blockchain: 'stacks',
+        network: 'testnet',
+      },
+      operations: [
+        {
+          operation_identifier: {
+            index: 1,
+            network_index: 0,
+          },
+          related_operations: [],
+          type: 'fee',
+          account: {
+            address: sender,
+            metadata: {},
+          },
+          amount: {
+            value: fee,
+            currency: {
+              symbol: 'STX',
+              decimals: 6,
+            },
+            metadata:{
+            	number_of_cycles: 5
+            },
+          },
+        },
+        {
+          operation_identifier: {
+            index: 1,
+            network_index: 0,
+          },
+          related_operations: [],
+          type: 'stacking',
+          account: {
+            address: sender,
+            metadata: {},
+          },
+          amount: {
+            value: '-' + stacking_amount,
+            currency: {
+              symbol: 'STX',
+              decimals: 6,
+            },
+          },
+          metadata: {
+            number_of_cycles: number_of_cycles, 
+            contract_address: contract_address, 
+            contract_name: contract_name,
+            burn_block_height: burn_block_height, 
+
+          }
+        },
+      ],
+      metadata: {
+        account_sequence: 0,
+      },
+      public_keys: [
+        {
+          hex_bytes: publicKey,
+          curve_type: 'secp256k1',
+        },
+      ],
+    };
+
+    const poxBTCAddress = publicKeyToBitcoinAddress(
+      publicKey,
+      'testnet'
+    ) as string;
+
+    const { hashMode, data } = decodeBtcAddress(poxBTCAddress);
+    const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
+    const hashbytes = bufferCV(data);
+    const poxAddressCV = tupleCV({
+      hashbytes,
+      version: hashModeBuffer,
+    });
+
+
+    const stackingTx: UnsignedContractCallOptions = {
+      contractAddress: contract_address,
+      contractName: contract_name,
+      functionName: 'stack-stx',
+      publicKey: publicKey,
+      functionArgs: [
+        uintCV(stacking_amount),
+        poxAddressCV,
+        uintCV(burn_block_height),
+        uintCV(number_of_cycles),
+      ],
+      validateWithAbi: false,
+      nonce: new BN(0), 
+      fee: new BN(fee),
+      network: getStacksNetwork(),
+    };
+    const transaction = await makeUnsignedContractCall(stackingTx);
+    const unsignedTransaction = transaction.serialize();
+    // const hexBytes = digestSha512_256(unsignedTransaction).toString('hex');
+
+    const signer = new TransactionSigner(transaction);
+
+    const prehash = makeSigHashPreSign(signer.sigHash, AuthType.Standard, new BN(fee), new BN(0));
+
+    const result = await supertest(api.server)
+      .post(`/rosetta/v1/construction/payloads`)
+      .send(request);
+
+    expect(result.status).toBe(200);
+    expect(result.type).toBe('application/json');
+
+    const accountIdentifier: RosettaAccountIdentifier = {
+      address: sender,
+    };
+
+    const expectedResponse = {
+      unsigned_transaction: '0x' + unsignedTransaction.toString('hex'),
+      payloads: [
+        {
+          address: sender,
+          account_identifier: accountIdentifier,
+          hex_bytes: prehash,
+          signature_type: 'ecdsa_recovery',
+        },
+      ],
+    };
 
     expect(JSON.parse(result.text)).toEqual(expectedResponse);
   });

--- a/src/tests-rosetta/offline-api-tests.ts
+++ b/src/tests-rosetta/offline-api-tests.ts
@@ -674,15 +674,15 @@ describe('Rosetta API', () => {
           },
           metadata: {
             number_of_cycles: number_of_cycles, 
-            contract_address: contract_address, 
-            contract_name: contract_name,
-            burn_block_height: burn_block_height, 
 
           }
         },
       ],
       metadata: {
         account_sequence: 0,
+        contract_address: contract_address, 
+        contract_name: contract_name,
+        burn_block_height: burn_block_height, 
       },
       public_keys: [
         {


### PR DESCRIPTION
## Description
This PR fixes the rosetta construction `/payloads` API to create stacking transactions. It also fixes the offline issue with `/payloads`. It was supposed to run in offline mode. 

closes #684 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Testing information

Added test cases in offline and online tests
npm run test:integration:rosetta

you can test it by not supplying `contract_address` or `contract_name` in the `stacking` operation `metadata`
the API should fail. 


## Checklist
- [ ] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] @zone117x for review
