### PR TITLE
return tx_id on every asset in /extended/v1/address/[:addr]/assets

### DIFF
--- a/docs/api/address/get-address-assets.example.json
+++ b/docs/api/address/get-address-assets.example.json
@@ -6,6 +6,7 @@
     {
       "event_index": 0,
       "event_type": "stx_asset",
+      "tx_id": "0xb31df5a363dad31723324cb5e0eefa04d491519fd30827a521cbc830114aa50c",
       "asset": {
         "asset_event_type": "transfer",
         "sender": "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6",

--- a/docs/entities/transaction-events/transaction-event-fungible-asset.schema.json
+++ b/docs/entities/transaction-events/transaction-event-fungible-asset.schema.json
@@ -14,6 +14,9 @@
           "type": "string",
           "enum": ["fungible_token_asset"]
         },
+        "tx_id": {
+          "type": "string"
+        },
         "asset": {
           "type": "object",
           "additionalProperties": false,

--- a/docs/entities/transaction-events/transaction-event-fungible-asset.schema.json
+++ b/docs/entities/transaction-events/transaction-event-fungible-asset.schema.json
@@ -8,7 +8,7 @@
     },
     {
       "type": "object",
-      "required": ["event_type", "asset"],
+      "required": ["event_type", "tx_id", "asset"],
       "properties": {
         "event_type": {
           "type": "string",

--- a/docs/entities/transaction-events/transaction-event-non-fungible-asset.schema.json
+++ b/docs/entities/transaction-events/transaction-event-non-fungible-asset.schema.json
@@ -8,7 +8,7 @@
     },
     {
       "type": "object",
-      "required": ["event_type", "asset"],
+      "required": ["event_type", "tx_id", "asset"],
       "properties": {
         "event_type": {
           "type": "string",

--- a/docs/entities/transaction-events/transaction-event-non-fungible-asset.schema.json
+++ b/docs/entities/transaction-events/transaction-event-non-fungible-asset.schema.json
@@ -14,6 +14,9 @@
           "type": "string",
           "enum": ["non_fungible_token_asset"]
         },
+        "tx_id": {
+          "type": "string"
+        },
         "asset": {
           "type": "object",
           "additionalProperties": false,

--- a/docs/entities/transaction-events/transaction-event-smart-contract-log.schema.json
+++ b/docs/entities/transaction-events/transaction-event-smart-contract-log.schema.json
@@ -15,6 +15,9 @@
           "type": "string",
           "enum": ["smart_contract_log"]
         },
+        "tx_id": {
+          "type": "string"
+        },
         "contract_log": {
           "type": "object",
           "additionalProperties": false,

--- a/docs/entities/transaction-events/transaction-event-smart-contract-log.schema.json
+++ b/docs/entities/transaction-events/transaction-event-smart-contract-log.schema.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "object",
-      "required": ["event_type", "contract_log"],
+      "required": ["event_type", "tx_id", "contract_log"],
       "properties": {
         "event_type": {
           "type": "string",

--- a/docs/entities/transaction-events/transaction-event-stx-asset.schema.json
+++ b/docs/entities/transaction-events/transaction-event-stx-asset.schema.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "object",
-      "required": ["event_type", "asset"],
+      "required": ["event_type", "tx_id", "asset"],
       "properties": {
         "event_type": {
           "type": "string",

--- a/docs/entities/transaction-events/transaction-event-stx-asset.schema.json
+++ b/docs/entities/transaction-events/transaction-event-stx-asset.schema.json
@@ -15,6 +15,9 @@
           "type": "string",
           "enum": ["stx_asset"]
         },
+        "tx_id": {
+          "type": "string"
+        },
         "asset": {
           "$ref": "./asset-types/transaction-event-asset.schema.json"
         }

--- a/docs/entities/transaction-events/transaction-event-stx-lock.schema.json
+++ b/docs/entities/transaction-events/transaction-event-stx-lock.schema.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "object",
-      "required": ["event_type", "stx_lock_event"],
+      "required": ["event_type", "tx_id", "stx_lock_event"],
       "properties": {
         "event_type": {
           "type": "string",

--- a/docs/entities/transaction-events/transaction-event-stx-lock.schema.json
+++ b/docs/entities/transaction-events/transaction-event-stx-lock.schema.json
@@ -15,6 +15,9 @@
           "type": "string",
           "enum": ["stx_lock"]
         },
+        "tx_id": {
+          "type": "string"
+        },
         "stx_lock_event": {
           "type": "object",
           "additionalProperties": false,

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -212,6 +212,7 @@ export function parseDbEvent(dbEvent: DbEvent): TransactionEvent {
       const event: TransactionEventSmartContractLog = {
         event_index: dbEvent.event_index,
         event_type: 'smart_contract_log',
+        tx_id: dbEvent.tx_id,
         contract_log: {
           contract_id: dbEvent.contract_identifier,
           topic: dbEvent.topic,
@@ -224,6 +225,7 @@ export function parseDbEvent(dbEvent: DbEvent): TransactionEvent {
       const event: TransactionEventStxLock = {
         event_index: dbEvent.event_index,
         event_type: 'stx_lock',
+        tx_id: dbEvent.tx_id,
         stx_lock_event: {
           locked_amount: dbEvent.locked_amount.toString(10),
           unlock_height: Number(dbEvent.unlock_height),
@@ -236,6 +238,7 @@ export function parseDbEvent(dbEvent: DbEvent): TransactionEvent {
       const event: TransactionEventStxAsset = {
         event_index: dbEvent.event_index,
         event_type: 'stx_asset',
+        tx_id: dbEvent.tx_id,
         asset: {
           asset_event_type: getAssetEventTypeString(dbEvent.asset_event_type_id),
           sender: dbEvent.sender || '',
@@ -249,6 +252,7 @@ export function parseDbEvent(dbEvent: DbEvent): TransactionEvent {
       const event: TransactionEventFungibleAsset = {
         event_index: dbEvent.event_index,
         event_type: 'fungible_token_asset',
+        tx_id: dbEvent.tx_id,
         asset: {
           asset_event_type: getAssetEventTypeString(dbEvent.asset_event_type_id),
           asset_id: dbEvent.asset_identifier,
@@ -266,6 +270,7 @@ export function parseDbEvent(dbEvent: DbEvent): TransactionEvent {
       const event: TransactionEventNonFungibleAsset = {
         event_index: dbEvent.event_index,
         event_type: 'non_fungible_token_asset',
+        tx_id: dbEvent.tx_id,
         asset: {
           asset_event_type: getAssetEventTypeString(dbEvent.asset_event_type_id),
           asset_id: dbEvent.asset_identifier,

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -2753,6 +2753,7 @@ describe('api tests', () => {
         {
           event_index: 0,
           event_type: 'fungible_token_asset',
+          tx_id: '0x1234',
           asset: {
             asset_event_type: 'transfer',
             asset_id: 'bux',
@@ -2764,6 +2765,7 @@ describe('api tests', () => {
         {
           event_index: 0,
           event_type: 'fungible_token_asset',
+          tx_id: '0x1234',
           asset: {
             asset_event_type: 'transfer',
             asset_id: 'bux',
@@ -2775,6 +2777,7 @@ describe('api tests', () => {
         {
           event_index: 0,
           event_type: 'fungible_token_asset',
+          tx_id: '0x1234',
           asset: {
             asset_event_type: 'transfer',
             asset_id: 'bux',
@@ -2786,6 +2789,7 @@ describe('api tests', () => {
         {
           event_index: 0,
           event_type: 'fungible_token_asset',
+          tx_id: '0x1234',
           asset: {
             asset_event_type: 'transfer',
             asset_id: 'gox',
@@ -2797,6 +2801,7 @@ describe('api tests', () => {
         {
           event_index: 0,
           event_type: 'fungible_token_asset',
+          tx_id: '0x1234',
           asset: {
             asset_event_type: 'transfer',
             asset_id: 'gox',
@@ -2808,6 +2813,7 @@ describe('api tests', () => {
         {
           event_index: 0,
           event_type: 'fungible_token_asset',
+          tx_id: '0x1234',
           asset: {
             asset_event_type: 'transfer',
             asset_id: 'gox',
@@ -2819,6 +2825,7 @@ describe('api tests', () => {
         {
           event_index: 0,
           event_type: 'non_fungible_token_asset',
+          tx_id: '0x1234',
           asset: {
             asset_event_type: 'transfer',
             asset_id: 'bux',
@@ -2830,6 +2837,7 @@ describe('api tests', () => {
         {
           event_index: 0,
           event_type: 'stx_asset',
+          tx_id: '0x1234',
           asset: {
             asset_event_type: 'transfer',
             sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
@@ -3074,6 +3082,7 @@ describe('api tests', () => {
         {
           event_index: 4,
           event_type: 'smart_contract_log',
+          tx_id: '0x421234',
           contract_log: {
             contract_id: 'some-contract-id',
             topic: 'some-topic',
@@ -4221,6 +4230,7 @@ describe('api tests', () => {
         {
           event_index: 0,
           event_type: 'non_fungible_token_asset',
+          tx_id: '0x1234',
           asset: {
             asset_event_type: 'transfer',
             asset_id: 'bux',

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -1164,11 +1164,13 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'stx_asset',
+        tx_id: '0x1234',
         asset: { asset_event_type: 'transfer', sender: 'addrA', recipient: 'addrB', amount: '100' },
       },
       {
         event_index: 0,
         event_type: 'stx_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           sender: 'none',
@@ -1179,16 +1181,19 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'stx_asset',
+        tx_id: '0x1234',
         asset: { asset_event_type: 'transfer', sender: 'addrA', recipient: 'addrC', amount: '35' },
       },
       {
         event_index: 0,
         event_type: 'stx_asset',
+        tx_id: '0x1234',
         asset: { asset_event_type: 'transfer', sender: 'addrA', recipient: 'addrB', amount: '250' },
       },
       {
         event_index: 5,
         event_type: 'fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1200,6 +1205,7 @@ describe('postgres datastore', () => {
       {
         event_index: 3,
         event_type: 'fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1211,6 +1217,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1222,6 +1229,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1233,6 +1241,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'cash',
@@ -1244,6 +1253,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'tendies',
@@ -1255,6 +1265,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1266,6 +1277,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1277,6 +1289,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1288,6 +1301,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1299,6 +1313,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1310,6 +1325,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1321,6 +1337,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1332,6 +1349,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1343,6 +1361,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1354,6 +1373,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1365,6 +1385,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1376,6 +1397,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1387,6 +1409,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1398,6 +1421,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1409,6 +1433,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1420,6 +1445,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1431,6 +1457,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1442,6 +1469,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1453,6 +1481,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1464,6 +1493,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1475,6 +1505,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1486,6 +1517,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1497,6 +1529,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1508,6 +1541,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1519,6 +1553,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1530,6 +1565,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1541,6 +1577,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1552,6 +1589,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'gox',
@@ -1563,6 +1601,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'cash',
@@ -1574,6 +1613,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'cash',
@@ -1585,6 +1625,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'cash',
@@ -1596,6 +1637,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'cash',
@@ -1607,6 +1649,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'cash',
@@ -1618,6 +1661,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'tendies',
@@ -1629,6 +1673,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1640,6 +1685,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1651,6 +1697,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1662,6 +1709,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1673,6 +1721,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1684,6 +1733,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1695,6 +1745,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1706,6 +1757,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1717,6 +1769,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1728,6 +1781,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1739,6 +1793,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1750,6 +1805,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',
@@ -1761,6 +1817,7 @@ describe('postgres datastore', () => {
       {
         event_index: 0,
         event_type: 'non_fungible_token_asset',
+        tx_id: '0x1234',
         asset: {
           asset_event_type: 'transfer',
           asset_id: 'bux',


### PR DESCRIPTION
## Description

Returns the transaction ID along with every asset queried on a particular address under the  `/extended/v1/address/[:addr]/assets` endpoint. This will be useful for wallets and the explorer so they can display additional information about the purchase or transfer of said assets.

Closes #678 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
Yes, the documentation for this particular endpoint should be updated.

## Testing information

Covered by current API and Datastore unit tests (ammended in this PR).

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review
