### PR TITLE
feat(rosetta): support memos in stx token transfer operations

### DIFF
--- a/docs/entities/rosetta/rosetta-construction-options.schema.json
+++ b/docs/entities/rosetta/rosetta-construction-options.schema.json
@@ -60,6 +60,10 @@
       "type": "integer",
       "description": "Transaction approximative size (used to calculate total fee)."
     },
+    "memo": {
+      "type": "string",
+      "description": "STX token transfer memo."
+    },
     "number_of_cycles": {
       "type": "integer",
       "description": "Number of cycles when stacking."

--- a/docs/entities/rosetta/rosetta-transaction.schema.json
+++ b/docs/entities/rosetta/rosetta-transaction.schema.json
@@ -18,8 +18,12 @@
     "metadata": {
       "type": "object",
       "description": "Transactions that are related to other transactions (like a cross-shard transaction) should include the tranaction_identifier of these transactions in the metadata.",
-      "required": ["size", "lockTime"],
+      "required": [],
       "properties": {
+        "memo": {
+          "type": "string",
+          "description": "STX token transfer memo."
+        },
         "size": {
           "type": "integer",
           "description": "The Size"

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -2026,13 +2026,17 @@ export interface RosettaTransaction {
    */
   metadata?: {
     /**
+     * STX token transfer memo.
+     */
+    memo?: string;
+    /**
      * The Size
      */
-    size: number;
+    size?: number;
     /**
      * The locktime
      */
-    lockTime: number;
+    lockTime?: number;
     [k: string]: unknown | undefined;
   };
   [k: string]: unknown | undefined;
@@ -2338,6 +2342,10 @@ export interface RosettaOptions {
    * Transaction approximative size (used to calculate total fee).
    */
   size?: number;
+  /**
+   * STX token transfer memo.
+   */
+  memo?: string;
   /**
    * Number of cycles when stacking.
    */

--- a/src/api/routes/rosetta/construction.ts
+++ b/src/api/routes/rosetta/construction.ts
@@ -22,6 +22,7 @@ import {
   RosettaCurrency,
   RosettaTransaction,
   RosettaError,
+  RosettaConstructionParseResponse,
 } from '@stacks/stacks-blockchain-api-types';
 import {
   createMessageSignature,
@@ -72,6 +73,7 @@ import {
   getStacksNetwork,
   makePresignHash,
   verifySignature,
+  parseTransactionMemo,
 } from './../../../rosetta-helpers';
 import { makeRosettaError, rosettaValidateRequest, ValidSchema } from './../../rosetta-validate';
 
@@ -191,6 +193,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           network: getStacksNetwork(),
           // We don't know the non yet but need a placeholder
           nonce: new BN(0),
+          memo: req.body.metadata?.memo,
         };
 
         transaction = await makeUnsignedSTXTokenTransfer(dummyTokenTransferTx);
@@ -289,6 +292,10 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
     const unsignedTransaction = transaction.serialize();
 
     options.size = unsignedTransaction.length;
+
+    if (req.body.metadata?.memo) {
+      options.memo = req.body.metadata?.memo;
+    }
 
     const rosettaPreprocessResponse: RosettaConstructionPreprocessResponse = {
       options,
@@ -489,8 +496,10 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       return;
     }
     try {
-      const operations = await getOperations(rawTxToBaseTx(inputTx), db);
-      let response;
+      const baseTx = rawTxToBaseTx(inputTx);
+      const operations = await getOperations(baseTx, db);
+      const txMemo = parseTransactionMemo(baseTx);
+      let response: RosettaConstructionParseResponse;
       if (signed) {
         response = {
           operations: operations,
@@ -499,6 +508,11 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
       } else {
         response = {
           operations: operations,
+        };
+      }
+      if (txMemo) {
+        response.metadata = {
+          memo: txMemo,
         };
       }
       res.json(response);
@@ -620,6 +634,7 @@ export function createRosettaConstructionRouter(db: DataStore, chainId: ChainID)
           publicKey: publicKeys[0].hex_bytes,
           network: getStacksNetwork(),
           nonce: nonce,
+          memo: req.body.metadata?.memo,
         };
 
         transaction = await makeUnsignedSTXTokenTransfer(tokenTransferOptions);

--- a/src/api/routes/rosetta/mempool.ts
+++ b/src/api/routes/rosetta/mempool.ts
@@ -9,7 +9,7 @@ import {
   RosettaMempoolTransactionResponse,
   RosettaTransaction,
 } from '@stacks/stacks-blockchain-api-types';
-import { getOperations } from '../../../rosetta-helpers';
+import { getOperations, parseTransactionMemo } from '../../../rosetta-helpers';
 import { RosettaErrors, RosettaErrorsTypes } from '../../rosetta-constants';
 import { ChainID } from '@stacks/transactions';
 
@@ -64,10 +64,16 @@ export function createRosettaMempoolRouter(db: DataStore, chainId: ChainID): Rou
     }
 
     const operations = await getOperations(mempoolTxQuery.result, db);
+    const txMemo = parseTransactionMemo(mempoolTxQuery.result);
     const transaction: RosettaTransaction = {
       transaction_identifier: { hash: tx_id },
       operations: operations,
     };
+    if (txMemo) {
+      transaction.metadata = {
+        memo: txMemo,
+      };
+    }
     const result: RosettaMempoolTransactionResponse = {
       transaction: transaction,
     };

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -391,6 +391,9 @@ describe('Rosetta API', () => {
       transaction_identifier: {
         hash: txDb.result.tx_id,
       },
+      metadata: {
+        memo: 'test1234',
+      },
       operations: [
         {
           operation_identifier: { index: 0 },
@@ -854,7 +857,9 @@ describe('Rosetta API', () => {
           },
         },
       ],
-      metadata: {},
+      metadata: {
+        memo: 'SAMPLE MEMO',
+      },
       max_fee: [
         {
           value: '12380898',
@@ -885,6 +890,7 @@ describe('Rosetta API', () => {
         symbol: 'STX',
         decimals: 6,
         max_fee: '12380898',
+        memo: 'SAMPLE MEMO',
         size: 180,
       },
       required_public_keys: [
@@ -985,6 +991,7 @@ describe('Rosetta API', () => {
         decimals: 6,
         max_fee: '12380898',
         size: 180,
+        memo: 'SAMPLE MEMO',
       },
     };
 
@@ -997,6 +1004,7 @@ describe('Rosetta API', () => {
     expect(JSON.parse(result.text)).toHaveProperty('metadata');
     expect(JSON.parse(result.text)).toHaveProperty('suggested_fee');
     expect(JSON.parse(result.text).suggested_fee[0].value).toBe('180');
+    expect(JSON.parse(result.text).metadata.memo).toBe('SAMPLE MEMO');
   });
 
   test('construction/metadata - empty network identifier', async () => {
@@ -1435,6 +1443,7 @@ describe('Rosetta API', () => {
       ],
       metadata: {
         account_sequence: 0,
+        memo: 'SAMPLE MEMO',
       },
       public_keys: [
         {
@@ -1451,6 +1460,7 @@ describe('Rosetta API', () => {
       publicKey: publicKey,
       network: getStacksNetwork(),
       nonce: new BN(0),
+      memo: 'SAMPLE MEMO',
     };
 
     const transaction = await makeUnsignedSTXTokenTransfer(tokenTransferOptions);


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/752

Implement memo support for rosetta STX token transfers. 
Uses the proposed schema from https://github.com/blockstack/stacks-blockchain-api/issues/752