### PR TITLE
emit prometheus metrics for socket.io

### DIFF
--- a/src/api/routes/socket-io.ts
+++ b/src/api/routes/socket-io.ts
@@ -1,5 +1,6 @@
 import { Server as SocketIOServer, Socket } from 'socket.io';
 import * as http from 'http';
+import * as prom from 'prom-client';
 import { DataStore } from '../../datastore/common';
 import {
   AddressStxBalanceResponse,
@@ -14,24 +15,59 @@ import { parseDbBlock, parseDbMempoolTx, parseDbTx } from '../controllers/db-con
 import { logError, logger } from '../../helpers';
 
 export function createSocketIORouter(db: DataStore, server: http.Server) {
+  const metrics = {
+    subscriptions: new prom.Gauge({
+      name: 'socket_io_subscriptions',
+      help: 'Current subscriptions',
+      labelNames: ['topic'],
+    }),
+    connectTotal: new prom.Counter({
+      name: 'socket_io_connect_total',
+      help: 'Total count of socket.io connection requests',
+    }),
+    disconnectTotal: new prom.Counter({
+      name: 'socket_io_disconnect_total',
+      help: 'Total count of socket.io disconnections',
+    }),
+    eventsSent: new prom.Counter({
+      name: 'socket_io_events_sent',
+      help: 'Socket.io sent events',
+      labelNames: ['event'],
+    }),
+  };
   const io = new SocketIOServer<ClientToServerMessages, ServerToClientMessages>(server, {
     cors: { origin: '*' },
   });
 
   io.on('connection', socket => {
+    metrics.connectTotal.inc();
+    socket.on('disconnect', _ => {
+      metrics.disconnectTotal.inc();
+    });
     const subscriptions = socket.handshake.query['subscriptions'];
     if (subscriptions) {
       // TODO: check if init topics are valid, reject connection with error if not
       const topics = [...[subscriptions]].flat().flatMap(r => r.split(','));
-      topics.forEach(topic => socket.join(topic));
+      topics.forEach(topic => {
+        metrics.subscriptions.inc();
+        void socket.join(topic);
+      });
     }
     socket.on('subscribe', (topic, callback) => {
+      if (Array.isArray(topic)) {
+        topic.forEach(t => metrics.subscriptions.inc({ topic: t.toString() }));
+      } else {
+        metrics.subscriptions.inc({ topic: topic.toString() });
+      }
       void socket.join(topic);
       // TODO: check if topic is valid, and return error message if not
       callback?.(null);
     });
     socket.on('unsubscribe', (...topics) => {
-      topics.forEach(topic => void socket.leave(topic));
+      topics.forEach(topic => {
+        metrics.subscriptions.dec({ topic: topic.toString() });
+        void socket.leave(topic);
+      });
     });
   });
 
@@ -58,6 +94,7 @@ export function createSocketIORouter(db: DataStore, server: http.Server) {
     const blockTopic: Topic = 'block';
     if (adapter.rooms.has(blockTopic)) {
       const block = parseDbBlock(dbBlock, txIds, microblocksAccepted, microblocksStreamed);
+      metrics.eventsSent.inc({ event: 'block' });
       io.to(blockTopic).emit('block', block);
     }
   });
@@ -71,6 +108,7 @@ export function createSocketIORouter(db: DataStore, server: http.Server) {
         // do not send updates for dropped/pruned mempool txs
         if (!dbTx.pruned) {
           const tx = parseDbMempoolTx(dbTx);
+          metrics.eventsSent.inc({ event: 'mempool' });
           io.to(mempoolTopic).emit('mempool', tx);
         }
       }
@@ -108,6 +146,7 @@ export function createSocketIORouter(db: DataStore, server: http.Server) {
           stx_received: stxReceived.toString(),
           stx_transfers: stxTransfers,
         };
+        metrics.eventsSent.inc({ event: 'address-transaction' });
         io.to(addrTxTopic).emit('address-transaction', info.address, result);
         // TODO: force type until template literal index signatures are supported https://github.com/microsoft/TypeScript/pull/26797
         io.to(addrTxTopic).emit(
@@ -126,6 +165,7 @@ export function createSocketIORouter(db: DataStore, server: http.Server) {
       const latestBlock = Math.max(...blockHeights);
       void getAddressStxBalance(info.address, latestBlock)
         .then(balance => {
+          metrics.eventsSent.inc({ event: 'address-stx-balance' });
           io.to(addrStxBalanceTopic).emit('address-stx-balance', info.address, balance);
           // TODO: force type until template literal index signatures are supported https://github.com/microsoft/TypeScript/pull/26797
           io.to(addrStxBalanceTopic).emit(

--- a/src/api/routes/socket-io.ts
+++ b/src/api/routes/socket-io.ts
@@ -1,4 +1,4 @@
-import { Server as SocketIOServer, Socket } from 'socket.io';
+import { Server as SocketIOServer } from 'socket.io';
 import * as http from 'http';
 import * as prom from 'prom-client';
 import { DataStore } from '../../datastore/common';
@@ -12,60 +12,96 @@ import {
   ServerToClientMessages,
 } from '@stacks/stacks-blockchain-api-types';
 import { parseDbBlock, parseDbMempoolTx, parseDbTx } from '../controllers/db-controller';
-import { logError, logger } from '../../helpers';
+import { isProdEnv, logError, logger } from '../../helpers';
+
+interface SocketIOMetrics {
+  subscriptions: prom.Gauge<string>;
+  connectTotal: prom.Counter<string>;
+  disconnectTotal: prom.Counter<string>;
+  eventsSent: prom.Counter<string>;
+}
+
+class SocketIOPrometheus {
+  private metrics: SocketIOMetrics;
+
+  constructor() {
+    this.metrics = {
+      subscriptions: new prom.Gauge({
+        name: 'socket_io_subscriptions',
+        help: 'Current subscriptions',
+        labelNames: ['topic'],
+      }),
+      connectTotal: new prom.Counter({
+        name: 'socket_io_connect_total',
+        help: 'Total count of socket.io connection requests',
+      }),
+      disconnectTotal: new prom.Counter({
+        name: 'socket_io_disconnect_total',
+        help: 'Total count of socket.io disconnections',
+      }),
+      eventsSent: new prom.Counter({
+        name: 'socket_io_events_sent',
+        help: 'Socket.io sent events',
+        labelNames: ['event'],
+      }),
+    };
+  }
+
+  public connect() {
+    this.metrics.connectTotal.inc();
+  }
+
+  public disconnect() {
+    this.metrics.disconnectTotal.inc();
+  }
+
+  public subscribe(topic: Topic | Topic[] | string) {
+    if (Array.isArray(topic)) {
+      topic.forEach(t => this.metrics.subscriptions.inc({ topic: t.toString() }));
+    } else {
+      this.metrics.subscriptions.inc({ topic: topic.toString() });
+    }
+  }
+
+  public unsubscribe(topic: Topic | string) {
+    this.metrics.subscriptions.dec({ topic: topic.toString() });
+  }
+
+  public sendEvent(event: string) {
+    this.metrics.eventsSent.inc({ event: event });
+  }
+}
 
 export function createSocketIORouter(db: DataStore, server: http.Server) {
-  const metrics = {
-    subscriptions: new prom.Gauge({
-      name: 'socket_io_subscriptions',
-      help: 'Current subscriptions',
-      labelNames: ['topic'],
-    }),
-    connectTotal: new prom.Counter({
-      name: 'socket_io_connect_total',
-      help: 'Total count of socket.io connection requests',
-    }),
-    disconnectTotal: new prom.Counter({
-      name: 'socket_io_disconnect_total',
-      help: 'Total count of socket.io disconnections',
-    }),
-    eventsSent: new prom.Counter({
-      name: 'socket_io_events_sent',
-      help: 'Socket.io sent events',
-      labelNames: ['event'],
-    }),
-  };
   const io = new SocketIOServer<ClientToServerMessages, ServerToClientMessages>(server, {
     cors: { origin: '*' },
   });
+  let prometheus: SocketIOPrometheus | null;
+  if (isProdEnv) {
+    prometheus = new SocketIOPrometheus();
+  }
 
   io.on('connection', socket => {
-    metrics.connectTotal.inc();
-    socket.on('disconnect', _ => {
-      metrics.disconnectTotal.inc();
-    });
+    prometheus?.connect();
+    socket.on('disconnect', _ => prometheus?.disconnect());
     const subscriptions = socket.handshake.query['subscriptions'];
     if (subscriptions) {
       // TODO: check if init topics are valid, reject connection with error if not
       const topics = [...[subscriptions]].flat().flatMap(r => r.split(','));
       topics.forEach(topic => {
-        metrics.subscriptions.inc();
+        prometheus?.subscribe(topic);
         void socket.join(topic);
       });
     }
     socket.on('subscribe', (topic, callback) => {
-      if (Array.isArray(topic)) {
-        topic.forEach(t => metrics.subscriptions.inc({ topic: t.toString() }));
-      } else {
-        metrics.subscriptions.inc({ topic: topic.toString() });
-      }
+      prometheus?.subscribe(topic);
       void socket.join(topic);
       // TODO: check if topic is valid, and return error message if not
       callback?.(null);
     });
     socket.on('unsubscribe', (...topics) => {
       topics.forEach(topic => {
-        metrics.subscriptions.dec({ topic: topic.toString() });
+        prometheus?.unsubscribe(topic);
         void socket.leave(topic);
       });
     });
@@ -94,7 +130,7 @@ export function createSocketIORouter(db: DataStore, server: http.Server) {
     const blockTopic: Topic = 'block';
     if (adapter.rooms.has(blockTopic)) {
       const block = parseDbBlock(dbBlock, txIds, microblocksAccepted, microblocksStreamed);
-      metrics.eventsSent.inc({ event: 'block' });
+      prometheus?.sendEvent('block');
       io.to(blockTopic).emit('block', block);
     }
   });
@@ -108,7 +144,7 @@ export function createSocketIORouter(db: DataStore, server: http.Server) {
         // do not send updates for dropped/pruned mempool txs
         if (!dbTx.pruned) {
           const tx = parseDbMempoolTx(dbTx);
-          metrics.eventsSent.inc({ event: 'mempool' });
+          prometheus?.sendEvent('mempool');
           io.to(mempoolTopic).emit('mempool', tx);
         }
       }
@@ -146,7 +182,7 @@ export function createSocketIORouter(db: DataStore, server: http.Server) {
           stx_received: stxReceived.toString(),
           stx_transfers: stxTransfers,
         };
-        metrics.eventsSent.inc({ event: 'address-transaction' });
+        prometheus?.sendEvent('address-transaction');
         io.to(addrTxTopic).emit('address-transaction', info.address, result);
         // TODO: force type until template literal index signatures are supported https://github.com/microsoft/TypeScript/pull/26797
         io.to(addrTxTopic).emit(
@@ -165,7 +201,7 @@ export function createSocketIORouter(db: DataStore, server: http.Server) {
       const latestBlock = Math.max(...blockHeights);
       void getAddressStxBalance(info.address, latestBlock)
         .then(balance => {
-          metrics.eventsSent.inc({ event: 'address-stx-balance' });
+          prometheus?.sendEvent('address-stx-balance');
           io.to(addrStxBalanceTopic).emit('address-stx-balance', info.address, balance);
           // TODO: force type until template literal index signatures are supported https://github.com/microsoft/TypeScript/pull/26797
           io.to(addrStxBalanceTopic).emit(


### PR DESCRIPTION
## Description

This code adds metrics for socket.io activity in the API. It tracks connections, disconnections, topic subscriptions, and sent events.

Example metrics output:
```
# HELP socket_io_subscriptions Current subscriptions
# TYPE socket_io_subscriptions gauge
socket_io_subscriptions 1
socket_io_subscriptions{topic="mempool"} 1

# HELP socket_io_connect_total Total count of socket.io connection requests
# TYPE socket_io_connect_total counter
socket_io_connect_total 1

# HELP socket_io_disconnect_total Total count of socket.io disconnections
# TYPE socket_io_disconnect_total counter
socket_io_disconnect_total 1

# HELP socket_io_events_sent Socket.io sent events
# TYPE socket_io_events_sent counter
socket_io_events_sent{event="mempool"} 3
```

Closes #589 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
Testing was done locally via a Prometheus instance.

## Checklist
- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review
