### PR TITLE
fix: increase the 10 second cap on prometheus http metric reporting

### DIFF
--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -90,8 +90,16 @@ export async function startApiServer(opts: {
   }[] = [];
 
   if (isProdEnv) {
+    // The default from
+    // https://github.com/tdeekens/promster/blob/696803abf03a9a657d4af46d312fa9fb70a75320/packages/metrics/src/create-metric-types/create-metric-types.ts#L16
+    const defaultPromHttpRequestDurationInSeconds = [0.05, 0.1, 0.3, 0.5, 0.8, 1, 1.5, 2, 3, 10];
+
+    // Add a few more buckets to account for requests that take longer than 10 seconds
+    defaultPromHttpRequestDurationInSeconds.push(25, 50, 100, 250, 500);
+
     const promMiddleware = createPrometheusMiddleware({
       options: {
+        buckets: defaultPromHttpRequestDurationInSeconds as [number],
         normalizePath: path => {
           // Get the url pathname without a query string or fragment
           // (note base url doesn't matter, but required by URL constructor)


### PR DESCRIPTION
Related to https://github.com/hirosystems/devops/issues/795

Add buckets larger than 10 seconds to the prometheus http duration histogram configuration as defined here: https://github.com/tdeekens/promster/#-documentation


thx @wileyj for identifying this default config