### PR TITLE
Fix conflicting transaction hash for rosetta issue

### DIFF
--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -5860,9 +5860,10 @@ export class PgDataStore
       tx_id: Buffer;
     }>(
       `
-      SELECT locked_amount, unlock_height, block_height, tx_id, locked_address
-      FROM stx_lock_events
-      WHERE canonical = true AND unlock_height <= $1 AND unlock_height > $2
+      SELECT locked_amount, unlock_height, sle.block_height, locked_address, txs.tx_id
+      FROM stx_lock_events sle inner JOIN txs ON (sle.unlock_height = txs.block_height)
+      WHERE sle.canonical = true AND sle.microblock_canonical = true
+      AND unlock_height <= $1 AND unlock_height > $2
       `,
       [current_burn_height, previous_burn_height]
     );

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -5861,11 +5861,11 @@ export class PgDataStore
     }>(
       `
       SELECT locked_amount, unlock_height, sle.block_height, locked_address, txs.tx_id
-      FROM stx_lock_events sle inner JOIN txs ON (sle.unlock_height = txs.block_height)
-      WHERE sle.canonical = true AND sle.microblock_canonical = true
+      FROM stx_lock_events sle INNER JOIN txs ON ($3 = txs.block_height)
+      WHERE txs.type_id = $4 AND sle.canonical = true AND sle.microblock_canonical = true
       AND unlock_height <= $1 AND unlock_height > $2
       `,
-      [current_burn_height, previous_burn_height]
+      [current_burn_height, previous_burn_height, block.block_height, DbTxTypeId.Coinbase]
     );
 
     const result: StxUnlockEvent[] = [];

--- a/src/rosetta-helpers.ts
+++ b/src/rosetta-helpers.ts
@@ -110,7 +110,8 @@ export async function getOperations(
   tx: DbTx | DbMempoolTx | BaseTx,
   db: DataStore,
   minerRewards?: DbMinerReward[],
-  events?: DbEvent[]
+  events?: DbEvent[],
+  stxUnlockEvents?: StxUnlockEvent[]
 ): Promise<RosettaOperation[]> {
   const operations: RosettaOperation[] = [];
   const txType = getTxTypeString(tx.type_id);
@@ -132,6 +133,9 @@ export async function getOperations(
       operations.push(makeCoinbaseOperation(tx, 0));
       if (minerRewards !== undefined) {
         getMinerOperations(minerRewards, operations);
+      }
+      if (stxUnlockEvents && stxUnlockEvents?.length > 0) {
+        processUnlockingEvents(stxUnlockEvents, operations);
       }
       break;
     case 'poison_microblock':

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -2679,15 +2679,6 @@ describe('Rosetta API', () => {
       await timeout(100);
     }
 
-    stxUnlockHeight = stxUnlockHeight+1;
-    //wait for atleast one more burn block
-    while(current_burn_block_height < stxUnlockHeight){
-      const currentBlock = await db.getCurrentBlock();
-      assert(currentBlock.found);
-      current_burn_block_height =  currentBlock.result?.burn_block_height;
-      await timeout(100);
-    }
-
     const query1 = await supertest(api.address)
       .post(`/rosetta/v1/block`)
       .send({
@@ -2695,7 +2686,6 @@ describe('Rosetta API', () => {
         block_identifier: { hash: block.result.block_hash },
       });
 
-      console.log('there you go4');
     expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
     expect(JSON.stringify(query1.body)).toMatch(/"stx_unlock"/)

--- a/src/tests-rosetta/api.ts
+++ b/src/tests-rosetta/api.ts
@@ -74,7 +74,6 @@ import { makeSigHashPreSign, MessageSignature } from '@stacks/transactions';
 import { decodeBtcAddress } from '@stacks/stacking';
 
 
-
 describe('Rosetta API', () => {
   let db: PgDataStore;
   let client: PoolClient;
@@ -2688,7 +2687,10 @@ describe('Rosetta API', () => {
 
     expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
-    expect(JSON.stringify(query1.body)).toMatch(/"stx_unlock"/)
+    expect(query1.body.block.transactions[0].operations[0].type).toBe('coinbase');
+    expect(query1.body.block.transactions[1].operations[0].type).toBe('stx_unlock');
+    //check if transaction hash is from the coinbase transaction
+    expect(query1.body.block.transactions[1].hash).toBe(query1.body.block.transactions[0].hash);
   })
 
   test('delegate-stacking rosetta transaction cycle', async() => {


### PR DESCRIPTION
## Description
This pr fixes the conflicting hash problem. The `stx_lock` transaction hash was conflicting with `stx_unlock` transactions. Now,  `stx_unlock` uses `coinbase` transaction hash.  

closes #760 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other


## Testing information
Updated integration test to check this scenerio

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] @zone117x for review
