### PR TITLE
Change sender and receiver operations to token_transfer

### DIFF
--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -326,7 +326,7 @@ function makeMintOperation(tx: DbStxEvent, baseTx: BaseTx, index: number): Roset
 function makeSenderOperation(tx: BaseTx, index: number): RosettaOperation {
   const sender: RosettaOperation = {
     operation_identifier: { index: index },
-    type: getTxTypeString(tx.type_id),
+    type: 'token_transfer', //Sender operation should always be token_transfer,
     status: getTxStatus(tx.status),
     account: {
       address: unwrapOptional(tx.sender_address, () => 'Unexpected nullish sender_address'),
@@ -351,7 +351,7 @@ function makeReceiverOperation(tx: BaseTx, index: number): RosettaOperation {
   const receiver: RosettaOperation = {
     operation_identifier: { index: index },
     related_operations: [{ index: index - 1 }],
-    type: getTxTypeString(tx.type_id),
+    type: 'token_transfer', //Receiver operation should always be token_transfer
     status: getTxStatus(tx.status),
     account: {
       address: unwrapOptional(


### PR DESCRIPTION
## Description
This PR changes the type of `sender` and `receiver` operations to  `token_transfer`, even if the STX transfer happens through `contract_call` the last two operations(`sender` & `receiver`) will be `token_transfer`.
closes #683 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
All the clients expecting `contract_call` of the last two operations of transfer through contract call should change the logic and expect `token_transfer` now. 

see details here #683. 


## Checklist
- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] @zone117x for review
