### PR TITLE
[Rosetta] Avoid conflicting nonce issue in rosetta

### DIFF
--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -67,7 +67,11 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
     // return spendable balance (liquid) if no sub-account is specified
     let balance = (stxBalance.balance - stxBalance.locked).toString();
 
-    const accountInfo = await new StacksCoreRpcClient().getAccount(accountIdentifier.address);
+    // Getting nonce info
+    const nondeNonce = await new StacksCoreRpcClient().getAccountNonce(accountIdentifier.address);
+
+    const apiNonce = await db.getAddressNonces({ stxAddress: accountIdentifier.address });
+    const nonce = Math.max(nondeNonce, apiNonce.possibleNextNonce);
 
     const extra_metadata: any = {};
 
@@ -117,7 +121,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
         },
       ],
       metadata: {
-        sequence_number: accountInfo.nonce ? accountInfo.nonce : 0,
+        sequence_number: nonce,
       },
     };
 

--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -13,6 +13,7 @@ import {
 } from '@stacks/stacks-blockchain-api-types';
 import { RosettaErrors, RosettaConstants, RosettaErrorsTypes } from '../../rosetta-constants';
 import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
+import { getAddressNonce } from '../../../rosetta-helpers';
 import { ChainID } from '@stacks/transactions';
 import { StacksCoreRpcClient } from '../../../core-rpc/client';
 
@@ -68,10 +69,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
     let balance = (stxBalance.balance - stxBalance.locked).toString();
 
     // Getting nonce info
-    const nondeNonce = await new StacksCoreRpcClient().getAccountNonce(accountIdentifier.address);
-
-    const apiNonce = await db.getAddressNonces({ stxAddress: accountIdentifier.address });
-    const nonce = Math.max(nondeNonce, apiNonce.possibleNextNonce);
+    const nonce = await getAddressNonce(db, accountIdentifier.address);
 
     const extra_metadata: any = {};
 

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -72,6 +72,7 @@ import {
   getStacksNetwork,
   makePresignHash,
   verifySignature,
+  getAddressNonce,
 } from './../../../rosetta-helpers';
 import { makeRosettaError, rosettaValidateRequest, ValidSchema } from './../../rosetta-validate';
 
@@ -370,10 +371,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     const stxAddress = options.sender_address;
 
     // Getting nonce info
-    const nondeNonce = await new StacksCoreRpcClient().getAccountNonce(stxAddress);
-
-    const apiNonce = await db.getAddressNonces({ stxAddress: stxAddress });
-    const nonce = Math.max(nondeNonce, apiNonce.possibleNextNonce);
+    const nonce = await getAddressNonce(db, stxAddress);
 
     let recentBlockHash = undefined;
     const blockQuery: FoundOrNot<DbBlock> = await db.getCurrentBlock();

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -371,8 +371,10 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     const stxAddress = options.sender_address;
 
     // Getting nonce info
-    const accountInfo = await new StacksCoreRpcClient().getAccount(stxAddress);
-    const nonce = accountInfo.nonce;
+    const nondeNonce = await new StacksCoreRpcClient().getAccountNonce(stxAddress);
+
+    const apiNonce = await db.getAddressNonces({ stxAddress: stxAddress });
+    const nonce = Math.max(nondeNonce, apiNonce.possibleNextNonce);
 
     let recentBlockHash = undefined;
     const blockQuery: FoundOrNot<DbBlock> = await db.getCurrentBlock();

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -347,8 +347,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
         const contractInfo = poxInfo.contract_id.split('.');
         options.contract_address = contractInfo[0];
         options.contract_name = contractInfo[1];
-        // Adding 3 blocks to provide a buffer for transaction to confirm
-        options.burn_block_height = coreInfo.burn_block_height + 3;
+        options.burn_block_height = coreInfo.burn_block_height;
         break;
       }
       case RosettaOperationType.DelegateStx: {

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -61,9 +61,10 @@ import { getTxSenderAddress, getTxSponsorAddress } from './event-stream/reader';
 import { unwrapOptional, bufferToHexPrefixString, hexToBuffer } from './helpers';
 import { readTransaction, TransactionPayloadTypeID } from './p2p/tx';
 
-import { getCoreNodeEndpoint } from './core-rpc/client';
+import { getCoreNodeEndpoint, StacksCoreRpcClient } from './core-rpc/client';
 import { TupleCV } from '@stacks/transactions/dist/transactions/src/clarity';
 import { getBTCAddress, poxAddressToBtcAddress } from '@stacks/stacking';
+import { once } from 'node:events';
 
 enum CoinAction {
   CoinSpent = 'coin_spent',
@@ -452,6 +453,18 @@ function makePoisonMicroblockOperation(tx: BaseTx, index: number): RosettaOperat
   };
 
   return sender;
+}
+
+/**
+ * Determine the best nonce to use for the next tx by querying both the stacks-node RPC
+ * and the postgres db, then taking the max value found.
+ * See https://github.com/blockstack/stacks-blockchain-api/issues/685
+ */
+export async function getAddressNonce(db: DataStore, stxAddress: string): Promise<number> {
+  const nodeNonce = await new StacksCoreRpcClient().getAccountNonce(stxAddress);
+  const apiNonce = await db.getAddressNonces({ stxAddress: stxAddress });
+  const nonce = Math.max(nodeNonce, apiNonce.possibleNextNonce);
+  return nonce;
 }
 
 export function publicKeyToBitcoinAddress(publicKey: string, network: string): string | undefined {


### PR DESCRIPTION
## Description
Fetch nonce, using both `postgres` and `stacks-node` and selecting the maximum nonce to avoid conflict. 

Closes https://github.com/blockstack/stacks-blockchain-api/issues/685

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] @zone117x for review
