### PR TITLE
add smart contract id or contract call id queries to /extended/v1/tx/mempool

### DIFF
--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -101,17 +101,22 @@ export function createTxRouter(db: DataStore): RouterWithAsync {
         if (!addr) {
           return undefined;
         }
-        if (!isValidC32Address(addr)) {
-          if (p !== 'address') {
-            throw new Error(
-              `Invalid query parameter for "${p}": "${addr}" is not a valid STX address`
-            );
-          }
-          if (!isValidPrincipal(addr)) {
-            throw new Error(
-              `Invalid query parameter for "${p}": "${addr}" is not a valid STX address or principal`
-            );
-          }
+        switch (p) {
+          case 'sender_address':
+            if (!isValidC32Address(addr)) {
+              throw new Error(
+                `Invalid query parameter for "${p}": "${addr}" is not a valid STX address`
+              );
+            }
+            break;
+          case 'recipient_address':
+          case 'address':
+            if (!(isValidC32Address(addr) || isValidPrincipal(addr))) {
+              throw new Error(
+                `Invalid query parameter for "${p}": "${addr}" is not a valid STX address or principal`
+              );
+            }
+            break;
         }
         return addr;
       });

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -15,6 +15,7 @@ import {
   isProdEnv,
   isValidC32Address,
   bufferToHexPrefixString,
+  isValidPrincipal,
 } from '../../helpers';
 import { isUnanchoredRequest, getBlockHeightPathParam } from '../query-helpers';
 import { parseLimitQuery, parsePagingQueryInput } from '../pagination';
@@ -101,9 +102,16 @@ export function createTxRouter(db: DataStore): RouterWithAsync {
           return undefined;
         }
         if (!isValidC32Address(addr)) {
-          throw new Error(
-            `Invalid query parameter for "${p}": "${addr}" is not a valid STX address`
-          );
+          if (p !== 'address') {
+            throw new Error(
+              `Invalid query parameter for "${p}": "${addr}" is not a valid STX address`
+            );
+          }
+          if (!isValidPrincipal(addr)) {
+            throw new Error(
+              `Invalid query parameter for "${p}": "${addr}" is not a valid STX address or principal`
+            );
+          }
         }
         return addr;
       });

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -3124,8 +3124,13 @@ export class PgDataStore
     const queryValues: any[] = [];
 
     if (address) {
-      whereConditions.push('(sender_address = $$ OR token_transfer_recipient_address = $$)');
-      queryValues.push(address, address);
+      whereConditions.push(
+        `(sender_address = $$
+          OR token_transfer_recipient_address = $$
+          OR smart_contract_contract_id = $$
+          OR contract_call_contract_id = $$)`
+      );
+      queryValues.push(address, address, address, address);
     } else if (senderAddress && recipientAddress) {
       whereConditions.push('(sender_address = $$ AND token_transfer_recipient_address = $$)');
       queryValues.push(senderAddress, recipientAddress);


### PR DESCRIPTION
## Description

This change allows API users to query the mempool by a smart contract id or a contract call id using the existing `address` parameter so they can monitor transactions that are relevant to the execution of any smart contract.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
Yes. The new parameter behavior should be updated in the API endpoint docs.

## Testing information

Covered by existing unit tests.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review

Closes #605 