### PR TITLE
Fix rosetta delegate stx parse error

### DIFF
--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -62,7 +62,7 @@ import { unwrapOptional, bufferToHexPrefixString, hexToBuffer } from './helpers'
 import { readTransaction, TransactionPayloadTypeID } from './p2p/tx';
 
 import { getCoreNodeEndpoint, StacksCoreRpcClient } from './core-rpc/client';
-import { TupleCV } from '@stacks/transactions/dist/transactions/src/clarity';
+import { serializeCV, TupleCV } from '@stacks/transactions';
 import { getBTCAddress, poxAddressToBtcAddress } from '@stacks/stacking';
 import { once } from 'node:events';
 
@@ -651,12 +651,8 @@ function parseDelegateStxArgs(contract: ContractCallTransaction): RosettaDelegat
   } else {
     const pox_address_cv = deserializeCV(hexToBuffer(pox_address_raw.hex));
     if (pox_address_cv.type === ClarityType.OptionalSome) {
-      const chainID = parseInt(process.env['STACKS_CHAIN_ID'] as string);
       if (pox_address_cv.value.type === ClarityType.Tuple)
-        args.pox_addr = poxAddressToBtcAddress(
-          pox_address_cv.value,
-          chainID == ChainID.Mainnet ? 'mainnet' : 'testnet'
-        );
+        args.pox_addr = bufferToHexPrefixString(serializeCV(pox_address_cv.value));
     }
   }
 

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -2714,6 +2714,7 @@ describe('Rosetta API', () => {
     const stacking_amount = '1250180000000000';//minimum stacking 
     const sender = deriveResult.body.account_identifier.address;
     const pox_addr = '2MtzNEqm2D9jcbPJ5mW7Z3AUNwqt3afZH66';
+    const clarityPoxAddr = '0x0c000000020968617368627974657302000000141320e6542e2146ea486700f4091aa793e73607880776657273696f6e020000000101';
     const size = 253;
     const max_fee = '12380898';
     const delegate_to = testnetKeys[2].stacksAddress;
@@ -3034,7 +3035,7 @@ describe('Rosetta API', () => {
         },
         metadata: {
           amount_ustx: stacking_amount,
-          pox_addr: pox_addr,
+          pox_addr: clarityPoxAddr,
           delegate_to: delegate_to,
         },
       },


### PR DESCRIPTION
Fixes https://github.com/blockstack/stacks-blockchain-api/issues/732


> I'm able to reproduce it on latest. It looks like many `delegate-stx` contract calls are providing a non-standard format for the `pox-addr`. In the case of this error, the tx is https://stacks-node-api.testnet.stacks.co/extended/v1/tx/0x41706da445ac744570a95548472add8485e8c4d59bfc105474dca2ef22d6a4e7
> 
> ```json
> {
> "hex": "0x0a0c0000000209686173686279746573020000001433bca9edc296f59e1a933e32af18ee1891a2045d0776657273696f6e0200000001c4",
> "repr": "(some (tuple (hashbytes 0x33bca9edc296f59e1a933e32af18ee1891a2045d) (version 0xc4)))",
> "name": "pox-addr",
> "type": "(optional (tuple (hashbytes (buff 20)) (version (buff 1))))"
> }
> ```
> 
> The value `0xc4` (196) is causing `poxAddressToBtcAddress` to throw at
> 
> https://github.com/blockstack/stacks-blockchain-api/blob/1914333f669e4ff8d4497e715cb703ca17d14fae/src/rosetta-helpers.ts#L643
> 
> The value `196` is bitcoin testnet P2SH address version byte rather than a Stacks address hash mode byte.
> 
> AFAIK the encoding for this specific `delegate-stx` arg is somewhat free-form, as the pool operator can choose how to interpret this address data. So I think in this case it probably makes sense to make leave the `pox_addr` field in delegate STX as the original hex encoded clarity value.

