### PR TITLE
expose FT and NFT transfers in /extended/v1/address/[:principal]/transactions_with_transfers

### DIFF
--- a/docs/api/address/get-address-transactions-with-transfers.example.json
+++ b/docs/api/address/get-address-transactions-with-transfers.example.json
@@ -70,7 +70,7 @@
       ],
       "ft_transfers": [
         {
-          "amount": "10.53",
+          "amount": "103",
           "asset_identifier": "SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.miamicoin-token::miamicoin",
           "sender": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
           "recipient": "SP24Q9PK9DNTA2V89APY8WNBJ1QYKKSW9SWB04RJP"

--- a/docs/api/address/get-address-transactions-with-transfers.example.json
+++ b/docs/api/address/get-address-transactions-with-transfers.example.json
@@ -71,14 +71,14 @@
       "ft_transfers": [
         {
           "amount": "10.53",
-          "asset_identifier": "COOL",
+          "asset_identifier": "SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.miamicoin-token::miamicoin",
           "sender": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
           "recipient": "SP24Q9PK9DNTA2V89APY8WNBJ1QYKKSW9SWB04RJP"
         }
       ],
       "nft_transfers": [
         {
-          "asset_identifier": "punk2",
+          "asset_identifier": "SP497E7RX3233ATBS2AB9G4WTHB63X5PBSP5VGAQ.boom-nfts::boom",
           "value": { "hex": "0x00", "repr": "0" },
           "sender": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
           "recipient": "SP24Q9PK9DNTA2V89APY8WNBJ1QYKKSW9SWB04RJP"

--- a/docs/api/address/get-address-transactions-with-transfers.example.json
+++ b/docs/api/address/get-address-transactions-with-transfers.example.json
@@ -67,6 +67,22 @@
           "sender": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
           "recipient": "SP26066SDPP4NXKGCVYZQDR5GX2QPE8KADZ0YK2J7"
         }
+      ],
+      "ft_transfers": [
+        {
+          "amount": "10.53",
+          "asset_identifier": "COOL",
+          "sender": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
+          "recipient": "SP24Q9PK9DNTA2V89APY8WNBJ1QYKKSW9SWB04RJP"
+        }
+      ],
+      "nft_transfers": [
+        {
+          "asset_identifier": "punk2",
+          "value": { "hex": "0x00", "repr": "0" },
+          "sender": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
+          "recipient": "SP24Q9PK9DNTA2V89APY8WNBJ1QYKKSW9SWB04RJP"
+        }
       ]
     },
     {
@@ -109,7 +125,9 @@
           "sender": "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
           "recipient": "SPRSM0R2JZWBCZ39NQBARWTMX9TE99K3JK8D5KMX"
         }
-      ]
+      ],
+      "ft_transfers": [],
+      "nft_transfers": []
     }
   ]
 }

--- a/docs/entities/address/transaction-with-transfers.schema.json
+++ b/docs/entities/address/transaction-with-transfers.schema.json
@@ -52,7 +52,7 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
-          "amount"
+          "amount", "asset_identifier"
         ],
         "properties": {
           "asset_identifier": {
@@ -62,6 +62,34 @@
           "amount": {
             "type": "string",
             "description": "Amount transferred as an integer string."
+          },
+          "sender": {
+            "type": "string",
+            "description": "Principal that sent the asset."
+          },
+          "recipient": {
+            "type": "string",
+            "description": "Principal that received the asset."
+          }
+        }
+      }
+    },
+    "nft_transfers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "asset_identifier", "value"
+        ],
+        "properties": {
+          "asset_identifier": {
+            "type": "string",
+            "description": "Non Fungible Token asset identifier."
+          },
+          "value": {
+            "type": "string",
+            "description": "Non Fungible Token asset value."
           },
           "sender": {
             "type": "string",

--- a/docs/entities/address/transaction-with-transfers.schema.json
+++ b/docs/entities/address/transaction-with-transfers.schema.json
@@ -61,7 +61,7 @@
           },
           "amount": {
             "type": "string",
-            "description": "Amount transferred as an integer string."
+            "description": "Amount transferred as an integer string. This balance does not factor in possible SIP-010 decimals."
           },
           "sender": {
             "type": "string",

--- a/docs/entities/address/transaction-with-transfers.schema.json
+++ b/docs/entities/address/transaction-with-transfers.schema.json
@@ -45,6 +45,34 @@
           }
         }
       }
+    },
+    "ft_transfers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "amount"
+        ],
+        "properties": {
+          "asset_identifier": {
+            "type": "string",
+            "description": "Fungible Token asset identifier."
+          },
+          "amount": {
+            "type": "string",
+            "description": "Amount transferred as an integer string."
+          },
+          "sender": {
+            "type": "string",
+            "description": "Principal that sent the asset."
+          },
+          "recipient": {
+            "type": "string",
+            "description": "Principal that received the asset."
+          }
+        }
+      }
     }
   }
 }

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -919,11 +919,29 @@ export interface AddressTransactionWithTransfers {
     /**
      * Fungible Token asset identifier.
      */
-    asset_identifier?: string;
+    asset_identifier: string;
     /**
      * Amount transferred as an integer string.
      */
     amount: string;
+    /**
+     * Principal that sent the asset.
+     */
+    sender?: string;
+    /**
+     * Principal that received the asset.
+     */
+    recipient?: string;
+  }[];
+  nft_transfers?: {
+    /**
+     * Non Fungible Token asset identifier.
+     */
+    asset_identifier: string;
+    /**
+     * Non Fungible Token asset value.
+     */
+    value: string;
     /**
      * Principal that sent the asset.
      */

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -915,6 +915,24 @@ export interface AddressTransactionWithTransfers {
      */
     recipient?: string;
   }[];
+  ft_transfers?: {
+    /**
+     * Fungible Token asset identifier.
+     */
+    asset_identifier?: string;
+    /**
+     * Amount transferred as an integer string.
+     */
+    amount: string;
+    /**
+     * Principal that sent the asset.
+     */
+    sender?: string;
+    /**
+     * Principal that received the asset.
+     */
+    recipient?: string;
+  }[];
 }
 /**
  * Transaction properties that are available from a raw serialized transactions. These are available for transactions in the mempool as well as mined transactions.

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -921,7 +921,7 @@ export interface AddressTransactionWithTransfers {
      */
     asset_identifier: string;
     /**
-     * Amount transferred as an integer string.
+     * Amount transferred as an integer string. This balance does not factor in possible SIP-010 decimals.
      */
     amount: string;
     /**

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -252,6 +252,12 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
           sender: transfer.sender,
           recipient: transfer.recipient,
         })),
+        ft_transfers: entry.ft_transfers.map(transfer => ({
+          asset_identifier: transfer.asset_identifier,
+          amount: transfer.amount.toString(),
+          sender: transfer.sender,
+          recipient: transfer.recipient,
+        })),
       };
       return result;
     });

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -258,6 +258,12 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
           sender: transfer.sender,
           recipient: transfer.recipient,
         })),
+        nft_transfers: entry.nft_transfers.map(transfer => ({
+          asset_identifier: transfer.asset_identifier,
+          value: transfer.value.toString(),
+          sender: transfer.sender,
+          recipient: transfer.recipient,
+        })),
       };
       return result;
     });

--- a/src/api/routes/address.ts
+++ b/src/api/routes/address.ts
@@ -227,7 +227,7 @@ export function createAddressRouter(db: DataStore, chainId: ChainID): RouterWith
     const blockParams = getBlockParams(req, res, next);
     const limit = parseTxQueryLimit(req.query.limit ?? 20);
     const offset = parsePagingQueryInput(req.query.offset ?? 0);
-    const { results: txResults, total } = await db.getAddressTxsWithStxTransfers({
+    const { results: txResults, total } = await db.getAddressTxsWithAssetTransfers({
       stxAddress: stxAddress,
       limit,
       offset,

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -313,6 +313,12 @@ export interface DbTxWithStxTransfers {
     sender?: string;
     recipient?: string;
   }[];
+  ft_transfers: {
+    asset_identifier?: string;
+    amount: bigint;
+    sender?: string;
+    recipient?: string;
+  }[];
 }
 
 export interface AddressTxUpdateInfo {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -304,7 +304,7 @@ export interface StxUnlockEvent {
 
 export type DbEvent = DbSmartContractEvent | DbStxEvent | DbStxLockEvent | DbFtEvent | DbNftEvent;
 
-export interface DbTxWithStxTransfers {
+export interface DbTxWithAssetTransfers {
   tx: DbTx;
   stx_sent: bigint;
   stx_received: bigint;
@@ -668,18 +668,18 @@ export interface DataStore extends DataStoreEventEmitter {
     } & ({ blockHeight: number } | { includeUnanchored: boolean })
   ): Promise<{ results: DbTx[]; total: number }>;
 
-  getAddressTxsWithStxTransfers(
+  getAddressTxsWithAssetTransfers(
     args: {
       stxAddress: string;
       limit: number;
       offset: number;
     } & ({ blockHeight: number } | { includeUnanchored: boolean })
-  ): Promise<{ results: DbTxWithStxTransfers[]; total: number }>;
+  ): Promise<{ results: DbTxWithAssetTransfers[]; total: number }>;
 
   getInformationTxsWithStxTransfers(args: {
     stxAddress: string;
     tx_id: string;
-  }): Promise<DbTxWithStxTransfers>;
+  }): Promise<DbTxWithAssetTransfers>;
 
   getAddressAssetEvents(args: {
     stxAddress: string;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -314,8 +314,14 @@ export interface DbTxWithStxTransfers {
     recipient?: string;
   }[];
   ft_transfers: {
-    asset_identifier?: string;
+    asset_identifier: string;
     amount: bigint;
+    sender?: string;
+    recipient?: string;
+  }[];
+  nft_transfers: {
+    asset_identifier: string;
+    value: Buffer;
     sender?: string;
     recipient?: string;
   }[];

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -28,7 +28,7 @@ import {
   DbBnsSubdomain,
   DbConfigState,
   DbMinerReward,
-  DbTxWithStxTransfers,
+  DbTxWithAssetTransfers,
   DataStoreMicroblockUpdateData,
   DbMicroblock,
   DbGetBlockWithMetadataOpts,
@@ -517,16 +517,16 @@ export class MemoryDataStore
   getInformationTxsWithStxTransfers(args: {
     stxAddress: string;
     tx_id: string;
-  }): Promise<DbTxWithStxTransfers> {
+  }): Promise<DbTxWithAssetTransfers> {
     throw new Error('not yet implemented');
   }
 
-  getAddressTxsWithStxTransfers(args: {
+  getAddressTxsWithAssetTransfers(args: {
     stxAddress: string;
     limit: number;
     offset: number;
     blockHeight?: number;
-  }): Promise<{ results: DbTxWithStxTransfers[]; total: number }> {
+  }): Promise<{ results: DbTxWithAssetTransfers[]; total: number }> {
     throw new Error('not yet implemented');
   }
 

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -61,7 +61,7 @@ import {
   DbBnsSubdomain,
   DbConfigState,
   DbTokenOfferingLocked,
-  DbTxWithStxTransfers,
+  DbTxWithAssetTransfers,
   DataStoreMicroblockUpdateData,
   DbMicroblock,
   DbTxAnchorMode,
@@ -4444,7 +4444,7 @@ export class PgDataStore
   }: {
     stxAddress: string;
     tx_id: string;
-  }): Promise<DbTxWithStxTransfers> {
+  }): Promise<DbTxWithAssetTransfers> {
     return this.query(async client => {
       const queryParams: (string | Buffer)[] = [stxAddress, hexToBuffer(tx_id)];
       const resultQuery = await client.query<
@@ -4498,19 +4498,19 @@ export class PgDataStore
         queryParams
       );
 
-      const txs = this.parseTxsWithStxTransfers(resultQuery, stxAddress);
+      const txs = this.parseTxsWithAssetTransfers(resultQuery, stxAddress);
       const txTransfers = [...txs.values()];
       return txTransfers[0];
     });
   }
 
-  async getAddressTxsWithStxTransfers(
+  async getAddressTxsWithAssetTransfers(
     args: {
       stxAddress: string;
       limit: number;
       offset: number;
     } & ({ blockHeight: number } | { includeUnanchored: boolean })
-  ): Promise<{ results: DbTxWithStxTransfers[]; total: number }> {
+  ): Promise<{ results: DbTxWithAssetTransfers[]; total: number }> {
     return this.queryTx(async client => {
       let atSingleBlock: boolean;
       const queryParams: (string | number)[] = [args.stxAddress, args.limit, args.offset];
@@ -4614,7 +4614,7 @@ export class PgDataStore
 
       // TODO: should mining rewards be added?
 
-      const txs = this.parseTxsWithStxTransfers(resultQuery, args.stxAddress);
+      const txs = this.parseTxsWithAssetTransfers(resultQuery, args.stxAddress);
       const txTransfers = [...txs.values()];
       txTransfers.sort((a, b) => {
         return b.tx.block_height - a.tx.block_height || b.tx.tx_index - a.tx.tx_index;
@@ -4624,7 +4624,7 @@ export class PgDataStore
     });
   }
 
-  parseTxsWithStxTransfers(
+  parseTxsWithAssetTransfers(
     resultQuery: QueryResult<
       TxQueryResult & {
         count: number;

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1192,7 +1192,7 @@ export class PgDataStore
     // Flag orphaned microblock rows as `microblock_canonical=false`
     const updatedMicroblocksQuery = await client.query(
       `
-      UPDATE microblocks
+      UPDATE microblocks 
       SET microblock_canonical = $1, canonical = $2, index_block_hash = $3, block_hash = $4
       WHERE microblock_hash = ANY($5)
       `,
@@ -1320,7 +1320,7 @@ export class PgDataStore
         `
         SELECT ${MICROBLOCK_COLUMNS}
         FROM microblocks
-        WHERE microblock_hash = $1
+        WHERE microblock_hash = $1 
         ORDER BY canonical DESC, microblock_canonical DESC
         LIMIT 1
         `,
@@ -2189,7 +2189,7 @@ export class PgDataStore
     const result = await client.query(
       `
       INSERT INTO blocks(
-        block_hash, index_block_hash,
+        block_hash, index_block_hash, 
         parent_index_block_hash, parent_block_hash, parent_microblock_hash, parent_microblock_sequence,
         block_height, burn_block_time, burn_block_hash, burn_block_height, miner_txid, canonical
       ) values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
@@ -2322,7 +2322,7 @@ export class PgDataStore
         `
         SELECT ${BLOCK_COLUMNS}
         FROM blocks
-        WHERE block_height = $1
+        WHERE block_height = $1 
         ORDER BY canonical DESC
         LIMIT 1
         `,
@@ -2333,7 +2333,7 @@ export class PgDataStore
         `
         SELECT ${BLOCK_COLUMNS}
         FROM blocks
-        WHERE burn_block_hash = $1
+        WHERE burn_block_hash = $1 
         ORDER BY canonical DESC, block_height DESC
         LIMIT 1
         `,
@@ -2344,7 +2344,7 @@ export class PgDataStore
         `
         SELECT ${BLOCK_COLUMNS}
         FROM blocks
-        WHERE burn_block_height = $1
+        WHERE burn_block_height = $1 
         ORDER BY canonical DESC, block_height DESC
         LIMIT 1
         `,
@@ -2494,7 +2494,7 @@ export class PgDataStore
         `
         UPDATE reward_slot_holders
         SET canonical = false
-        WHERE canonical = true AND (burn_block_hash = $1 OR burn_block_height >= $2)
+        WHERE canonical = true AND (burn_block_hash = $1 OR burn_block_height >= $2) 
         RETURNING address
         `,
         [hexToBuffer(burnchainBlockHash), burnchainBlockHeight]
@@ -2555,7 +2555,7 @@ export class PgDataStore
         count: number;
       }>(
         `
-        SELECT
+        SELECT 
           burn_block_hash, burn_block_height, address, slot_index,
           (COUNT(*) OVER())::integer AS count
         FROM reward_slot_holders
@@ -2780,7 +2780,7 @@ export class PgDataStore
       INSERT INTO txs(
         ${TX_COLUMNS}
       ) values(
-        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19,
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, 
         $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37
       )
       -- ON CONFLICT ON CONSTRAINT unique_tx_id_index_block_hash
@@ -3038,7 +3038,7 @@ export class PgDataStore
           `
           SELECT tx_id
           FROM txs
-          WHERE canonical = true AND microblock_canonical = true
+          WHERE canonical = true AND microblock_canonical = true 
           AND block_height = $1
           AND tx_id = $2
           LIMIT 1
@@ -3592,7 +3592,7 @@ export class PgDataStore
       if (txIndex === -1) {
         const txQuery = await client.query<{ tx_index: number }>(
           `
-          SELECT tx_index from txs
+          SELECT tx_index from txs 
           WHERE tx_id = $1 AND index_block_hash = $2 AND block_height = $3
           LIMIT 1
           `,
@@ -4174,7 +4174,7 @@ export class PgDataStore
         } & { count: number }
       >(
         `
-        SELECT *,
+        SELECT *,  
         (
           COUNT(*) OVER()
         )::INTEGER AS COUNT  FROM(
@@ -4297,7 +4297,7 @@ export class PgDataStore
         WITH transfers AS (
           SELECT amount, sender, recipient, asset_identifier
           FROM ft_events
-          WHERE canonical = true AND microblock_canonical = true
+          WHERE canonical = true AND microblock_canonical = true 
           AND (sender = $1 OR recipient = $1)
           AND block_height <= $2
         ), credit AS (
@@ -5399,7 +5399,7 @@ export class PgDataStore
         WHERE name = $1
         AND zonefile_hash = $2
         UNION ALL
-        SELECT zonefile
+        SELECT zonefile 
         FROM subdomains
         WHERE fully_qualified_subdomain = $1
         AND zonefile_hash = $2

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1192,7 +1192,7 @@ export class PgDataStore
     // Flag orphaned microblock rows as `microblock_canonical=false`
     const updatedMicroblocksQuery = await client.query(
       `
-      UPDATE microblocks 
+      UPDATE microblocks
       SET microblock_canonical = $1, canonical = $2, index_block_hash = $3, block_hash = $4
       WHERE microblock_hash = ANY($5)
       `,
@@ -1320,7 +1320,7 @@ export class PgDataStore
         `
         SELECT ${MICROBLOCK_COLUMNS}
         FROM microblocks
-        WHERE microblock_hash = $1 
+        WHERE microblock_hash = $1
         ORDER BY canonical DESC, microblock_canonical DESC
         LIMIT 1
         `,
@@ -2189,7 +2189,7 @@ export class PgDataStore
     const result = await client.query(
       `
       INSERT INTO blocks(
-        block_hash, index_block_hash, 
+        block_hash, index_block_hash,
         parent_index_block_hash, parent_block_hash, parent_microblock_hash, parent_microblock_sequence,
         block_height, burn_block_time, burn_block_hash, burn_block_height, miner_txid, canonical
       ) values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
@@ -2322,7 +2322,7 @@ export class PgDataStore
         `
         SELECT ${BLOCK_COLUMNS}
         FROM blocks
-        WHERE block_height = $1 
+        WHERE block_height = $1
         ORDER BY canonical DESC
         LIMIT 1
         `,
@@ -2333,7 +2333,7 @@ export class PgDataStore
         `
         SELECT ${BLOCK_COLUMNS}
         FROM blocks
-        WHERE burn_block_hash = $1 
+        WHERE burn_block_hash = $1
         ORDER BY canonical DESC, block_height DESC
         LIMIT 1
         `,
@@ -2344,7 +2344,7 @@ export class PgDataStore
         `
         SELECT ${BLOCK_COLUMNS}
         FROM blocks
-        WHERE burn_block_height = $1 
+        WHERE burn_block_height = $1
         ORDER BY canonical DESC, block_height DESC
         LIMIT 1
         `,
@@ -2494,7 +2494,7 @@ export class PgDataStore
         `
         UPDATE reward_slot_holders
         SET canonical = false
-        WHERE canonical = true AND (burn_block_hash = $1 OR burn_block_height >= $2) 
+        WHERE canonical = true AND (burn_block_hash = $1 OR burn_block_height >= $2)
         RETURNING address
         `,
         [hexToBuffer(burnchainBlockHash), burnchainBlockHeight]
@@ -2555,7 +2555,7 @@ export class PgDataStore
         count: number;
       }>(
         `
-        SELECT 
+        SELECT
           burn_block_hash, burn_block_height, address, slot_index,
           (COUNT(*) OVER())::integer AS count
         FROM reward_slot_holders
@@ -2780,7 +2780,7 @@ export class PgDataStore
       INSERT INTO txs(
         ${TX_COLUMNS}
       ) values(
-        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, 
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19,
         $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37
       )
       -- ON CONFLICT ON CONSTRAINT unique_tx_id_index_block_hash
@@ -3038,7 +3038,7 @@ export class PgDataStore
           `
           SELECT tx_id
           FROM txs
-          WHERE canonical = true AND microblock_canonical = true 
+          WHERE canonical = true AND microblock_canonical = true
           AND block_height = $1
           AND tx_id = $2
           LIMIT 1
@@ -3592,7 +3592,7 @@ export class PgDataStore
       if (txIndex === -1) {
         const txQuery = await client.query<{ tx_index: number }>(
           `
-          SELECT tx_index from txs 
+          SELECT tx_index from txs
           WHERE tx_id = $1 AND index_block_hash = $2 AND block_height = $3
           LIMIT 1
           `,
@@ -4174,7 +4174,7 @@ export class PgDataStore
         } & { count: number }
       >(
         `
-        SELECT *,  
+        SELECT *,
         (
           COUNT(*) OVER()
         )::INTEGER AS COUNT  FROM(
@@ -4297,7 +4297,7 @@ export class PgDataStore
         WITH transfers AS (
           SELECT amount, sender, recipient, asset_identifier
           FROM ft_events
-          WHERE canonical = true AND microblock_canonical = true 
+          WHERE canonical = true AND microblock_canonical = true
           AND (sender = $1 OR recipient = $1)
           AND block_height <= $2
         ), credit AS (
@@ -4458,9 +4458,9 @@ export class PgDataStore
         }
       >(
         `
-      SELECT 
-        tx_results.*, 
-        events.event_index as event_index, 
+      SELECT
+        tx_results.*,
+        events.event_index as event_index,
         events.asset_event_type_id as event_type,
         events.amount as event_amount,
         events.sender as event_sender,
@@ -4474,13 +4474,13 @@ export class PgDataStore
             token_transfer_recipient_address = $1 OR
             contract_call_contract_id = $1 OR
             smart_contract_contract_id = $1
-          ) 
+          )
           UNION
           SELECT txs.* FROM txs
           LEFT OUTER JOIN stx_events
           ON txs.tx_id = stx_events.tx_id
-          WHERE 
-            txs.canonical = true AND txs.microblock_canonical = true AND txs.tx_id = $2 AND 
+          WHERE
+            txs.canonical = true AND txs.microblock_canonical = true AND txs.tx_id = $2 AND
             (stx_events.sender = $1 OR stx_events.recipient = $1)
         )
         SELECT ${TX_COLUMNS}, (COUNT(*) OVER())::integer as count
@@ -4533,16 +4533,18 @@ export class PgDataStore
           event_amount?: string;
           event_sender?: string;
           event_recipient?: string;
+          ft_asset_identifier?: string;
         }
       >(
         `
-        SELECT 
-          tx_results.*, 
-          events.event_index as event_index, 
-          events.asset_event_type_id as event_type,
+        SELECT
+          tx_results.*,
+          events.event_index as event_index,
+          events.event_type_id as event_type,
           events.amount as event_amount,
           events.sender as event_sender,
-          events.recipient as event_recipient
+          events.recipient as event_recipient,
+          events.asset_identifier as ft_asset_identifier
         FROM (
           WITH transactions AS (
             SELECT *
@@ -4555,12 +4557,14 @@ export class PgDataStore
             )
             UNION
             SELECT txs.* FROM txs
-            LEFT OUTER JOIN stx_events
-            ON txs.tx_id = stx_events.tx_id
-            WHERE 
+            LEFT OUTER JOIN stx_events ON txs.tx_id = stx_events.tx_id
+            LEFT OUTER JOIN ft_events ON txs.tx_id = ft_events.tx_id
+            WHERE
               txs.canonical = true AND txs.microblock_canonical = true AND (
-                stx_events.sender = $1 OR 
-                stx_events.recipient = $1
+                stx_events.sender = $1 OR
+                stx_events.recipient = $1 OR
+                ft_events.sender = $1 OR
+                ft_events.recipient = $1
               )
           )
           SELECT ${TX_COLUMNS}, (COUNT(*) OVER())::integer as count
@@ -4571,11 +4575,22 @@ export class PgDataStore
           OFFSET $3
         ) tx_results
         LEFT JOIN (
-          SELECT *
-          FROM stx_events
-          WHERE canonical = true AND microblock_canonical = true AND (sender = $1 OR recipient = $1)
-        ) events
-        ON tx_results.tx_id = events.tx_id
+          (
+            SELECT tx_id, sender, recipient, event_index, ${
+              DbEventTypeId.StxAsset
+            } as event_type_id, amount, NULL as asset_identifier
+            FROM stx_events
+            WHERE canonical = true AND microblock_canonical = true AND (sender = $1 OR recipient = $1)
+          )
+          UNION
+          (
+            SELECT tx_id, sender, recipient, event_index, ${
+              DbEventTypeId.FungibleTokenAsset
+            } as event_type_id, amount, asset_identifier
+            FROM ft_events
+            WHERE canonical = true AND microblock_canonical = true AND (sender = $1 OR recipient = $1)
+          )
+        ) events ON tx_results.tx_id = events.tx_id
         ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
         `,
         queryParams
@@ -4602,6 +4617,7 @@ export class PgDataStore
         event_amount?: string | undefined;
         event_sender?: string | undefined;
         event_recipient?: string | undefined;
+        ft_asset_identifier?: string | undefined;
       }
     >,
     stxAddress: string
@@ -4617,6 +4633,12 @@ export class PgDataStore
           sender?: string;
           recipient?: string;
         }[];
+        ft_transfers: {
+          asset_identifier?: string;
+          amount: bigint;
+          sender?: string;
+          recipient?: string;
+        }[];
       }
     >();
     for (const r of resultQuery.rows) {
@@ -4628,6 +4650,7 @@ export class PgDataStore
           stx_sent: 0n,
           stx_received: 0n,
           stx_transfers: [],
+          ft_transfers: [],
         };
         if (txResult.tx.sender_address === stxAddress) {
           txResult.stx_sent += txResult.tx.fee_rate;
@@ -4636,16 +4659,29 @@ export class PgDataStore
       }
       if (r.event_index !== undefined && r.event_index !== null) {
         const eventAmount = BigInt(r.event_amount as string);
-        txResult.stx_transfers.push({
-          amount: eventAmount,
-          sender: r.event_sender,
-          recipient: r.event_recipient,
-        });
-        if (r.event_sender === stxAddress) {
-          txResult.stx_sent += eventAmount;
-        }
-        if (r.event_recipient === stxAddress) {
-          txResult.stx_received += eventAmount;
+        switch (r.event_type) {
+          case DbEventTypeId.StxAsset:
+            txResult.stx_transfers.push({
+              amount: eventAmount,
+              sender: r.event_sender,
+              recipient: r.event_recipient,
+            });
+            if (r.event_sender === stxAddress) {
+              txResult.stx_sent += eventAmount;
+            }
+            if (r.event_recipient === stxAddress) {
+              txResult.stx_received += eventAmount;
+            }
+            break;
+
+          case DbEventTypeId.FungibleTokenAsset:
+            txResult.ft_transfers.push({
+              asset_identifier: r.ft_asset_identifier,
+              amount: eventAmount,
+              sender: r.event_sender,
+              recipient: r.event_recipient,
+            });
+            break;
         }
       }
     }
@@ -5330,7 +5366,7 @@ export class PgDataStore
         WHERE name = $1
         AND zonefile_hash = $2
         UNION ALL
-        SELECT zonefile 
+        SELECT zonefile
         FROM subdomains
         WHERE fully_qualified_subdomain = $1
         AND zonefile_hash = $2

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -4461,7 +4461,7 @@ export class PgDataStore
       SELECT
         tx_results.*,
         events.event_index as event_index,
-        events.asset_event_type_id as event_type,
+        events.event_type_id as event_type,
         events.amount as event_amount,
         events.sender as event_sender,
         events.recipient as event_recipient
@@ -4488,7 +4488,7 @@ export class PgDataStore
         ORDER BY block_height DESC, tx_index DESC
       ) tx_results
       LEFT JOIN (
-        SELECT *
+        SELECT *, ${DbEventTypeId.StxAsset} as event_type_id
         FROM stx_events
         WHERE canonical = true AND microblock_canonical = true AND (sender = $1 OR recipient = $1)
       ) events
@@ -4576,17 +4576,15 @@ export class PgDataStore
         ) tx_results
         LEFT JOIN (
           (
-            SELECT tx_id, sender, recipient, event_index, ${
-              DbEventTypeId.StxAsset
-            } as event_type_id, amount, NULL as asset_identifier
+            SELECT tx_id, sender, recipient, event_index,
+            ${DbEventTypeId.StxAsset} as event_type_id, amount, NULL as asset_identifier
             FROM stx_events
             WHERE canonical = true AND microblock_canonical = true AND (sender = $1 OR recipient = $1)
           )
           UNION
           (
-            SELECT tx_id, sender, recipient, event_index, ${
-              DbEventTypeId.FungibleTokenAsset
-            } as event_type_id, amount, asset_identifier
+            SELECT tx_id, sender, recipient, event_index,
+            ${DbEventTypeId.FungibleTokenAsset} as event_type_id, amount, asset_identifier
             FROM ft_events
             WHERE canonical = true AND microblock_canonical = true AND (sender = $1 OR recipient = $1)
           )

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -2166,8 +2166,10 @@ describe('api tests', () => {
       recipient: string,
       amount: number,
       canonical: boolean = true,
-      eventCount = 1
-    ): [DbTx, DbStxEvent[]] => {
+      stxEventCount = 1,
+      ftEventCount = 1,
+      nftEventCount = 1
+    ): [DbTx, DbStxEvent[], DbFtEvent[], DbNftEvent[]] => {
       const tx: DbTx = {
         tx_id: '0x1234' + (++indexIdIndex).toString().padStart(4, '0'),
         tx_index: indexIdIndex,
@@ -2200,7 +2202,7 @@ describe('api tests', () => {
         event_count: 0,
       };
       const stxEvents: DbStxEvent[] = [];
-      for (let i = 0; i < eventCount; i++) {
+      for (let i = 0; i < stxEventCount; i++) {
         const stxEvent: DbStxEvent = {
           canonical,
           event_type: DbEventTypeId.StxAsset,
@@ -2215,21 +2217,61 @@ describe('api tests', () => {
         };
         stxEvents.push(stxEvent);
       }
-      return [tx, stxEvents];
+      const ftEvents: DbFtEvent[] = [];
+      for (let i = 0; i < ftEventCount; i++) {
+        const ftEvent: DbFtEvent = {
+          canonical,
+          event_type: DbEventTypeId.FungibleTokenAsset,
+          asset_event_type_id: DbAssetEventTypeId.Transfer,
+          asset_identifier: 'usdc',
+          event_index: i,
+          tx_id: tx.tx_id,
+          tx_index: tx.tx_index,
+          block_height: tx.block_height,
+          amount: BigInt(amount),
+          recipient,
+          sender,
+        };
+        ftEvents.push(ftEvent);
+      }
+      const nftEvents: DbNftEvent[] = [];
+      for (let i = 0; i < nftEventCount; i++) {
+        const nftEvent: DbNftEvent = {
+          canonical,
+          event_type: DbEventTypeId.NonFungibleTokenAsset,
+          asset_event_type_id: DbAssetEventTypeId.Transfer,
+          asset_identifier: 'punk1',
+          event_index: i,
+          tx_id: tx.tx_id,
+          tx_index: tx.tx_index,
+          block_height: tx.block_height,
+          value: Buffer.from([0]),
+          recipient,
+          sender,
+        };
+        nftEvents.push(nftEvent);
+      }
+      return [tx, stxEvents, ftEvents, nftEvents];
     };
 
     const txs = [
       createStxTx(testAddr1, testAddr2, 100_000),
-      createStxTx(testAddr2, testContractAddr, 100),
-      createStxTx(testAddr2, testContractAddr, 250),
+      createStxTx(testAddr2, testContractAddr, 100, true, 1, 2, 1),
+      createStxTx(testAddr2, testContractAddr, 250, true, 1, 0, 0),
       createStxTx(testAddr2, testContractAddr, 40, false),
       createStxTx(testContractAddr, testAddr4, 15),
-      createStxTx(testAddr2, testAddr4, 35, true, 3),
+      createStxTx(testAddr2, testAddr4, 35, true, 3, 1, 2),
     ];
-    for (const [tx, events] of txs) {
+    for (const [tx, stxEvents, ftEvents, nftEvents] of txs) {
       await db.updateTx(client, tx);
-      for (const event of events) {
+      for (const event of stxEvents) {
         await db.updateStxEvent(client, tx, event);
+      }
+      for (const event of ftEvents) {
+        await db.updateFtEvent(client, tx, event);
+      }
+      for (const event of nftEvents) {
+        await db.updateNftEvent(client, tx, event);
       }
     }
 
@@ -2296,6 +2338,14 @@ describe('api tests', () => {
               recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
             },
           ],
+          ft_transfers: [
+            {
+              amount: '35',
+              asset_identifier: 'usdc',
+              sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
+              recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
+            },
+          ],
         },
         {
           tx: {
@@ -2340,6 +2390,7 @@ describe('api tests', () => {
               recipient: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
             },
           ],
+          ft_transfers: [],
         },
         {
           tx: {
@@ -2380,6 +2431,20 @@ describe('api tests', () => {
           stx_transfers: [
             {
               amount: '100',
+              sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
+              recipient: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
+            },
+          ],
+          ft_transfers: [
+            {
+              amount: '100',
+              asset_identifier: 'usdc',
+              sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
+              recipient: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
+            },
+            {
+              amount: '100',
+              asset_identifier: 'usdc',
               sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
               recipient: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
             },

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -2259,7 +2259,7 @@ describe('api tests', () => {
       createStxTx(testAddr2, testContractAddr, 100, true, 1, 2, 1),
       createStxTx(testAddr2, testContractAddr, 250, true, 1, 0, 0),
       createStxTx(testAddr2, testContractAddr, 40, false),
-      createStxTx(testContractAddr, testAddr4, 15),
+      createStxTx(testContractAddr, testAddr4, 15, true, 1, 1, 0),
       createStxTx(testAddr2, testAddr4, 35, true, 3, 1, 2),
     ];
     for (const [tx, stxEvents, ftEvents, nftEvents] of txs) {
@@ -2580,6 +2580,14 @@ describe('api tests', () => {
               recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
             },
           ],
+          ft_transfers: [
+            {
+              amount: '35',
+              asset_identifier: 'usdc',
+              sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
+              recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
+            },
+          ],
         },
         {
           tx: {
@@ -2620,6 +2628,14 @@ describe('api tests', () => {
           stx_transfers: [
             {
               amount: '15',
+              sender: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
+              recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
+            },
+          ],
+          ft_transfers: [
+            {
+              amount: '15',
+              asset_identifier: 'usdc',
               sender: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
               recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
             },

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -2245,7 +2245,7 @@ describe('api tests', () => {
           tx_id: tx.tx_id,
           tx_index: tx.tx_index,
           block_height: tx.block_height,
-          value: Buffer.from([0]),
+          value: Buffer.from(amount.toString()),
           recipient,
           sender,
         };
@@ -2255,10 +2255,10 @@ describe('api tests', () => {
     };
 
     const txs = [
-      createStxTx(testAddr1, testAddr2, 100_000),
+      createStxTx(testAddr1, testAddr2, 100_000, true, 1, 1, 1),
       createStxTx(testAddr2, testContractAddr, 100, true, 1, 2, 1),
-      createStxTx(testAddr2, testContractAddr, 250, true, 1, 0, 0),
-      createStxTx(testAddr2, testContractAddr, 40, false),
+      createStxTx(testAddr2, testContractAddr, 250, true, 1, 0, 1),
+      createStxTx(testAddr2, testContractAddr, 40, false, 1, 1, 1),
       createStxTx(testContractAddr, testAddr4, 15, true, 1, 1, 0),
       createStxTx(testAddr2, testAddr4, 35, true, 3, 1, 2),
     ];
@@ -2346,6 +2346,20 @@ describe('api tests', () => {
               recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
             },
           ],
+          nft_transfers: [
+            {
+              asset_identifier: 'punk1',
+              sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
+              recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
+              value: '35',
+            },
+            {
+              asset_identifier: 'punk1',
+              sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
+              recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
+              value: '35',
+            },
+          ],
         },
         {
           tx: {
@@ -2391,6 +2405,14 @@ describe('api tests', () => {
             },
           ],
           ft_transfers: [],
+          nft_transfers: [
+            {
+              asset_identifier: 'punk1',
+              sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
+              recipient: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
+              value: '250',
+            },
+          ],
         },
         {
           tx: {
@@ -2447,6 +2469,14 @@ describe('api tests', () => {
               asset_identifier: 'usdc',
               sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
               recipient: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
+            },
+          ],
+          nft_transfers: [
+            {
+              asset_identifier: 'punk1',
+              sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
+              recipient: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
+              value: '100',
             },
           ],
         },
@@ -2588,6 +2618,20 @@ describe('api tests', () => {
               recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
             },
           ],
+          nft_transfers: [
+            {
+              asset_identifier: 'punk1',
+              sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
+              recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
+              value: '35',
+            },
+            {
+              asset_identifier: 'punk1',
+              sender: 'ST1HB64MAJ1MBV4CQ80GF01DZS4T1DSMX20ADCRA4',
+              recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
+              value: '35',
+            },
+          ],
         },
         {
           tx: {
@@ -2640,6 +2684,7 @@ describe('api tests', () => {
               recipient: 'ST3DWSXBPYDB484QXFTR81K4AWG4ZB5XZNFF3H70C',
             },
           ],
+          nft_transfers: [],
         },
       ],
     };


### PR DESCRIPTION
## Description

Add FT and NFT transfers to the list of transactions listed in `/extended/v1/address/[:principal]/transactions_with_transfers` so wallets can display this information to users.

Closes #615 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No.

## Are documentation updates required?
Yes. Endpoint descriptions should be updated.

## Testing information

Covered in existing unit tests.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @kyranjamie or @zone117x for review
