### PR TITLE
Revert "fix(rosetta): conflicting nonce issue in rosetta tx construction #685"

### DIFF
--- a/src/api/routes/rosetta/account.ts
+++ b/src/api/routes/rosetta/account.ts
@@ -13,7 +13,6 @@ import {
 } from '@stacks/stacks-blockchain-api-types';
 import { RosettaErrors, RosettaConstants, RosettaErrorsTypes } from '../../rosetta-constants';
 import { rosettaValidateRequest, ValidSchema, makeRosettaError } from '../../rosetta-validate';
-import { getAddressNonce } from '../../../rosetta-helpers';
 import { ChainID } from '@stacks/transactions';
 import { StacksCoreRpcClient } from '../../../core-rpc/client';
 
@@ -68,8 +67,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
     // return spendable balance (liquid) if no sub-account is specified
     let balance = (stxBalance.balance - stxBalance.locked).toString();
 
-    // Getting nonce info
-    const nonce = await getAddressNonce(db, accountIdentifier.address);
+    const accountInfo = await new StacksCoreRpcClient().getAccount(accountIdentifier.address);
 
     const extra_metadata: any = {};
 
@@ -119,7 +117,7 @@ export function createRosettaAccountRouter(db: DataStore, chainId: ChainID): Rou
         },
       ],
       metadata: {
-        sequence_number: nonce,
+        sequence_number: accountInfo.nonce ? accountInfo.nonce : 0,
       },
     };
 

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -72,7 +72,6 @@ import {
   getStacksNetwork,
   makePresignHash,
   verifySignature,
-  getAddressNonce,
 } from './../../../rosetta-helpers';
 import { makeRosettaError, rosettaValidateRequest, ValidSchema } from './../../rosetta-validate';
 
@@ -371,7 +370,8 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     const stxAddress = options.sender_address;
 
     // Getting nonce info
-    const nonce = await getAddressNonce(db, stxAddress);
+    const accountInfo = await new StacksCoreRpcClient().getAccount(stxAddress);
+    const nonce = accountInfo.nonce;
 
     let recentBlockHash = undefined;
     const blockQuery: FoundOrNot<DbBlock> = await db.getCurrentBlock();

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -61,10 +61,9 @@ import { getTxSenderAddress, getTxSponsorAddress } from './event-stream/reader';
 import { unwrapOptional, bufferToHexPrefixString, hexToBuffer } from './helpers';
 import { readTransaction, TransactionPayloadTypeID } from './p2p/tx';
 
-import { getCoreNodeEndpoint, StacksCoreRpcClient } from './core-rpc/client';
+import { getCoreNodeEndpoint } from './core-rpc/client';
 import { TupleCV } from '@stacks/transactions/dist/transactions/src/clarity';
 import { getBTCAddress, poxAddressToBtcAddress } from '@stacks/stacking';
-import { once } from 'node:events';
 
 enum CoinAction {
   CoinSpent = 'coin_spent',
@@ -453,18 +452,6 @@ function makePoisonMicroblockOperation(tx: BaseTx, index: number): RosettaOperat
   };
 
   return sender;
-}
-
-/**
- * Determine the best nonce to use for the next tx by querying both the stacks-node RPC
- * and the postgres db, then taking the max value found.
- * See https://github.com/blockstack/stacks-blockchain-api/issues/685
- */
-export async function getAddressNonce(db: DataStore, stxAddress: string): Promise<number> {
-  const nodeNonce = await new StacksCoreRpcClient().getAccountNonce(stxAddress);
-  const apiNonce = await db.getAddressNonces({ stxAddress: stxAddress });
-  const nonce = Math.max(nodeNonce, apiNonce.possibleNextNonce);
-  return nonce;
 }
 
 export function publicKeyToBitcoinAddress(publicKey: string, network: string): string | undefined {


### PR DESCRIPTION
Should revert the change that introduced https://github.com/blockstack/stacks-blockchain-api/issues/718

However, this re-introduces possible conflicting nonce errors if more than one tx per account is submitted in a block https://github.com/blockstack/stacks-blockchain-api/issues/685