### PR TITLE
Execution cost for in block response

### DIFF
--- a/docs/entities/blocks/block.schema.json
+++ b/docs/entities/blocks/block.schema.json
@@ -18,7 +18,11 @@
     "parent_microblock_sequence",
     "microblocks_accepted",
     "microblocks_streamed",
-    "total_execution_cost"
+    "execution_cost_read_count",
+    "execution_cost_read_length",
+    "execution_cost_runtime",
+    "execution_cost_write_count",
+    "execution_cost_write_length"
   ],
   "properties": {
     "canonical": {
@@ -89,9 +93,25 @@
         "description": "Microblock hash"
       }
     },
-    "total_execution_cost": {
+    "execution_cost_read_count": {
       "type": "integer",
-      "description": "Sum of the execution costs for each tx included in the block"
+      "description": "Execution cost read count."
+    },
+    "execution_cost_read_length": {
+      "type": "integer",
+      "description": "Execution cost read length."
+    },
+    "execution_cost_runtime": {
+      "type": "integer",
+      "description": "Execution cost runtime."
+    },
+    "execution_cost_write_count": {
+      "type": "integer",
+      "description": "Execution cost write count."
+    },
+    "execution_cost_write_length": {
+      "type": "integer",
+      "description": "Execution cost write length."
     }
   }
 }

--- a/docs/entities/blocks/block.schema.json
+++ b/docs/entities/blocks/block.schema.json
@@ -3,7 +3,23 @@
   "title": "Block",
   "description": "A block",
   "type": "object",
-  "required": ["canonical", "height", "hash", "parent_block_hash", "txs", "burn_block_time", "burn_block_time_iso", "burn_block_hash", "burn_block_height", "miner_txid", "parent_microblock_hash", "parent_microblock_sequence", "microblocks_accepted", "microblocks_streamed"],
+  "required": [
+    "canonical",
+    "height",
+    "hash",
+    "parent_block_hash",
+    "txs",
+    "burn_block_time",
+    "burn_block_time_iso",
+    "burn_block_hash",
+    "burn_block_height",
+    "miner_txid",
+    "parent_microblock_hash",
+    "parent_microblock_sequence",
+    "microblocks_accepted",
+    "microblocks_streamed",
+    "total_execution_cost"
+  ],
   "properties": {
     "canonical": {
       "type": "boolean",
@@ -72,6 +88,10 @@
         "type": "string",
         "description": "Microblock hash"
       }
+    },
+    "total_execution_cost": {
+      "type": "integer",
+      "description": "Sum of the execution costs for each tx included in the block"
     }
   }
 }

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -1215,9 +1215,25 @@ export interface Block {
    */
   microblocks_streamed: string[];
   /**
-   * Sum of the execution costs for each tx included in the block
+   * Execution cost read count.
    */
-  total_execution_cost: number;
+  execution_cost_read_count: number;
+  /**
+   * Execution cost read length.
+   */
+  execution_cost_read_length: number;
+  /**
+   * Execution cost runtime.
+   */
+  execution_cost_runtime: number;
+  /**
+   * Execution cost write count.
+   */
+  execution_cost_write_count: number;
+  /**
+   * Execution cost write length.
+   */
+  execution_cost_write_length: number;
   [k: string]: unknown | undefined;
 }
 /**

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -1214,6 +1214,10 @@ export interface Block {
    * List of microblocks that were streamed/produced by this anchor block's miner. This list only includes microblocks that were accepted in the following anchor block. Microblocks that were orphaned are not included in this list.
    */
   microblocks_streamed: string[];
+  /**
+   * Sum of the execution costs for each tx included in the block
+   */
+  total_execution_cost: number;
   [k: string]: unknown | undefined;
 }
 /**

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -466,7 +466,11 @@ export function parseDbBlock(
     txs: [...txIds],
     microblocks_accepted: [...microblocksAccepted],
     microblocks_streamed: [...microblocksStreamed],
-    total_execution_cost: dbBlock.total_execution_cost,
+    execution_cost_read_count: dbBlock.execution_cost_read_count,
+    execution_cost_read_length: dbBlock.execution_cost_read_length,
+    execution_cost_runtime: dbBlock.execution_cost_runtime,
+    execution_cost_write_count: dbBlock.execution_cost_write_count,
+    execution_cost_write_length: dbBlock.execution_cost_write_length,
   };
   return apiBlock;
 }

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -466,6 +466,7 @@ export function parseDbBlock(
     txs: [...txIds],
     microblocks_accepted: [...microblocksAccepted],
     microblocks_streamed: [...microblocksStreamed],
+    total_execution_cost: dbBlock.total_execution_cost,
   };
   return apiBlock;
 }

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -33,6 +33,7 @@ export interface DbBlock {
   block_height: number;
   /** Set to `true` if entry corresponds to the canonical chain tip */
   canonical: boolean;
+  total_execution_cost: number; // sum of the execution costs for each tx included in the block
 }
 
 /** An interface representing the microblock data that can be constructed _only_ from the /new_microblocks payload */

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -33,7 +33,12 @@ export interface DbBlock {
   block_height: number;
   /** Set to `true` if entry corresponds to the canonical chain tip */
   canonical: boolean;
-  total_execution_cost: number; // sum of the execution costs for each tx included in the block
+  /**  Sum of the execution costs for each tx included in the block */
+  execution_cost_read_count: number;
+  execution_cost_read_length: number;
+  execution_cost_runtime: number;
+  execution_cost_write_count: number;
+  execution_cost_write_length: number;
 }
 
 /** An interface representing the microblock data that can be constructed _only_ from the /new_microblocks payload */

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -293,7 +293,7 @@ const MEMPOOL_TX_ID_COLUMNS = `
 const BLOCK_COLUMNS = `
   block_hash, index_block_hash,
   parent_index_block_hash, parent_block_hash, parent_microblock_hash, parent_microblock_sequence,
-  block_height, burn_block_time, burn_block_hash, burn_block_height, miner_txid, canonical
+  block_height, burn_block_time, burn_block_hash, burn_block_height, miner_txid, canonical, total_execution_cost
 `;
 
 const MICROBLOCK_COLUMNS = `
@@ -316,6 +316,7 @@ interface BlockQueryResult {
   burn_block_height: number;
   miner_txid: Buffer;
   canonical: boolean;
+  total_execution_cost: string;
 }
 
 interface MicroblockQueryResult {
@@ -2277,8 +2278,8 @@ export class PgDataStore
       INSERT INTO blocks(
         block_hash, index_block_hash,
         parent_index_block_hash, parent_block_hash, parent_microblock_hash, parent_microblock_sequence,
-        block_height, burn_block_time, burn_block_hash, burn_block_height, miner_txid, canonical
-      ) values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        block_height, burn_block_time, burn_block_hash, burn_block_height, miner_txid, canonical, total_execution_cost
+      ) values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
       ON CONFLICT (index_block_hash)
       DO NOTHING
       `,
@@ -2295,6 +2296,7 @@ export class PgDataStore
         block.burn_block_height,
         hexToBuffer(block.miner_txid),
         block.canonical,
+        block.total_execution_cost,
       ]
     );
     return result.rowCount;
@@ -2315,6 +2317,7 @@ export class PgDataStore
       burn_block_height: row.burn_block_height,
       miner_txid: bufferToHexPrefixString(row.miner_txid),
       canonical: row.canonical,
+      total_execution_cost: Number.parseInt(row.total_execution_cost),
     };
     return block;
   }

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -293,7 +293,9 @@ const MEMPOOL_TX_ID_COLUMNS = `
 const BLOCK_COLUMNS = `
   block_hash, index_block_hash,
   parent_index_block_hash, parent_block_hash, parent_microblock_hash, parent_microblock_sequence,
-  block_height, burn_block_time, burn_block_hash, burn_block_height, miner_txid, canonical, total_execution_cost
+  block_height, burn_block_time, burn_block_hash, burn_block_height, miner_txid, canonical,
+  execution_cost_read_count, execution_cost_read_length, execution_cost_runtime,
+  execution_cost_write_count, execution_cost_write_length
 `;
 
 const MICROBLOCK_COLUMNS = `
@@ -316,7 +318,11 @@ interface BlockQueryResult {
   burn_block_height: number;
   miner_txid: Buffer;
   canonical: boolean;
-  total_execution_cost: string;
+  execution_cost_read_count: string;
+  execution_cost_read_length: string;
+  execution_cost_runtime: string;
+  execution_cost_write_count: string;
+  execution_cost_write_length: string;
 }
 
 interface MicroblockQueryResult {
@@ -972,6 +978,44 @@ export class PgDataStore
           logger.debug(`Removed ${removedTxsResult.removedTxs.length} txs from mempool table`);
         }
       }
+
+      //calculate total execution cost of the block
+      const totalCost = data.txs.reduce(
+        (previousValue, currentValue) => {
+          const {
+            execution_cost_read_count,
+            execution_cost_read_length,
+            execution_cost_runtime,
+            execution_cost_write_count,
+            execution_cost_write_length,
+          } = previousValue;
+
+          return {
+            execution_cost_read_count:
+              execution_cost_read_count + currentValue.tx.execution_cost_read_count,
+            execution_cost_read_length:
+              execution_cost_read_length + currentValue.tx.execution_cost_read_length,
+            execution_cost_runtime: execution_cost_runtime + currentValue.tx.execution_cost_runtime,
+            execution_cost_write_count:
+              execution_cost_write_count + currentValue.tx.execution_cost_write_count,
+            execution_cost_write_length:
+              execution_cost_write_length + currentValue.tx.execution_cost_write_length,
+          };
+        },
+        {
+          execution_cost_read_count: 0,
+          execution_cost_read_length: 0,
+          execution_cost_runtime: 0,
+          execution_cost_write_count: 0,
+          execution_cost_write_length: 0,
+        }
+      );
+
+      data.block.execution_cost_read_count = totalCost.execution_cost_read_count;
+      data.block.execution_cost_read_length = totalCost.execution_cost_read_length;
+      data.block.execution_cost_runtime = totalCost.execution_cost_runtime;
+      data.block.execution_cost_write_count = totalCost.execution_cost_write_count;
+      data.block.execution_cost_write_length = totalCost.execution_cost_write_length;
 
       // Find microblocks that weren't already inserted via the unconfirmed microblock event.
       // This happens when a stacks-node is syncing and receives confirmed microblocks with their anchor block at the same time.
@@ -2278,8 +2322,10 @@ export class PgDataStore
       INSERT INTO blocks(
         block_hash, index_block_hash,
         parent_index_block_hash, parent_block_hash, parent_microblock_hash, parent_microblock_sequence,
-        block_height, burn_block_time, burn_block_hash, burn_block_height, miner_txid, canonical, total_execution_cost
-      ) values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+        block_height, burn_block_time, burn_block_hash, burn_block_height, miner_txid, canonical,
+        execution_cost_read_count, execution_cost_read_length, execution_cost_runtime,
+        execution_cost_write_count, execution_cost_write_length
+      ) values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
       ON CONFLICT (index_block_hash)
       DO NOTHING
       `,
@@ -2296,7 +2342,11 @@ export class PgDataStore
         block.burn_block_height,
         hexToBuffer(block.miner_txid),
         block.canonical,
-        block.total_execution_cost,
+        block.execution_cost_read_count,
+        block.execution_cost_read_length,
+        block.execution_cost_runtime,
+        block.execution_cost_write_count,
+        block.execution_cost_write_length,
       ]
     );
     return result.rowCount;
@@ -2317,7 +2367,11 @@ export class PgDataStore
       burn_block_height: row.burn_block_height,
       miner_txid: bufferToHexPrefixString(row.miner_txid),
       canonical: row.canonical,
-      total_execution_cost: Number.parseInt(row.total_execution_cost),
+      execution_cost_read_count: Number.parseInt(row.execution_cost_read_count),
+      execution_cost_read_length: Number.parseInt(row.execution_cost_read_length),
+      execution_cost_runtime: Number.parseInt(row.execution_cost_runtime),
+      execution_cost_write_count: Number.parseInt(row.execution_cost_write_count),
+      execution_cost_write_length: Number.parseInt(row.execution_cost_write_length),
     };
     return block;
   }

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -236,17 +236,6 @@ async function handleBlockMessage(
     }
   });
 
-  const totalCost: number = msg.transactions.reduce((previousValue, currentValue) => {
-    return (
-      previousValue +
-      currentValue.execution_cost.read_count +
-      currentValue.execution_cost.read_length +
-      currentValue.execution_cost.runtime +
-      currentValue.execution_cost.write_count +
-      currentValue.execution_cost.write_length
-    );
-  }, 0);
-
   const dbBlock: DbBlock = {
     canonical: true,
     block_hash: msg.block_hash,
@@ -260,7 +249,11 @@ async function handleBlockMessage(
     burn_block_hash: msg.burn_block_hash,
     burn_block_height: msg.burn_block_height,
     miner_txid: msg.miner_txid,
-    total_execution_cost: totalCost,
+    execution_cost_read_count: 0,
+    execution_cost_read_length: 0,
+    execution_cost_runtime: 0,
+    execution_cost_write_count: 0,
+    execution_cost_write_length: 0,
   };
 
   logger.verbose(`Received block ${msg.block_hash} (${msg.block_height}) from node`, dbBlock);

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -236,6 +236,17 @@ async function handleBlockMessage(
     }
   });
 
+  const totalCost: number = msg.transactions.reduce((previousValue, currentValue) => {
+    return (
+      previousValue +
+      currentValue.execution_cost.read_count +
+      currentValue.execution_cost.read_length +
+      currentValue.execution_cost.runtime +
+      currentValue.execution_cost.write_count +
+      currentValue.execution_cost.write_length
+    );
+  }, 0);
+
   const dbBlock: DbBlock = {
     canonical: true,
     block_hash: msg.block_hash,
@@ -249,6 +260,7 @@ async function handleBlockMessage(
     burn_block_hash: msg.burn_block_hash,
     burn_block_height: msg.burn_block_height,
     miner_txid: msg.miner_txid,
+    total_execution_cost: totalCost,
   };
 
   logger.verbose(`Received block ${msg.block_hash} (${msg.block_height}) from node`, dbBlock);

--- a/src/migrations/1584604583726_blocks.ts
+++ b/src/migrations/1584604583726_blocks.ts
@@ -52,6 +52,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       type: 'boolean',
       notNull: true,
     },
+    total_execution_cost: {
+      type: 'bigint',
+      notNull: true,
+    },
   });
   pgm.createIndex('blocks', 'block_height');
   pgm.createIndex('blocks', 'block_hash');

--- a/src/migrations/1584604583726_blocks.ts
+++ b/src/migrations/1584604583726_blocks.ts
@@ -52,7 +52,23 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       type: 'boolean',
       notNull: true,
     },
-    total_execution_cost: {
+    execution_cost_read_count: {
+      type: 'bigint',
+      notNull: true,
+    },
+    execution_cost_read_length: {
+      type: 'bigint',
+      notNull: true,
+    },
+    execution_cost_runtime: {
+      type: 'bigint',
+      notNull: true,
+    },
+    execution_cost_write_count: {
+      type: 'bigint',
+      notNull: true,
+    },
+    execution_cost_write_length: {
       type: 'bigint',
       notNull: true,
     },

--- a/src/tests-bns/api.ts
+++ b/src/tests-bns/api.ts
@@ -26,6 +26,7 @@ describe('BNS API tests', () => {
     burn_block_height: 123,
     miner_txid: '0x4321',
     canonical: true,
+    total_execution_cost: 0,
   };
 
   beforeAll(async () => {

--- a/src/tests-bns/api.ts
+++ b/src/tests-bns/api.ts
@@ -26,7 +26,11 @@ describe('BNS API tests', () => {
     burn_block_height: 123,
     miner_txid: '0x4321',
     canonical: true,
-    total_execution_cost: 0,
+    execution_cost_read_count: 0, 
+    execution_cost_read_length: 0, 
+    execution_cost_runtime: 0, 
+    execution_cost_write_count: 0, 
+    execution_cost_write_length: 0, 
   };
 
   beforeAll(async () => {

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -100,7 +100,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const tx: DbTx = {
       tx_id: '0x1234',
@@ -750,7 +754,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const mempoolTx: DbMempoolTx = {
@@ -1010,7 +1018,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: false,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const dbTx1: DbTx = {
       ...mempoolTx1,
@@ -1566,7 +1578,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, block);
     const tx: DbTx = {
@@ -2193,7 +2209,11 @@ describe('api tests', () => {
       burn_block_height: 100123123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, block);
 
@@ -2782,7 +2802,11 @@ describe('api tests', () => {
       burn_block_height: 100123123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, block);
 
@@ -3374,7 +3398,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const tx1: DbTx = {
       tx_id: '0x421234',
@@ -3514,7 +3542,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, block);
     const tx: DbTx = {
@@ -3576,7 +3608,11 @@ describe('api tests', () => {
       txs: ['0x1234'],
       microblocks_accepted: [],
       microblocks_streamed: [],
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
 
     expect(blockQuery.result).toEqual(expectedResp);
@@ -3664,7 +3700,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const txBuilder = await makeContractCall({
@@ -3816,7 +3856,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -4024,7 +4068,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const txBuilder = await makeContractDeploy({
@@ -4143,7 +4191,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const txBuilder = await makeContractDeploy({
@@ -4262,7 +4314,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const tx: DbTx = {
       tx_id: '0x421234',
@@ -4372,7 +4428,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, block);
     const tx: DbTx = {
@@ -4445,7 +4505,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -4621,7 +4685,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, block);
     const tx: DbTx = {
@@ -4749,7 +4817,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const senderAddress = 'SP25YGP221F01S9SSCGN114MKDAK9VRK8P3KXGEMB';
@@ -4817,7 +4889,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const senderAddress = 'SP25YGP221F01S9SSCGN114MKDAK9VRK8P3KXGEMB';
@@ -4889,7 +4965,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, block);
     const tx: DbTx = {
@@ -4948,7 +5028,11 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, block);
     const tx: DbTx = {
@@ -5029,6 +5113,125 @@ describe('api tests', () => {
     expect(result.status).toBe(200);
     expect(result.type).toBe('application/json');
     expect(result.body.fee_rate).toBe(FEE_RATE);
+  });
+
+  test('Block execution cost', async () => {
+    const dbBlock: DbBlock = {
+      block_hash: '0x0123',
+      index_block_hash: '0x1234',
+      parent_index_block_hash: '0x00',
+      parent_block_hash: '0x5678',
+      parent_microblock_hash: '',
+      parent_microblock_sequence: 0,
+      block_height: 1,
+      burn_block_time: 39486,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
+      canonical: false,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
+    };
+    const dbTx1: DbTx = {
+      ...dbBlock,
+      tx_id: '0x8912000000000000000000000000000000000000000000000000000000000000',
+      anchor_mode: 3,
+      nonce: 0,
+      raw_tx: Buffer.from('test-raw-tx'),
+      type_id: DbTxTypeId.Coinbase,
+      coinbase_payload: Buffer.from('coinbase hi'),
+      post_conditions: Buffer.from([0x01, 0xf5]),
+      fee_rate: 1234n,
+      sponsored: true,
+      sender_address: 'sender-addr',
+      sponsor_address: 'sponsor-addr',
+      origin_hash_mode: 1,
+      parent_burn_block_time: 1626122935,
+      tx_index: 4,
+      status: DbTxStatus.Success,
+      raw_result: '0x0100000000000000000000000000000001', // u1
+      canonical: true,
+      microblock_canonical: true,
+      microblock_sequence: I32_MAX,
+      microblock_hash: '',
+      parent_index_block_hash: '',
+      event_count: 0,
+      execution_cost_read_count: 1,
+      execution_cost_read_length: 2,
+      execution_cost_runtime: 2,
+      execution_cost_write_count: 1,
+      execution_cost_write_length: 1,
+    };
+    const dbTx2: DbTx = {
+      ...dbBlock,
+      tx_id: '0x8912000000000000000000000000000000000000000000000000000000000001',
+      anchor_mode: 3,
+      nonce: 0,
+      raw_tx: Buffer.from('test-raw-tx'),
+      type_id: DbTxTypeId.Coinbase,
+      coinbase_payload: Buffer.from('coinbase hi'),
+      post_conditions: Buffer.from([0x01, 0xf5]),
+      fee_rate: 1234n,
+      sponsored: true,
+      sender_address: 'sender-addr',
+      sponsor_address: 'sponsor-addr',
+      origin_hash_mode: 1,
+      parent_burn_block_time: 1626122935,
+      tx_index: 4,
+      status: DbTxStatus.Success,
+      raw_result: '0x0100000000000000000000000000000001', // u1
+      canonical: true,
+      microblock_canonical: true,
+      microblock_sequence: I32_MAX,
+      microblock_hash: '',
+      parent_index_block_hash: '',
+      event_count: 0,
+      execution_cost_read_count: 2,
+      execution_cost_read_length: 2,
+      execution_cost_runtime: 2,
+      execution_cost_write_count: 2,
+      execution_cost_write_length: 2,
+    };
+    const dataStoreUpdate: DataStoreBlockUpdateData = {
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: dbTx1,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          smartContracts: [],
+          names: [],
+          namespaces: [],
+        },
+        {
+          tx: dbTx2,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          smartContracts: [],
+          names: [],
+          namespaces: [],
+        },
+      ],
+    };
+    await db.update(dataStoreUpdate);
+
+    const blockQuery = await supertest(api.server).get(`/extended/v1/block/${dbBlock.block_hash}`);
+    expect(blockQuery.body.execution_cost_read_count).toBe(3);
+    expect(blockQuery.body.execution_cost_read_length).toBe(4);
+    expect(blockQuery.body.execution_cost_runtime).toBe(4);
+    expect(blockQuery.body.execution_cost_write_count).toBe(3);
+    expect(blockQuery.body.execution_cost_write_length).toBe(3);
   });
 
   afterEach(async () => {

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -100,6 +100,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     const tx: DbTx = {
       tx_id: '0x1234',
@@ -749,6 +750,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const mempoolTx: DbMempoolTx = {
@@ -1008,6 +1010,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: false,
+      total_execution_cost: 0,
     };
     const dbTx1: DbTx = {
       ...mempoolTx1,
@@ -1563,6 +1566,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, block);
     const tx: DbTx = {
@@ -2189,6 +2193,7 @@ describe('api tests', () => {
       burn_block_height: 100123123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, block);
 
@@ -2777,6 +2782,7 @@ describe('api tests', () => {
       burn_block_height: 100123123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, block);
 
@@ -3368,6 +3374,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     const tx1: DbTx = {
       tx_id: '0x421234',
@@ -3507,6 +3514,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, block);
     const tx: DbTx = {
@@ -3568,6 +3576,7 @@ describe('api tests', () => {
       txs: ['0x1234'],
       microblocks_accepted: [],
       microblocks_streamed: [],
+      total_execution_cost: 0,
     };
 
     expect(blockQuery.result).toEqual(expectedResp);
@@ -3655,6 +3664,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const txBuilder = await makeContractCall({
@@ -3806,6 +3816,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -4013,6 +4024,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const txBuilder = await makeContractDeploy({
@@ -4131,6 +4143,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const txBuilder = await makeContractDeploy({
@@ -4249,6 +4262,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     const tx: DbTx = {
       tx_id: '0x421234',
@@ -4358,6 +4372,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, block);
     const tx: DbTx = {
@@ -4430,6 +4445,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -4605,6 +4621,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, block);
     const tx: DbTx = {
@@ -4732,6 +4749,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const senderAddress = 'SP25YGP221F01S9SSCGN114MKDAK9VRK8P3KXGEMB';
@@ -4799,6 +4817,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const senderAddress = 'SP25YGP221F01S9SSCGN114MKDAK9VRK8P3KXGEMB';
@@ -4870,6 +4889,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, block);
     const tx: DbTx = {
@@ -4928,6 +4948,7 @@ describe('api tests', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, block);
     const tx: DbTx = {

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -55,7 +55,11 @@ describe('in-memory datastore', () => {
       miner_txid: '0x4321',
       canonical: false,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(block);
     const blockQuery = await db.getBlock({ hash: block.block_hash });
@@ -199,7 +203,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -407,7 +415,11 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -550,7 +562,11 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -697,7 +713,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, block);
     const blockQuery = await db.getBlock({ hash: block.block_hash });
@@ -758,7 +778,11 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     let indexIdIndex = 0;
@@ -976,7 +1000,11 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx1: DbTx = {
@@ -1892,7 +1920,11 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -1949,7 +1981,11 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -2011,7 +2047,11 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -2072,7 +2112,11 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -2134,7 +2178,11 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -2195,7 +2243,11 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -2255,7 +2307,11 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -2320,7 +2376,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const tx1: DbTx = {
       tx_id: '0x421234',
@@ -2677,7 +2737,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const block2: DbBlock = {
       block_hash: '0x22',
@@ -2692,7 +2756,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const block3: DbBlock = {
       block_hash: '0x33',
@@ -2707,7 +2775,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const block3B: DbBlock = {
       ...block3,
@@ -2728,7 +2800,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const block4: DbBlock = {
       block_hash: '0x44',
@@ -2743,7 +2819,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const block5: DbBlock = {
       block_hash: '0x55',
@@ -2758,7 +2838,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const block6: DbBlock = {
       block_hash: '0x66',
@@ -2773,7 +2857,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
 
     const tx1Mempool: DbMempoolTx = {
@@ -2956,7 +3044,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: false,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const block2: DbBlock = {
       block_hash: '0x22',
@@ -2971,7 +3063,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: false,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const block3: DbBlock = {
       block_hash: '0x33',
@@ -2986,7 +3082,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: false,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const block3B: DbBlock = {
       ...block3,
@@ -3007,7 +3107,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: false,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
 
     const minerReward1: DbMinerReward = {
@@ -3133,7 +3237,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
 
     const reorgResult = await db.handleReorg(client, block5, 0);
@@ -3194,7 +3302,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const block2: DbBlock = {
       block_hash: '0x22',
@@ -3209,7 +3321,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const block3: DbBlock = {
       block_hash: '0x33',
@@ -3224,7 +3340,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
 
     const minerReward1: DbMinerReward = {
@@ -3388,7 +3508,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const tx3: DbTx = {
       tx_id: '0x03',
@@ -3540,7 +3664,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.update({ block: block3b, microblocks: [], minerRewards: [], txs: [] });
     const blockQuery2 = await db.getBlock({ hash: block3b.block_hash });
@@ -3561,7 +3689,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.update({ block: block4b, microblocks: [], minerRewards: [], txs: [] });
     const blockQuery3 = await db.getBlock({ hash: block3b.block_hash });
@@ -3629,7 +3761,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const tx1: DbTx = {
       tx_id: '0x421234',
@@ -3704,7 +3840,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const tx1: DbTx = {
       tx_id: '0x421234',
@@ -3778,7 +3918,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     const tx1: DbTx = {
       tx_id: '0x421234',
@@ -3920,7 +4064,11 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -3971,7 +4119,11 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -4022,7 +4174,11 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -4075,7 +4231,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, block);
     const blockQuery = await db.getBlock({ hash: block.block_hash });
@@ -4172,7 +4332,11 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
     await db.updateBlock(client, block);
     const blockQuery = await db.getBlock({ hash: block.block_hash });

--- a/src/tests/datastore-tests.ts
+++ b/src/tests/datastore-tests.ts
@@ -55,6 +55,7 @@ describe('in-memory datastore', () => {
       miner_txid: '0x4321',
       canonical: false,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     await db.updateBlock(block);
     const blockQuery = await db.getBlock({ hash: block.block_hash });
@@ -198,6 +199,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -405,6 +407,7 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -547,6 +550,7 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -679,7 +683,7 @@ describe('postgres datastore', () => {
     expect([...addrDResult]).toEqual([]);
   });
 
-  test('pg block store and retrieve', async () => {
+  test.only('pg block store and retrieve', async () => {
     const block: DbBlock = {
       block_hash: '0x1234',
       index_block_hash: '0xdeadbeef',
@@ -693,6 +697,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, block);
     const blockQuery = await db.getBlock({ hash: block.block_hash });
@@ -753,6 +758,7 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     let indexIdIndex = 0;
@@ -970,6 +976,7 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx1: DbTx = {
@@ -1885,6 +1892,7 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -1941,6 +1949,7 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -2002,6 +2011,7 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -2062,6 +2072,7 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -2123,6 +2134,7 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -2183,6 +2195,7 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
     const tx: DbTx = {
@@ -2242,6 +2255,7 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -2306,6 +2320,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const tx1: DbTx = {
       tx_id: '0x421234',
@@ -2662,6 +2677,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const block2: DbBlock = {
       block_hash: '0x22',
@@ -2676,6 +2692,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const block3: DbBlock = {
       block_hash: '0x33',
@@ -2690,6 +2707,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const block3B: DbBlock = {
       ...block3,
@@ -2710,6 +2728,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const block4: DbBlock = {
       block_hash: '0x44',
@@ -2724,6 +2743,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const block5: DbBlock = {
       block_hash: '0x55',
@@ -2738,6 +2758,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const block6: DbBlock = {
       block_hash: '0x66',
@@ -2752,6 +2773,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
 
     const tx1Mempool: DbMempoolTx = {
@@ -2934,6 +2956,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: false,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const block2: DbBlock = {
       block_hash: '0x22',
@@ -2948,6 +2971,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: false,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const block3: DbBlock = {
       block_hash: '0x33',
@@ -2962,6 +2986,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: false,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const block3B: DbBlock = {
       ...block3,
@@ -2982,6 +3007,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: false,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
 
     const minerReward1: DbMinerReward = {
@@ -3107,6 +3133,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
 
     const reorgResult = await db.handleReorg(client, block5, 0);
@@ -3167,6 +3194,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const block2: DbBlock = {
       block_hash: '0x22',
@@ -3181,6 +3209,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const block3: DbBlock = {
       block_hash: '0x33',
@@ -3195,6 +3224,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
 
     const minerReward1: DbMinerReward = {
@@ -3358,6 +3388,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const tx3: DbTx = {
       tx_id: '0x03',
@@ -3509,6 +3540,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     await db.update({ block: block3b, microblocks: [], minerRewards: [], txs: [] });
     const blockQuery2 = await db.getBlock({ hash: block3b.block_hash });
@@ -3529,6 +3561,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     await db.update({ block: block4b, microblocks: [], minerRewards: [], txs: [] });
     const blockQuery3 = await db.getBlock({ hash: block3b.block_hash });
@@ -3596,6 +3629,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const tx1: DbTx = {
       tx_id: '0x421234',
@@ -3670,6 +3704,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const tx1: DbTx = {
       tx_id: '0x421234',
@@ -3743,6 +3778,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     const tx1: DbTx = {
       tx_id: '0x421234',
@@ -3884,6 +3920,7 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -3934,6 +3971,7 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -3984,6 +4022,7 @@ describe('postgres datastore', () => {
       burn_block_height: 123,
       miner_txid: '0x4321',
       canonical: true,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, dbBlock);
 
@@ -4036,6 +4075,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, block);
     const blockQuery = await db.getBlock({ hash: block.block_hash });
@@ -4132,6 +4172,7 @@ describe('postgres datastore', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
     await db.updateBlock(client, block);
     const blockQuery = await db.getBlock({ hash: block.block_hash });

--- a/src/tests/microblocks-tests.ts
+++ b/src/tests/microblocks-tests.ts
@@ -205,7 +205,11 @@ describe('microblock tests', () => {
           miner_txid: '0x4321',
           canonical: true,
           parent_microblock_sequence: 0,
-          total_execution_cost: 0,
+          execution_cost_read_count: 0,
+          execution_cost_read_length: 0,
+          execution_cost_runtime: 0,
+          execution_cost_write_count: 0,
+          execution_cost_write_length: 0,
         };
 
         const tx1: DbTx = {

--- a/src/tests/microblocks-tests.ts
+++ b/src/tests/microblocks-tests.ts
@@ -205,6 +205,7 @@ describe('microblock tests', () => {
           miner_txid: '0x4321',
           canonical: true,
           parent_microblock_sequence: 0,
+          total_execution_cost: 0,
         };
 
         const tx1: DbTx = {

--- a/src/tests/websocket-tests.ts
+++ b/src/tests/websocket-tests.ts
@@ -63,6 +63,7 @@ describe('websocket notifications', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
 
     const tx: DbTx = {
@@ -220,6 +221,7 @@ describe('websocket notifications', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
 
     const tx: DbTx = {
@@ -366,6 +368,7 @@ describe('websocket notifications', () => {
       miner_txid: '0x004321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
 
     const tx: DbTx = {
@@ -499,6 +502,7 @@ describe('websocket notifications', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
 
     const tx: DbTx = {
@@ -610,6 +614,7 @@ describe('websocket notifications', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
+      total_execution_cost: 0,
     };
 
     const tx: DbTx = {

--- a/src/tests/websocket-tests.ts
+++ b/src/tests/websocket-tests.ts
@@ -63,7 +63,11 @@ describe('websocket notifications', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
 
     const tx: DbTx = {
@@ -221,7 +225,11 @@ describe('websocket notifications', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
 
     const tx: DbTx = {
@@ -368,7 +376,11 @@ describe('websocket notifications', () => {
       miner_txid: '0x004321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
 
     const tx: DbTx = {
@@ -502,7 +514,11 @@ describe('websocket notifications', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
 
     const tx: DbTx = {
@@ -614,7 +630,11 @@ describe('websocket notifications', () => {
       miner_txid: '0x4321',
       canonical: true,
       parent_microblock_sequence: 0,
-      total_execution_cost: 0,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
     };
 
     const tx: DbTx = {


### PR DESCRIPTION
## Description
Added the execution cost(sum of the execution costs for each tx included in the block) in `blocks` and block response. 

closes #735 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
NO

## Are documentation updates required?
Schema changes should be enough

## Testing information
Unit tests coverage updated

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag @zone117x for review
