### PR TITLE
fix(rosetta): `/block/transaction` endpoint missing ops #704

### DIFF
--- a/docs/api/rosetta/rosetta-block-transaction-request.schema.json
+++ b/docs/api/rosetta/rosetta-block-transaction-request.schema.json
@@ -11,7 +11,7 @@
       "$ref": "./../../entities/rosetta/rosetta-network-identifier.schema.json"
     },
     "block_identifier": {
-      "$ref": "./../../entities/rosetta/rosetta-block-identifier.schema.json"
+      "$ref": "./../../entities/rosetta/rosetta-partial-block-identifier.schema.json"
     },
     "transaction_identifier": {
       "$ref": "./../../entities/rosetta/rosetta-transaction-identifier.schema.json"


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/704

Stacking transaction operations included in the rosetta `/block` endpoint where missing from the rosetta `/block/transaction` endpoint.