### PR TITLE
fix: client lib and docs build fix

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "sourceMap": true,
     "strict": true,
+    "strictNullChecks": false,
     "outDir": "lib",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
The `openapi-generator-cli` utility started generating typescript that is incompatible with `strictNullChecks: true`. Temporarily disable this in the client lib until fixed.