### PR TITLE
Return only latest name by address

### DIFF
--- a/src/api/routes/bns/addresses.ts
+++ b/src/api/routes/bns/addresses.ts
@@ -23,7 +23,7 @@ export function createBnsAddressesRouter(db: DataStore): RouterWithAsync {
     if (namesByAddress.found) {
       res.json({ names: namesByAddress.result });
     } else {
-      res.json([]);
+      res.json({ names: [] });
     }
   });
 

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -5647,7 +5647,7 @@ export class PgDataStore
 
       if (query.rowCount > 0) {
         const rows: { name: string; block_height: number }[] = [];
-        query.rows.forEach(async row => {
+        for (const row of query.rows) {
           const query_latest = await client.query<{ name: string }>(
             `
             SELECT name FROM (
@@ -5670,8 +5670,8 @@ export class PgDataStore
             [row.name, row.block_height]
           );
 
-          if (query_latest.rowCount === 0) rows.push(row); //if there is no names exit at greater height
-        });
+          if (query_latest.rowCount === 0) rows.push(row); //if there is no names exist at greater height
+        }
 
         query.rows = rows;
       }

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -5624,22 +5624,21 @@ export class PgDataStore
         `
         SELECT name FROM (
           (
-            SELECT DISTINCT ON (name) name, registered_at as block_height, tx_index
+            SELECT DISTINCT ON (name) name, registered_at as block_height, tx_index, address
             FROM names
-            WHERE address = $1
-            AND registered_at <= $2
+            WHERE registered_at <= $2
             AND canonical = true AND microblock_canonical = true
             ORDER BY name, registered_at DESC, tx_index DESC
           )
           UNION ALL (
-            SELECT DISTINCT ON (fully_qualified_subdomain) fully_qualified_subdomain as name, block_height, tx_index
+            SELECT DISTINCT ON (fully_qualified_subdomain) fully_qualified_subdomain as name, block_height, tx_index, owner as address
             FROM subdomains
-            WHERE owner = $1
-            AND block_height <= $2
+            WHERE block_height <= $2
             AND canonical = true AND microblock_canonical = true
             ORDER BY fully_qualified_subdomain, block_height DESC, tx_index DESC
           )
         ) results
+        WHERE address = $1
         ORDER BY block_height DESC, tx_index DESC
         `,
         [address, maxBlockHeight]

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -5646,7 +5646,8 @@ export class PgDataStore
       );
 
       if (query.rowCount > 0) {
-        query.rows = query.rows.filter(async row => {
+        const rows: { name: string; block_height: number }[] = [];
+        query.rows.forEach(async row => {
           const query_latest = await client.query<{ name: string }>(
             `
             SELECT name FROM (
@@ -5669,9 +5670,10 @@ export class PgDataStore
             [row.name, row.block_height]
           );
 
-          if (query_latest.rowCount > 0) return false;
-          return true;
+          if (query_latest.rowCount === 0) rows.push(row); //if there is no names exit at greater height
         });
+
+        query.rows = rows;
       }
       return query;
     });

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -5620,61 +5620,46 @@ export class PgDataStore
   }): Promise<FoundOrNot<string[]>> {
     const queryResult = await this.queryTx(async client => {
       const maxBlockHeight = await this.getMaxBlockHeight(client, { includeUnanchored });
-      const query = await client.query<{ name: string; block_height: number }>(
+      const query = await client.query<{ name: string }>(
         `
-        SELECT name, block_height FROM (
-          (
-            SELECT DISTINCT ON (name) name, registered_at as block_height, tx_index
-            FROM names
-            WHERE address = $1
-            AND registered_at <= $2
-            AND canonical = true AND microblock_canonical = true
-            ORDER BY name, registered_at DESC, tx_index DESC
-          )
-          UNION ALL (
-            SELECT DISTINCT ON (fully_qualified_subdomain) fully_qualified_subdomain as name, block_height, tx_index
-            FROM subdomains
-            WHERE owner = $1
-            AND block_height <= $2
-            AND canonical = true AND microblock_canonical = true
-            ORDER BY fully_qualified_subdomain, block_height DESC, tx_index DESC
-          )
-        ) results
-        ORDER BY block_height DESC, tx_index DESC
+      WITH address_names AS(
+        (
+          SELECT name
+          FROM names
+          WHERE address = $1
+          AND registered_at <= $2
+          AND canonical = true AND microblock_canonical = true
+        )
+        UNION ALL (
+          SELECT DISTINCT ON (fully_qualified_subdomain) fully_qualified_subdomain as name
+          FROM subdomains
+          WHERE owner = $1
+          AND block_height <= $2
+          AND canonical = true AND microblock_canonical = true
+        )), 
+
+      latest_names AS( 
+      ( 
+        SELECT DISTINCT ON (names.name) names.name, address, registered_at as block_height, tx_index
+        FROM names, address_names
+        WHERE address_names.name = names.name
+        AND canonical = true AND microblock_canonical = true
+        ORDER BY names.name, registered_at DESC, tx_index DESC
+      )
+      UNION ALL(
+        SELECT DISTINCT ON (fully_qualified_subdomain) fully_qualified_subdomain as name, owner as address, block_height, tx_index
+        FROM subdomains, address_names
+        WHERE fully_qualified_subdomain = address_names.name
+        AND canonical = true AND microblock_canonical = true
+        ORDER BY fully_qualified_subdomain, block_height DESC, tx_index DESC
+      ))
+
+      SELECT name from latest_names
+      WHERE address = $1
+      ORDER BY name, block_height DESC, tx_index DESC
         `,
         [address, maxBlockHeight]
       );
-
-      if (query.rowCount > 0) {
-        const rows: { name: string; block_height: number }[] = [];
-        for (const row of query.rows) {
-          const query_latest = await client.query<{ name: string }>(
-            `
-            SELECT name FROM (
-              (
-                SELECT name
-                FROM names
-                WHERE name = $1
-                AND registered_at > $2
-                AND canonical = true AND microblock_canonical = true
-              )
-              UNION ALL (
-                SELECT fully_qualified_subdomain as name
-                FROM subdomains
-                WHERE fully_qualified_subdomain = $1
-                AND block_height > $2
-                AND canonical = true AND microblock_canonical = true
-              )
-            ) results
-            `,
-            [row.name, row.block_height]
-          );
-
-          if (query_latest.rowCount === 0) rows.push(row); //if there is no names exist at greater height
-        }
-
-        query.rows = rows;
-      }
       return query;
     });
 

--- a/src/tests-bns/api.ts
+++ b/src/tests-bns/api.ts
@@ -249,6 +249,7 @@ describe('BNS API tests', () => {
       canonical: true,
       tx_id: '',
       tx_index: 0,
+      status: 'name_register'
     };
     await db.updateNames(client, {
       index_block_hash: dbBlock.index_block_hash,
@@ -266,7 +267,7 @@ describe('BNS API tests', () => {
     const subdomain: DbBnsSubdomain = {
       namespace_id: 'blockstack',
       name: 'id.blockstack',
-      fully_qualified_subdomain: 'address_test.id.blockstack',
+      fully_qualified_subdomain: 'zone_test.id.blockstack',
       resolver: 'https://registrar.blockstack.org',
       owner: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
       zonefile: 'test',
@@ -418,6 +419,66 @@ describe('BNS API tests', () => {
     expect(query2.type).toBe('application/json');
   });
 
+  test('Success names transfer', async () => {
+    const blockchain = 'stacks';
+    const address = 'ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKA';
+    const name = 'test-name1';
+
+    const dbName: DbBnsName = {
+      name: name,
+      address: address,
+      namespace_id: 'test',
+      expire_block: 10000,
+      zonefile: 'test-zone-file',
+      zonefile_hash: 'zonefileHash',
+      registered_at: 0,
+      canonical: true,
+      tx_id: '',
+      tx_index: 0,
+      status: 'name-register'
+    };
+    await db.updateNames(client, {
+      index_block_hash: dbBlock.index_block_hash,
+      parent_index_block_hash: dbBlock.parent_index_block_hash,
+      microblock_hash: '',
+      microblock_sequence: I32_MAX,
+      microblock_canonical: true,
+    }, dbName);
+
+    const query1 = await supertest(api.server).get(`/v1/addresses/${blockchain}/${address}`);
+    expect(query1.status).toBe(200);
+    expect(query1.body.names[0]).toBe(name);
+    expect(query1.type).toBe('application/json');
+
+    const address1 = 'ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKT';
+
+    const dbNameTransfer: DbBnsName = {
+      name: name,
+      address: address1,
+      namespace_id: 'test',
+      expire_block: 10000,
+      zonefile: 'test-zone-file',
+      zonefile_hash: 'zonefileHash',
+      registered_at: 1,
+      canonical: true,
+      tx_id: '',
+      tx_index: 0,
+      status: 'name-transfer'
+    };
+    await db.updateNames(client, {
+      index_block_hash: dbBlock.index_block_hash,
+      parent_index_block_hash: dbBlock.parent_index_block_hash,
+      microblock_hash: '',
+      microblock_sequence: I32_MAX,
+      microblock_canonical: true,
+    }, dbNameTransfer);
+
+    const query2 = await supertest(api.server).get(`/v1/addresses/${blockchain}/${address1}`);
+    expect(query2.status).toBe(200);
+    expect(query2.type).toBe('application/json');
+    expect(query2.body.names[0]).toBe(name);
+  });
+
   test('Fail names by address - Blockchain not support', async () => {
     const query1 = await supertest(api.server).get(`/v1/addresses/invalid/test`);
     expect(query1.status).toBe(404);
@@ -458,7 +519,7 @@ describe('BNS API tests', () => {
     const subdomain: DbBnsSubdomain = {
       namespace_id: 'blockstack',
       name: 'id.blockstack',
-      fully_qualified_subdomain: 'address_test.id.blockstack',
+      fully_qualified_subdomain: 'zonefile_test.id.blockstack',
       resolver: 'https://registrar.blockstack.org',
       owner: address,
       zonefile: 'test',

--- a/src/tests-bns/api.ts
+++ b/src/tests-bns/api.ts
@@ -477,6 +477,11 @@ describe('BNS API tests', () => {
     expect(query2.status).toBe(200);
     expect(query2.type).toBe('application/json');
     expect(query2.body.names[0]).toBe(name);
+
+    const query3 = await supertest(api.server).get(`/v1/addresses/${blockchain}/${address}`);
+    expect(query3.status).toBe(200);
+    expect(query3.type).toBe('application/json');
+    expect(query3.body.names.length).toBe(0);
   });
 
   test('Fail names by address - Blockchain not support', async () => {


### PR DESCRIPTION
## Description
This PR fixes the bug described in #714. The names transferred to the new address should only be returned under the new address. 

closes #714

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other


## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] @zone117x for review
