### PR TITLE
Types for search

### DIFF
--- a/docs/api/search/search-address.schema.json
+++ b/docs/api/search/search-address.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "AddressSearchResult",
+  "description": "Address search result",
+  "required": ["found", "result"],
+  "additionalProperties": false,
+  "properties": {
+    "found": {
+      "type": "boolean",
+      "description": "Indicates if the requested object was found or not",
+      "default": true
+    },
+    "result": {
+      "type": "object",
+      "description": "This object carries the search result",
+      "required": ["entity_id", "entity_type"],
+      "additionalProperties": false,
+      "properties": {
+        "entity_id": {
+          "type": "string",
+          "description": "The id used to search this query."
+        },
+        "entity_type": {
+          "type": "string",
+          "enum": ["standard_address"]
+        }
+      }
+    }
+  }
+}

--- a/docs/api/search/search-block.schema.json
+++ b/docs/api/search/search-block.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "BlockSearchResult",
+  "description": "Block search result",
+  "required": ["found", "result"],
+  "additionalProperties": false,
+  "properties": {
+    "found": {
+      "type": "boolean",
+      "description": "Indicates if the requested object was found or not",
+      "default": true
+    },
+    "result": {
+      "type": "object",
+      "description": "This object carries the search result",
+      "required": ["entity_id", "entity_type", "block_data"],
+      "additionalProperties": false,
+      "properties": {
+        "entity_id": {
+          "type": "string",
+          "description": "The id used to search this query."
+        },
+        "entity_type": {
+          "type": "string",
+          "enum": ["block_hash"]
+        },
+        "block_data": {
+          "type": "object",
+          "description": "Returns basic search result information about the requested id",
+          "required": ["canonical", "hash", "parent_block_hash", "burn_block_time", "height"],
+          "additionalProperties": false,
+          "properties": {
+            "canonical": {
+              "type": "boolean",
+              "description": "If the block lies within the canonical chain"
+            },
+            "hash": {
+              "type": "string",
+              "description": "Refers to the hash of the block"
+            },
+            "parent_block_hash": {
+              "type": "string"
+            },
+            "burn_block_time": {
+              "type": "integer"
+            },
+            "height": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/api/search/search-contract.schema.json
+++ b/docs/api/search/search-contract.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "ContractSearchResult",
+  "description": "Contract search result",
+  "required": ["found", "result"],
+  "additionalProperties": false,
+  "properties": {
+    "found": {
+      "type": "boolean",
+      "description": "Indicates if the requested object was found or not",
+      "default": true
+    },
+    "result": {
+      "type": "object",
+      "description": "This object carries the search result",
+      "required": ["entity_id", "entity_type"],
+      "additionalProperties": false,
+      "properties": {
+        "entity_id": {
+          "type": "string",
+          "description": "The id used to search this query."
+        },
+        "entity_type": {
+          "type": "string",
+          "enum": ["contract_address"]
+        },
+        "tx_data": {
+          "type": "object",
+          "description": "Returns basic search result information about the requested id",
+          "additionalProperties": false,
+          "properties": {
+            "canonical": {
+              "type": "boolean",
+              "description": "If the transaction lies within the canonical chain"
+            },
+            "block_hash": {
+              "type": "string",
+              "description": "Refers to the hash of the block for searched transaction"
+            },
+            "burn_block_time": {
+              "type": "integer"
+            },
+            "block_height": {
+              "type": "integer"
+            },
+            "tx_type": {
+              "type": "string"
+            },
+            "tx_id": {
+              "type": "string",
+              "description": "Corresponding tx_id for smart_contract"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/api/search/search-error.schema.json
+++ b/docs/api/search/search-error.schema.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "title": "ErrorResult",
+    "description": "Error search result",
+    "required": ["found", "result", "error"],
+    "additionalProperties": false,
+    "properties": {
+      "found": {
+        "type": "boolean",
+        "description": "Indicates if the requested object was found or not",
+        "default": false
+      },
+      "result": {
+        "type": "object",
+        "required": ["entity_type"],
+        "additionalProperties": false,
+        "properties": {
+          "entity_type": {
+            "type": "string",
+            "description": "Shows the currenty category of entity it is searched in.",
+            "enum": ["standard_address", "unknown_hash", "contract_address", "invalid_term"]
+          }
+        }
+      },
+      "error": {
+        "type": "string"
+      }
+    }
+  }
+  

--- a/docs/api/search/search-error.schema.json
+++ b/docs/api/search/search-error.schema.json
@@ -1,31 +1,30 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
-    "type": "object",
-    "title": "ErrorResult",
-    "description": "Error search result",
-    "required": ["found", "result", "error"],
-    "additionalProperties": false,
-    "properties": {
-      "found": {
-        "type": "boolean",
-        "description": "Indicates if the requested object was found or not",
-        "default": false
-      },
-      "result": {
-        "type": "object",
-        "required": ["entity_type"],
-        "additionalProperties": false,
-        "properties": {
-          "entity_type": {
-            "type": "string",
-            "description": "Shows the currenty category of entity it is searched in.",
-            "enum": ["standard_address", "unknown_hash", "contract_address", "invalid_term"]
-          }
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "SearchErrorResult",
+  "description": "Error search result",
+  "required": ["found", "result", "error"],
+  "additionalProperties": false,
+  "properties": {
+    "found": {
+      "type": "boolean",
+      "description": "Indicates if the requested object was found or not",
+      "default": false
+    },
+    "result": {
+      "type": "object",
+      "required": ["entity_type"],
+      "additionalProperties": false,
+      "properties": {
+        "entity_type": {
+          "type": "string",
+          "description": "Shows the currenty category of entity it is searched in.",
+          "enum": ["standard_address", "unknown_hash", "contract_address", "invalid_term"]
         }
-      },
-      "error": {
-        "type": "string"
       }
+    },
+    "error": {
+      "type": "string"
     }
   }
-  
+}

--- a/docs/api/search/search-mempool.schema.json
+++ b/docs/api/search/search-mempool.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "MempoolTxSearchResult",
+  "description": "Contract search result",
+  "required": ["found", "result"],
+  "additionalProperties": false,
+  "properties": {
+    "found": {
+      "type": "boolean",
+      "description": "Indicates if the requested object was found or not",
+      "default": true
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "This object carries the search result",
+      "required": ["entity_id", "entity_type", "tx_data"],
+      "properties": {
+        "entity_id": {
+          "type": "string",
+          "description": "The id used to search this query."
+        },
+        "entity_type": {
+          "type": "string",
+          "enum": ["mempool_tx_id"]
+        },
+        "tx_data": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Returns basic search result information about the requested id",
+          "required": ["tx_type"],
+          "properties": {
+            "tx_type": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/api/search/search-success.schema.json
+++ b/docs/api/search/search-success.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "object",
-  "title": "SuccessResult",
+  "title": "SearchSuccessResult",
   "description": "Search success result",
   "additionalProperties": false,
   "anyOf": [

--- a/docs/api/search/search-success.schema.json
+++ b/docs/api/search/search-success.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "SuccessResult",
+  "description": "Search success result",
+  "additionalProperties": false,
+  "anyOf": [
+    {
+      "$ref": "./search-address.schema.json"
+    },
+    {
+      "$ref": "./search-block.schema.json"
+    },
+    {
+      "$ref": "./search-contract.schema.json"
+    },
+    {
+      "$ref": "./search-mempool.schema.json"
+    },
+    {
+      "$ref": "./search-tx-id.schema.json"
+    }
+  ]
+}

--- a/docs/api/search/search-tx-id.example.json
+++ b/docs/api/search/search-tx-id.example.json
@@ -1,0 +1,14 @@
+{
+  "found": true,
+  "result": {
+    "entity_id": "0x55f41c149506dc148add4c23a1ec160ce8cd89a4f598c2a9620bb0010dbc2d96",
+    "entity_type": "tx_id",
+    "tx_data": {
+      "canonical": true,
+      "block_hash": "0xe6596337b8012a1009272070963e1b1a13f1f980011099be40014bb725f06390",
+      "burn_block_time": 1629895386,
+      "block_height": 1,
+      "tx_type": "coinbase"
+    }
+  }
+}

--- a/docs/api/search/search-tx-id.schema.json
+++ b/docs/api/search/search-tx-id.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "TxSearchResult",
+  "description": "Transaction search result",
+  "additionalProperties": false,
+  "required": ["found", "result"],
+  "properties": {
+    "found": {
+      "type": "boolean",
+      "description": "Indicates if the requested object was found or not",
+      "default": true
+    },
+    "result": {
+      "type": "object",
+      "description": "This object carries the search result",
+      "required": ["entity_id", "entity_type", "tx_data"],
+      "additionalProperties": false,
+      "properties": {
+        "entity_id": {
+          "type": "string",
+          "description": "The id used to search this query."
+        },
+        "entity_type": {
+          "type": "string",
+          "enum": ["tx_id"]
+        },
+        "tx_data": {
+          "type": "object",
+          "description": "Returns basic search result information about the requested id",
+          "required": ["canonical", "block_hash", "burn_block_time", "block_height", "tx_type"],
+          "additionalProperties": false,
+          "properties": {
+            "canonical": {
+              "type": "boolean",
+              "description": "If the transaction lies within the canonical chain"
+            },
+            "block_hash": {
+              "type": "string",
+              "description": "Refers to the hash of the block for searched transaction"
+            },
+            "burn_block_time": {
+              "type": "integer"
+            },
+            "block_height": {
+              "type": "integer"
+            },
+            "tx_type": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/api/search/search.schema.json
+++ b/docs/api/search/search.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "SearchResult",
+  "description": "complete search result for terms",
+  "additionalProperties": false,
+  "anyOf": [
+    {
+      "$ref": "./search-error.schema.json"
+    },
+    {
+      "$ref": "./search-success.schema.json"
+    }
+  ]
+}

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -81,9 +81,9 @@ export type SchemaMergeRootStub =
   | AddressSearchResult
   | BlockSearchResult
   | ContractSearchResult
-  | ErrorResult
+  | SearchErrorResult
   | MempoolTxSearchResult
-  | SuccessResult
+  | SearchSuccessResult
   | TxSearchResult
   | SearchResult
   | MempoolTransactionListResponse
@@ -250,6 +250,7 @@ export type TransactionEventSmartContractLog = {
   [k: string]: unknown | undefined;
 } & {
   event_type: "smart_contract_log";
+  tx_id: string;
   contract_log: {
     contract_id: string;
     topic: string;
@@ -268,6 +269,7 @@ export type TransactionEventStxLock = {
   [k: string]: unknown | undefined;
 } & {
   event_type: "stx_lock";
+  tx_id: string;
   stx_lock_event: {
     locked_amount: string;
     unlock_height: number;
@@ -283,6 +285,7 @@ export type TransactionEventStxAsset = {
   [k: string]: unknown | undefined;
 } & {
   event_type: "stx_asset";
+  tx_id: string;
   asset: TransactionEventAsset;
   [k: string]: unknown | undefined;
 };
@@ -292,6 +295,7 @@ export type TransactionEventFungibleAsset = {
   [k: string]: unknown | undefined;
 } & {
   event_type: "fungible_token_asset";
+  tx_id: string;
   asset: {
     asset_event_type: string;
     asset_id: string;
@@ -306,6 +310,7 @@ export type TransactionEventNonFungibleAsset = {
   [k: string]: unknown | undefined;
 } & {
   event_type: "non_fungible_token_asset";
+  tx_id: string;
   asset: {
     asset_event_type: string;
     asset_id: string;
@@ -678,7 +683,7 @@ export type RosettaBlockIdentifier = RosettaBlockIdentifierHash1 & RosettaBlockI
 /**
  * Search success result
  */
-export type SuccessResult =
+export type SearchSuccessResult =
   | AddressSearchResult
   | BlockSearchResult
   | ContractSearchResult
@@ -687,7 +692,7 @@ export type SuccessResult =
 /**
  * complete search result for terms
  */
-export type SearchResult = ErrorResult | SuccessResult;
+export type SearchResult = SearchErrorResult | SearchSuccessResult;
 /**
  * Status of the transaction
  */
@@ -2089,7 +2094,7 @@ export interface OtherTransactionIdentifier {
  */
 export interface RosettaBlockTransactionRequest {
   network_identifier: NetworkIdentifier;
-  block_identifier: RosettaBlockIdentifier;
+  block_identifier: RosettaPartialBlockIdentifier;
   transaction_identifier: TransactionIdentifier;
 }
 /**
@@ -2837,7 +2842,7 @@ export interface ContractSearchResult {
 /**
  * Error search result
  */
-export interface ErrorResult {
+export interface SearchErrorResult {
   /**
    * Indicates if the requested object was found or not
    */

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -78,6 +78,14 @@ export type SchemaMergeRootStub =
   | RosettaNetworkOptionsResponse
   | RosettaStatusRequest
   | RosettaNetworkStatusResponse
+  | AddressSearchResult
+  | BlockSearchResult
+  | ContractSearchResult
+  | ErrorResult
+  | MempoolTxSearchResult
+  | SuccessResult
+  | TxSearchResult
+  | SearchResult
   | MempoolTransactionListResponse
   | GetRawTransactionResult
   | TransactionResults
@@ -667,6 +675,19 @@ export type RosettaPartialBlockIdentifier = RosettaBlockIdentifierHash | Rosetta
  * The block_identifier uniquely identifies a block in a particular network.
  */
 export type RosettaBlockIdentifier = RosettaBlockIdentifierHash1 & RosettaBlockIdentifierHeight1;
+/**
+ * Search success result
+ */
+export type SuccessResult =
+  | AddressSearchResult
+  | BlockSearchResult
+  | ContractSearchResult
+  | MempoolTxSearchResult
+  | TxSearchResult;
+/**
+ * complete search result for terms
+ */
+export type SearchResult = ErrorResult | SuccessResult;
 /**
  * Status of the transaction
  */
@@ -2719,6 +2740,175 @@ export interface RosettaPeers {
     [k: string]: unknown | undefined;
   };
   [k: string]: unknown | undefined;
+}
+/**
+ * Address search result
+ */
+export interface AddressSearchResult {
+  /**
+   * Indicates if the requested object was found or not
+   */
+  found: boolean;
+  /**
+   * This object carries the search result
+   */
+  result: {
+    /**
+     * The id used to search this query.
+     */
+    entity_id: string;
+    entity_type: "standard_address";
+  };
+}
+/**
+ * Block search result
+ */
+export interface BlockSearchResult {
+  /**
+   * Indicates if the requested object was found or not
+   */
+  found: boolean;
+  /**
+   * This object carries the search result
+   */
+  result: {
+    /**
+     * The id used to search this query.
+     */
+    entity_id: string;
+    entity_type: "block_hash";
+    /**
+     * Returns basic search result information about the requested id
+     */
+    block_data: {
+      /**
+       * If the block lies within the canonical chain
+       */
+      canonical: boolean;
+      /**
+       * Refers to the hash of the block
+       */
+      hash: string;
+      parent_block_hash: string;
+      burn_block_time: number;
+      height: number;
+    };
+  };
+}
+/**
+ * Contract search result
+ */
+export interface ContractSearchResult {
+  /**
+   * Indicates if the requested object was found or not
+   */
+  found: boolean;
+  /**
+   * This object carries the search result
+   */
+  result: {
+    /**
+     * The id used to search this query.
+     */
+    entity_id: string;
+    entity_type: "contract_address";
+    /**
+     * Returns basic search result information about the requested id
+     */
+    tx_data?: {
+      /**
+       * If the transaction lies within the canonical chain
+       */
+      canonical?: boolean;
+      /**
+       * Refers to the hash of the block for searched transaction
+       */
+      block_hash?: string;
+      burn_block_time?: number;
+      block_height?: number;
+      tx_type?: string;
+      /**
+       * Corresponding tx_id for smart_contract
+       */
+      tx_id?: string;
+    };
+  };
+}
+/**
+ * Error search result
+ */
+export interface ErrorResult {
+  /**
+   * Indicates if the requested object was found or not
+   */
+  found: boolean;
+  result: {
+    /**
+     * Shows the currenty category of entity it is searched in.
+     */
+    entity_type: "standard_address" | "unknown_hash" | "contract_address" | "invalid_term";
+  };
+  error: string;
+}
+/**
+ * Contract search result
+ */
+export interface MempoolTxSearchResult {
+  /**
+   * Indicates if the requested object was found or not
+   */
+  found: boolean;
+  /**
+   * This object carries the search result
+   */
+  result: {
+    /**
+     * The id used to search this query.
+     */
+    entity_id: string;
+    entity_type: "mempool_tx_id";
+    /**
+     * Returns basic search result information about the requested id
+     */
+    tx_data: {
+      tx_type: string;
+    };
+  };
+}
+/**
+ * Transaction search result
+ */
+export interface TxSearchResult {
+  /**
+   * Indicates if the requested object was found or not
+   */
+  found: boolean;
+  /**
+   * This object carries the search result
+   */
+  result: {
+    /**
+     * The id used to search this query.
+     */
+    entity_id: string;
+    entity_type: "tx_id";
+    /**
+     * Returns basic search result information about the requested id
+     */
+    tx_data: {
+      /**
+       * If the transaction lies within the canonical chain
+       */
+      canonical: boolean;
+      /**
+       * Refers to the hash of the block for searched transaction
+       */
+      block_hash: string;
+      burn_block_time: number;
+      block_height: number;
+      tx_type: string;
+    };
+  };
 }
 /**
  * GET request that returns transactions

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1556,7 +1556,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: ./api/search/search.schema.json 
               example:
                 $ref: ./api/search/search-contract.example.json
         404:

--- a/src/api/routes/search.ts
+++ b/src/api/routes/search.ts
@@ -2,7 +2,17 @@ import * as express from 'express';
 import { addAsync, RouterWithAsync } from '@awaitjs/express';
 import { DataStore, DbBlock, DbTx, DbMempoolTx } from '../../datastore/common';
 import { isValidPrincipal, has0xPrefix } from '../../helpers';
-import { Transaction, Block } from '@stacks/stacks-blockchain-api-types';
+import {
+  Transaction,
+  Block,
+  SearchResult,
+  BlockSearchResult,
+  TxSearchResult,
+  MempoolTxSearchResult,
+  ErrorResult,
+  ContractSearchResult,
+  AddressSearchResult,
+} from '@stacks/stacks-blockchain-api-types';
 import { getTxTypeString } from '../controllers/db-controller';
 import { address } from 'bitcoinjs-lib';
 
@@ -14,57 +24,6 @@ export const enum SearchResultType {
   ContractAddress = 'contract_address',
   UnknownHash = 'unknown_hash',
   InvalidTerm = 'invalid_term',
-}
-
-export type SearchResult =
-  | {
-      found: false;
-      result: {
-        entity_type:
-          | SearchResultType.StandardAddress
-          | SearchResultType.ContractAddress
-          | SearchResultType.UnknownHash
-          | SearchResultType.InvalidTerm;
-      };
-      error: string;
-    }
-  | {
-      found: true;
-      result:
-        | AddressSearchResult
-        | ContractSearchResult
-        | TxSearchResult
-        | MempoolTxSearchResult
-        | BlockSearchResult;
-    };
-
-export interface AddressSearchResult {
-  entity_type: SearchResultType.StandardAddress;
-  entity_id: string;
-}
-
-export interface ContractSearchResult {
-  entity_type: SearchResultType.ContractAddress;
-  entity_id: string;
-  tx_data?: Partial<Transaction>;
-}
-
-export interface TxSearchResult {
-  entity_type: SearchResultType.TxId;
-  entity_id: string;
-  tx_data: Partial<Transaction>;
-}
-
-export interface MempoolTxSearchResult {
-  entity_type: SearchResultType.MempoolTxId;
-  entity_id: string;
-  tx_data: Partial<Transaction>;
-}
-
-export interface BlockSearchResult {
-  entity_type: SearchResultType.BlockHash;
-  entity_id: string;
-  block_data: Partial<Block>;
 }
 
 export function createSearchRouter(db: DataStore): RouterWithAsync {
@@ -87,52 +46,64 @@ export function createSearchRouter(db: DataStore): RouterWithAsync {
         if (queryResult.result.entity_type === 'block_hash') {
           const blockData = queryResult.result.entity_data as DbBlock;
           const blockResult: BlockSearchResult = {
-            entity_id: queryResult.result.entity_id,
-            entity_type: SearchResultType.BlockHash,
-            block_data: {
-              canonical: blockData.canonical,
-              hash: blockData.block_hash,
-              parent_block_hash: blockData.parent_block_hash,
-              burn_block_time: blockData.burn_block_time,
-              height: blockData.block_height,
+            found: true,
+            result: {
+              entity_id: queryResult.result.entity_id,
+              entity_type: SearchResultType.BlockHash,
+              block_data: {
+                canonical: blockData.canonical,
+                hash: blockData.block_hash,
+                parent_block_hash: blockData.parent_block_hash,
+                burn_block_time: blockData.burn_block_time,
+                height: blockData.block_height,
+              },
             },
           };
-          return { found: true, result: blockResult };
+          return blockResult;
         } else if (queryResult.result.entity_type === 'tx_id') {
           const txData = queryResult.result.entity_data as DbTx;
           const txResult: TxSearchResult = {
-            entity_id: queryResult.result.entity_id,
-            entity_type: SearchResultType.TxId,
-            tx_data: {
-              canonical: txData.canonical,
-              block_hash: txData.block_hash,
-              burn_block_time: txData.burn_block_time,
-              block_height: txData.block_height,
-              tx_type: getTxTypeString(txData.type_id),
+            found: true,
+            result: {
+              entity_id: queryResult.result.entity_id,
+              entity_type: SearchResultType.TxId,
+              tx_data: {
+                canonical: txData.canonical,
+                block_hash: txData.block_hash,
+                burn_block_time: txData.burn_block_time,
+                block_height: txData.block_height,
+                tx_type: getTxTypeString(txData.type_id),
+              },
             },
           };
-          return { found: true, result: txResult };
+          return txResult;
         } else if (queryResult.result.entity_type === 'mempool_tx_id') {
           const txData = queryResult.result.entity_data as DbMempoolTx;
           const txResult: MempoolTxSearchResult = {
-            entity_id: queryResult.result.entity_id,
-            entity_type: SearchResultType.MempoolTxId,
-            tx_data: {
-              tx_type: getTxTypeString(txData.type_id),
+            found: true,
+            result: {
+              entity_id: queryResult.result.entity_id,
+              entity_type: SearchResultType.MempoolTxId,
+              tx_data: {
+                tx_type: getTxTypeString(txData.type_id),
+              },
             },
           };
-          return { found: true, result: txResult };
+          return txResult;
         } else {
           throw new Error(
             `Unexpected entity_type from db search result: ${queryResult.result.entity_type}`
           );
         }
       } else {
-        return {
+        const unknownResult: ErrorResult = {
           found: false,
-          result: { entity_type: SearchResultType.UnknownHash },
+          result: {
+            entity_type: SearchResultType.UnknownHash,
+          },
           error: `No block or transaction found with hash "${hash}"`,
         };
+        return unknownResult;
       }
     }
 
@@ -154,45 +125,57 @@ export function createSearchRouter(db: DataStore): RouterWithAsync {
           if ((principalResult.result.entity_data as DbTx).block_hash) {
             const txData = principalResult.result.entity_data as DbTx;
             const contractResult: ContractSearchResult = {
-              entity_id: principalResult.result.entity_id,
-              entity_type: entityType,
-              tx_data: {
-                canonical: txData.canonical,
-                block_hash: txData.block_hash,
-                burn_block_time: txData.burn_block_time,
-                block_height: txData.block_height,
-                tx_type: getTxTypeString(txData.type_id),
-                tx_id: txData.tx_id,
+              found: true,
+              result: {
+                entity_id: principalResult.result.entity_id,
+                entity_type: entityType,
+                tx_data: {
+                  canonical: txData.canonical,
+                  block_hash: txData.block_hash,
+                  burn_block_time: txData.burn_block_time,
+                  block_height: txData.block_height,
+                  tx_type: getTxTypeString(txData.type_id),
+                  tx_id: txData.tx_id,
+                },
               },
             };
-            return { found: true, result: contractResult };
+            return contractResult;
           } else {
             // Associated tx is a mempool tx
             const txData = principalResult.result.entity_data as DbMempoolTx;
             const contractResult: ContractSearchResult = {
-              entity_id: principalResult.result.entity_id,
-              entity_type: entityType,
-              tx_data: {
-                tx_type: getTxTypeString(txData.type_id),
-                tx_id: txData.tx_id,
+              found: true,
+              result: {
+                entity_id: principalResult.result.entity_id,
+                entity_type: entityType,
+                tx_data: {
+                  tx_type: getTxTypeString(txData.type_id),
+                  tx_id: txData.tx_id,
+                },
               },
             };
-            return { found: true, result: contractResult };
+            return contractResult;
           }
         } else if (entityType === SearchResultType.ContractAddress) {
           // Contract has no associated tx.
           // TODO: Can a non-materialized contract principal be an asset transfer recipient?
           const addrResult: ContractSearchResult = {
-            entity_id: principalResult.result.entity_id,
-            entity_type: entityType,
+            found: true,
+            result: {
+              entity_id: principalResult.result.entity_id,
+              entity_type: entityType,
+            },
           };
-          return { found: true, result: addrResult };
+          return addrResult;
         }
         const addrResult: AddressSearchResult = {
-          entity_id: principalResult.result.entity_id,
-          entity_type: entityType,
+          found: true,
+          result: {
+            entity_id: principalResult.result.entity_id,
+            entity_type: entityType,
+          },
         };
-        return { found: true, result: addrResult };
+        return addrResult;
       } else {
         return {
           found: false,

--- a/src/api/routes/search.ts
+++ b/src/api/routes/search.ts
@@ -9,9 +9,9 @@ import {
   BlockSearchResult,
   TxSearchResult,
   MempoolTxSearchResult,
-  ErrorResult,
   ContractSearchResult,
   AddressSearchResult,
+  SearchErrorResult,
 } from '@stacks/stacks-blockchain-api-types';
 import { getTxTypeString } from '../controllers/db-controller';
 import { address } from 'bitcoinjs-lib';
@@ -96,7 +96,7 @@ export function createSearchRouter(db: DataStore): RouterWithAsync {
           );
         }
       } else {
-        const unknownResult: ErrorResult = {
+        const unknownResult: SearchErrorResult = {
           found: false,
           result: {
             entity_type: SearchResultType.UnknownHash,


### PR DESCRIPTION
## Description

The types for Search were made locally and not documented properly. This PR adds types in the docs and uses them in search.ts.

Types for search can be imported as 
```
import {SearchResult} from '@stacks/stacks-blockchain-api-types';
```

For details refer to issue #645 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @kyranjamie or @zone117x for review
