### PR TITLE
support post verb in /extended/v1/status

### DIFF
--- a/src/api/routes/status.ts
+++ b/src/api/routes/status.ts
@@ -8,7 +8,7 @@ import { logger } from '../../helpers';
 export function createStatusRouter(_: DataStore): RouterWithAsync {
   const router = addAsync(express.Router());
 
-  router.get('/', (_, res) => {
+  const statusHandler = (_: Request, res: any) => {
     try {
       const [branch, commit, tag] = fs.readFileSync('.git-info', 'utf-8').split('\n');
       const response: ServerStatusResponse = {
@@ -23,7 +23,9 @@ export function createStatusRouter(_: DataStore): RouterWithAsync {
       };
       res.json(response);
     }
-  });
+  };
+  router.get('/', statusHandler);
+  router.post('/', statusHandler);
 
   return router;
 }


### PR DESCRIPTION
## Description

Support POST in status endpoint since the Desktop Wallet uses that verb to check API status.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
No

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review
