### PR TITLE
graceful shutdown of stuck connections

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -652,18 +652,35 @@ export function timeout(ms: number): Promise<void> {
  * Set an execution time limit for a promise.
  * @param promise - The promise being capped to `timeoutMs` max execution time
  * @param timeoutMs - Timeout limit in milliseconds
+ * @param wait - If we should wait another `timeoutMs` period for `promise` to resolve
+ * @param waitHandler - If `wait` is `true`, this closure will be executed before waiting another `timeoutMs` cycle
  * @returns `true` if `promise` ended gracefully, `false` if timeout was reached
  */
-export async function resolveOrTimeout(promise: Promise<void>, timeoutMs: number) {
+export async function resolveOrTimeout(
+  promise: Promise<void>,
+  timeoutMs: number,
+  wait: boolean = false,
+  waitHandler?: () => void
+) {
   let timer: NodeJS.Timeout;
   const result = await Promise.race([
     new Promise(async (resolve, _) => {
       await promise;
+      clearTimeout(timer);
       resolve(true);
     }),
     new Promise((resolve, _) => {
-      timer = setTimeout(() => resolve(false), timeoutMs);
-    }).finally(() => clearTimeout(timer)),
+      timer = setInterval(() => {
+        if (!wait) {
+          clearTimeout(timer);
+          resolve(false);
+          return;
+        }
+        if (waitHandler) {
+          waitHandler();
+        }
+      }, timeoutMs);
+    }),
   ]);
   return result;
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -648,6 +648,14 @@ export function timeout(ms: number): Promise<void> {
   });
 }
 
+export function resolveOrTimeout(promise: Promise<void>, timeoutMs: number, exception: any) {
+  let timer: NodeJS.Timeout;
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => (timer = setTimeout(reject, timeoutMs, exception))),
+  ]).finally(() => clearTimeout(timer));
+}
+
 export type Waiter<T> = Promise<T> & {
   finish: (result: T) => void;
   isFinished: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,9 +119,7 @@ async function init(): Promise<void> {
     registerShutdownConfig({
       name: 'Event Server',
       handler: () => eventServer.closeAsync(),
-      timeoutHandler: () => {
-        // TODO: Handle
-      },
+      forceKillable: false,
     });
 
     const networkChainId = await getCoreChainID();
@@ -143,10 +141,9 @@ async function init(): Promise<void> {
   logger.info(`API server listening on: http://${apiServer.address}`);
   registerShutdownConfig({
     name: 'API Server',
-    handler: async () => {
-      await apiServer.terminate();
-    },
-    timeoutHandler: () => {
+    handler: () => apiServer.terminate(),
+    forceKillable: true,
+    forceKillHandler: () => {
       // TODO: Handle
     },
   });
@@ -154,9 +151,7 @@ async function init(): Promise<void> {
   registerShutdownConfig({
     name: 'DB',
     handler: () => db.close(),
-    timeoutHandler: () => {
-      // TODO: Handle
-    },
+    forceKillable: false,
   });
 
   if (isProdEnv) {
@@ -176,7 +171,10 @@ async function init(): Promise<void> {
         }
         await Promise.resolve(prometheusServer.close());
       },
-      timeoutHandler: null,
+      forceKillable: true,
+      forceKillHandler: () => {
+        // TODO: Handle
+      },
     });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { startEventServer } from './event-stream/event-server';
 import { StacksCoreRpcClient } from './core-rpc/client';
 import { createServer as createPrometheusServer } from '@promster/server';
 import { ChainID } from '@stacks/transactions';
-import { registerShutdownHandler } from './shutdown-handler';
+import { registerShutdownConfig } from './shutdown-handler';
 import { importV1TokenOfferingData, importV1BnsData } from './import-v1';
 import { OfflineDummyStore } from './datastore/offline-dummy-store';
 import { Socket } from 'net';
@@ -29,7 +29,7 @@ loadDotEnv();
 
 sourceMapSupport.install({ handleUncaughtExceptions: false });
 
-registerShutdownHandler();
+registerShutdownConfig();
 
 async function monitorCoreRpcConnection(): Promise<void> {
   const CORE_RPC_HEARTBEAT_INTERVAL = 5000; // 5 seconds
@@ -116,7 +116,11 @@ async function init(): Promise<void> {
       datastore: db,
       chainId: configuredChainID,
     });
-    registerShutdownHandler(() => eventServer.closeAsync());
+    registerShutdownConfig({
+      name: 'Event Server',
+      handler: () => eventServer.closeAsync(),
+      timeoutHandler: null,
+    });
 
     const networkChainId = await getCoreChainID();
     if (networkChainId !== configuredChainID) {
@@ -135,14 +139,24 @@ async function init(): Promise<void> {
 
   const apiServer = await startApiServer({ datastore: db, chainId: getConfiguredChainID() });
   logger.info(`API server listening on: http://${apiServer.address}`);
-  registerShutdownHandler(async () => {
-    await apiServer.terminate();
+  registerShutdownConfig({
+    name: 'API Server',
+    handler: async () => {
+      await apiServer.terminate();
+    },
+    timeoutHandler: () => {
+      logger.info('todo');
+    },
   });
 
-  registerShutdownHandler(async () => {
-    logger.info('Closing DB...');
-    await db.close();
-    logger.info('DB closed.');
+  registerShutdownConfig({
+    name: 'DB',
+    handler: async () => {
+      logger.info('Closing DB...');
+      await db.close();
+      logger.info('DB closed.');
+    },
+    timeoutHandler: null,
   });
 
   if (isProdEnv) {
@@ -153,18 +167,22 @@ async function init(): Promise<void> {
       sockets.add(socket);
       socket.once('close', () => sockets.delete(socket));
     });
-    registerShutdownHandler(async () => {
-      logger.info('Closing Prometheus server...');
-      for (const socket of sockets) {
-        socket.destroy();
-        sockets.delete(socket);
-      }
-      await new Promise<void>(resolve => {
-        prometheusServer.close(() => {
-          logger.info('Prometheus server closed.');
-          resolve();
+    registerShutdownConfig({
+      name: 'Prometheus',
+      handler: async () => {
+        logger.info('Closing Prometheus server...');
+        for (const socket of sockets) {
+          socket.destroy();
+          sockets.delete(socket);
+        }
+        await new Promise<void>(resolve => {
+          prometheusServer.close(() => {
+            logger.info('Prometheus server closed.');
+            resolve();
+          });
         });
-      });
+      },
+      timeoutHandler: null,
     });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,11 +151,7 @@ async function init(): Promise<void> {
 
   registerShutdownConfig({
     name: 'DB',
-    handler: async () => {
-      logger.info('Closing DB...');
-      await db.close();
-      logger.info('DB closed.');
-    },
+    handler: () => db.close(),
     timeoutHandler: null,
   });
 
@@ -170,16 +166,12 @@ async function init(): Promise<void> {
     registerShutdownConfig({
       name: 'Prometheus',
       handler: async () => {
-        logger.info('Closing Prometheus server...');
         for (const socket of sockets) {
           socket.destroy();
           sockets.delete(socket);
         }
         await new Promise<void>(resolve => {
-          prometheusServer.close(() => {
-            logger.info('Prometheus server closed.');
-            resolve();
-          });
+          prometheusServer.close(() => resolve());
         });
       },
       timeoutHandler: null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,9 +143,7 @@ async function init(): Promise<void> {
     name: 'API Server',
     handler: () => apiServer.terminate(),
     forceKillable: true,
-    forceKillHandler: () => {
-      // TODO: Handle
-    },
+    forceKillHandler: () => apiServer.forceKill(),
   });
 
   registerShutdownConfig({
@@ -172,9 +170,6 @@ async function init(): Promise<void> {
         await Promise.resolve(prometheusServer.close());
       },
       forceKillable: true,
-      forceKillHandler: () => {
-        // TODO: Handle
-      },
     });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,9 @@ async function init(): Promise<void> {
     registerShutdownConfig({
       name: 'Event Server',
       handler: () => eventServer.closeAsync(),
-      timeoutHandler: null,
+      timeoutHandler: () => {
+        // TODO: Handle
+      },
     });
 
     const networkChainId = await getCoreChainID();
@@ -145,14 +147,16 @@ async function init(): Promise<void> {
       await apiServer.terminate();
     },
     timeoutHandler: () => {
-      logger.info('todo');
+      // TODO: Handle
     },
   });
 
   registerShutdownConfig({
     name: 'DB',
     handler: () => db.close(),
-    timeoutHandler: null,
+    timeoutHandler: () => {
+      // TODO: Handle
+    },
   });
 
   if (isProdEnv) {
@@ -170,9 +174,7 @@ async function init(): Promise<void> {
           socket.destroy();
           sockets.delete(socket);
         }
-        await new Promise<void>(resolve => {
-          prometheusServer.close(() => resolve());
-        });
+        await Promise.resolve(prometheusServer.close());
       },
       timeoutHandler: null,
     });

--- a/src/shutdown-handler.ts
+++ b/src/shutdown-handler.ts
@@ -22,11 +22,13 @@ async function startShutdown() {
   let errorEncountered = false;
   for (const config of shutdownConfigs) {
     try {
+      logger.info(`Closing ${config.name}...`);
       await resolveOrTimeout(Promise.resolve(config.handler()), 5000, timeoutError);
+      logger.info(`${config.name} closed`);
     } catch (error) {
       errorEncountered = true;
       if (error === timeoutError) {
-        logError(`${config.name} shutdown timed out`);
+        logError(`Closing of ${config.name} timed out`);
         if (config.timeoutHandler) {
           await Promise.resolve(config.timeoutHandler());
         }


### PR DESCRIPTION
## Description

Internal connections may take a long time to shut down, causing the API to hang and not report any errors until the process is complete. To avoid that, this PR sets a time limit for connection close handlers so we can run some logic when one of them gets stuck. Solves issue #681 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

Testing is done by sending a SIGINT to the nodejs process so shutdown sequences are triggered.

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review
