### PR TITLE
Support reward address for stacking transactions

### DIFF
--- a/docs/entities/rosetta/rosetta-construction-options.schema.json
+++ b/docs/entities/rosetta/rosetta-construction-options.schema.json
@@ -14,7 +14,10 @@
       "description": "Type of operation e.g transfer"
     },
     "status": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "This value indicates the state of the operations"
     },
     "token_transfer_recipient_address": {
@@ -67,7 +70,7 @@
     },
     "contract_name": {
       "type": "string",
-      "description": "Name of the contract to call."  
+      "description": "Name of the contract to call."
     },
     "burn_block_height": {
       "type": "integer",
@@ -75,7 +78,11 @@
     },
     "delegate_to": {
       "type": "string",
-      "description": "Delegator address for when calling `delegate-stacking`."  
+      "description": "Delegator address for when calling `delegate-stacking`."
+    },
+    "pox_addr": {
+      "type": "string",
+      "description": "The reward address for stacking transaction. It should be a valid Bitcoin address"
     }
   }
 }

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -2238,6 +2238,10 @@ export interface RosettaOptions {
    * Delegator address for when calling `delegate-stacking`.
    */
   delegate_to?: string;
+  /**
+   * The reward address for stacking transaction. It should be a valid Bitcoin address
+   */
+  pox_addr?: string;
   [k: string]: unknown | undefined;
 }
 /**

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -44,6 +44,8 @@ import {
   bufferCV,
   standardPrincipalCV,
   noneCV,
+  OptionalCV,
+  someCV,
 } from '@stacks/transactions';
 import { decodeBtcAddress } from '@stacks/stacking';
 import * as express from 'express';
@@ -189,9 +191,18 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         transaction = await makeUnsignedSTXTokenTransfer(dummyTokenTransferTx);
         break;
       case 'stacking': {
+        if (!options.number_of_cycles) {
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          return;
+        }
+
+        if (!options.pox_addr) {
+          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
+          return;
+        }
         // dummy transaction to calculate size
-        const dummyPoxAddress = '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3';
-        const { hashMode, data } = decodeBtcAddress(dummyPoxAddress);
+        const poxAddress = options.pox_addr;
+        const { hashMode, data } = decodeBtcAddress(poxAddress);
         const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
         const hashbytes = bufferCV(data);
         const poxAddressCV = tupleCV({
@@ -207,7 +218,12 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           contractName: 'pox',
           functionName: 'stack-stx',
           publicKey: '000000000000000000000000000000000000000000000000000000000000000000',
-          functionArgs: [uintCV(options.amount), poxAddressCV, uintCV(0), uintCV(0)],
+          functionArgs: [
+            uintCV(options.amount),
+            poxAddressCV,
+            uintCV(0),
+            uintCV(options.number_of_cycles),
+          ],
           validateWithAbi: false,
           network: getStacksNetwork(),
           fee: new BN(0),
@@ -222,6 +238,21 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidOperation]);
           return;
         }
+
+        let optionalPoxAddressCV: OptionalCV = noneCV();
+        if (options.pox_addr) {
+          const dummyPoxAddress = options.pox_addr;
+          const { hashMode, data } = decodeBtcAddress(dummyPoxAddress);
+          const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
+          const hashbytes = bufferCV(data);
+          optionalPoxAddressCV = someCV(
+            tupleCV({
+              hashbytes,
+              version: hashModeBuffer,
+            })
+          );
+        }
+
         const dummyStackingTx: UnsignedContractCallOptions = {
           contractAddress: 'ST000000000000000000002AMW42H',
           contractName: 'pox',
@@ -231,7 +262,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
             uintCV(options.amount),
             standardPrincipalCV('ST22X605P0QX2BJC3NXEENXDPFCNJPHE02DTX5V74'),
             noneCV(),
-            noneCV(),
+            optionalPoxAddressCV,
           ],
           validateWithAbi: false,
           network: getStacksNetwork(),
@@ -353,6 +384,11 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     const feeInfo = await new StacksCoreRpcClient().getEstimatedTransferFee();
     if (feeInfo === undefined || feeInfo === '0') {
       res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidFee]);
+      return;
+    }
+
+    if (!options.size) {
+      res.status(500).json(RosettaErrorsTypes.missingTransactionSize);
       return;
     }
     const feeValue = (BigInt(feeInfo) * BigInt(options.size)).toString();
@@ -584,14 +620,11 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         break;
       }
       case 'stacking': {
-        const poxBTCAddress = publicKeyToBitcoinAddress(
-          publicKeys[0].hex_bytes,
-          req.body.network_identifier.network
-        );
-        if (!poxBTCAddress) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+        if (!options.pox_addr) {
+          res.status(500).json(RosettaErrorsTypes.invalidOperation);
           return;
         }
+        const poxBTCAddress = options.pox_addr;
         const { hashMode, data } = decodeBtcAddress(poxBTCAddress);
         const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
         const hashbytes = bufferCV(data);
@@ -639,14 +672,11 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         break;
       }
       case 'delegate-stacking': {
-        const poxBTCAddress = publicKeyToBitcoinAddress(
-          publicKeys[0].hex_bytes,
-          req.body.network_identifier.network
-        );
-        if (!poxBTCAddress) {
-          res.status(500).json(RosettaErrors[RosettaErrorsTypes.invalidPublicKey]);
+        if (!options.pox_addr) {
+          res.status(500).json(RosettaErrorsTypes.invalidOperation);
           return;
         }
+        const poxBTCAddress = options.pox_addr;
         const { hashMode, data } = decodeBtcAddress(poxBTCAddress);
         const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
         const hashbytes = bufferCV(data);

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -421,6 +421,7 @@ export function getOptionsFromOperations(operations: RosettaOperation[]): Rosett
         options.amount = operation.amount?.value.replace('-', '');
         options.symbol = operation.amount?.currency.symbol;
         options.decimals = operation.amount?.currency.decimals;
+        options.pox_addr = operation.metadata?.pox_addr as string;
         break;
       case 'delegate-stacking':
         if (operation.amount && BigInt(operation.amount.value) > 0) {
@@ -435,6 +436,7 @@ export function getOptionsFromOperations(operations: RosettaOperation[]): Rosett
         options.amount = operation.amount?.value.replace('-', '');
         options.symbol = operation.amount?.currency.symbol;
         options.decimals = operation.amount?.currency.decimals;
+        options.pox_addr = operation.metadata?.pox_addr as string;
         break;
       default:
         return null;

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -1615,6 +1615,7 @@ describe('Rosetta API', () => {
           },
           metadata: {
             number_of_cycles: number_of_cycles,
+            pox_addr : '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3',
 
           }
         },
@@ -1635,10 +1636,7 @@ describe('Rosetta API', () => {
       ],
     };
 
-    const poxBTCAddress = publicKeyToBitcoinAddress(
-      publicKey,
-      'testnet'
-    ) as string;
+    const poxBTCAddress = '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3'
 
     const { hashMode, data } = decodeBtcAddress(poxBTCAddress);
     const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));
@@ -2160,80 +2158,6 @@ describe('Rosetta API', () => {
     const expectedResponse = RosettaErrors[RosettaErrorsTypes.signatureNotVerified];
 
     expect(JSON.parse(result.text)).toEqual(expectedResponse);
-  });
-
-  test('construction/preprocess - stacking', async () => {
-    const request: RosettaConstructionPreprocessRequest = {
-      network_identifier: {
-        blockchain: RosettaConstants.blockchain,
-        network: getRosettaNetworkName(ChainID.Testnet),
-      },
-      operations: [
-        {
-          operation_identifier: {
-            index: 0,
-            network_index: 0,
-          },
-          related_operations: [],
-          type: 'stacking',
-          account: {
-            address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
-            metadata: {},
-          },
-          amount: {
-            value: '-500000',
-            currency: {
-              symbol: 'STX',
-              decimals: 6,
-            },
-            metadata: {},
-          },
-          metadata: {
-            number_of_cycles: 3,
-          },
-        },
-      ],
-      metadata: {},
-      max_fee: [
-        {
-          value: '12380898',
-          currency: {
-            symbol: 'STX',
-            decimals: 6,
-          },
-          metadata: {},
-        },
-      ],
-      suggested_fee_multiplier: 1,
-    };
-
-    const result = await supertest(api.server)
-      .post(`/rosetta/v1/construction/preprocess`)
-      .send(request);
-
-    expect(result.status).toBe(200);
-    expect(result.type).toBe('application/json');
-
-    const expectResponse: RosettaConstructionPreprocessResponse = {
-      options: {
-        sender_address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
-        type: 'stacking',
-        suggested_fee_multiplier: 1,
-        amount: '500000',
-        symbol: 'STX',
-        decimals: 6,
-        max_fee: '12380898',
-        size: 260,
-        number_of_cycles: 3,
-      },
-      required_public_keys: [
-        {
-          address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
-        },
-      ],
-    };
-
-    expect(JSON.parse(result.text)).toEqual(expectResponse);
   });
 
   // TODO: fails with:

--- a/src/tests-rosetta/offline-api-tests.ts
+++ b/src/tests-rosetta/offline-api-tests.ts
@@ -274,6 +274,82 @@ describe('Rosetta API', () => {
     expect(JSON.parse(result.text)).toEqual(expectResponse);
   });
 
+  test('offline construction/preprocess - stacking', async () => {
+    const request: RosettaConstructionPreprocessRequest = {
+      network_identifier: {
+        blockchain: RosettaConstants.blockchain,
+        network: getRosettaNetworkName(ChainID.Testnet),
+      },
+      operations: [
+        {
+          operation_identifier: {
+            index: 0,
+            network_index: 0,
+          },
+          related_operations: [],
+          type: 'stacking',
+          account: {
+            address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
+            metadata: {},
+          },
+          amount: {
+            value: '-500000',
+            currency: {
+              symbol: 'STX',
+              decimals: 6,
+            },
+            metadata: {},
+          },
+          metadata: {
+            number_of_cycles: 3,
+            pox_addr: '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3'
+          },
+        },
+      ],
+      metadata: {},
+      max_fee: [
+        {
+          value: '12380898',
+          currency: {
+            symbol: 'STX',
+            decimals: 6,
+          },
+          metadata: {},
+        },
+      ],
+      suggested_fee_multiplier: 1,
+    };
+
+    const result = await supertest(api.server)
+      .post(`/rosetta/v1/construction/preprocess`)
+      .send(request);
+
+    expect(result.status).toBe(200);
+    expect(result.type).toBe('application/json');
+
+    const expectResponse: RosettaConstructionPreprocessResponse = {
+      options: {
+        sender_address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
+        type: 'stacking',
+        suggested_fee_multiplier: 1,
+        amount: '500000',
+        symbol: 'STX',
+        decimals: 6,
+        max_fee: '12380898',
+        size: 260,
+        number_of_cycles: 3,
+        pox_addr: '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3'
+      },
+      required_public_keys: [
+        {
+          address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
+        },
+      ],
+    };
+
+    expect(JSON.parse(result.text)).toEqual(expectResponse);
+  });
+
   test('Success: offline - construction/hash', async () => {
     const request: RosettaConstructionHashRequest = {
       network_identifier: {
@@ -615,7 +691,6 @@ describe('Rosetta API', () => {
     expect(JSON.parse(result.text)).toEqual(expectedResponse);
   });
 
-
   test('payloads single sign - stacking', async () => {
     const publicKey = publicKeyToString(pubKeyfromPrivKey(testnetKeys[0].secretKey));
     const sender = testnetKeys[0].stacksAddress;
@@ -649,9 +724,6 @@ describe('Rosetta API', () => {
               symbol: 'STX',
               decimals: 6,
             },
-            metadata:{
-            	number_of_cycles: 5
-            },
           },
         },
         {
@@ -674,7 +746,7 @@ describe('Rosetta API', () => {
           },
           metadata: {
             number_of_cycles: number_of_cycles, 
-
+            pox_addr : '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3',
           }
         },
       ],
@@ -692,10 +764,7 @@ describe('Rosetta API', () => {
       ],
     };
 
-    const poxBTCAddress = publicKeyToBitcoinAddress(
-      publicKey,
-      'testnet'
-    ) as string;
+    const poxBTCAddress = '1Xik14zRm29UsyS6DjhYg4iZeZqsDa8D3'
 
     const { hashMode, data } = decodeBtcAddress(poxBTCAddress);
     const hashModeBuffer = bufferCV(new BN(hashMode, 10).toArrayLike(Buffer));


### PR DESCRIPTION
## Description
Support BTC reward(`pox_addr`) address  for `preprocess` and `payload`

closes #672 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other


## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review
