### PR TITLE
fix: disable http keep-alive for stacks-node /v2 proxied endpoints

### DIFF
--- a/src/api/routes/core-node-rpc-proxy.ts
+++ b/src/api/routes/core-node-rpc-proxy.ts
@@ -25,9 +25,13 @@ export function createCoreNodeRpcProxyRouter(): express.Router {
 
   logger.info(`/v2/* proxying to: ${stacksNodeRpcEndpoint}`);
 
+  // Note: while keep-alive may result in some performance improvements with the stacks-node http server,
+  // it can also cause request distribution issues when proxying to a pool of stacks-nodes. See:
+  // https://github.com/blockstack/stacks-blockchain-api/issues/756
   const httpAgent = new Agent({
-    keepAlive: true,
-    keepAliveMsecs: 60000,
+    // keepAlive: true,
+    keepAlive: false, // `false` is the default -- set it explicitly for readability anyway.
+    // keepAliveMsecs: 60000,
     maxSockets: 200,
     maxTotalSockets: 400,
   });


### PR DESCRIPTION
(Hopefully) closes https://github.com/blockstack/stacks-blockchain-api/issues/756

Disables the http keep-alive header in the /v2 proxy to the Stacks core node. This should prevent individual API instances from sticking to specific stacks-node instances. 