### PR TITLE
feat: ability to configure multiple tx broadcast endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -29,9 +29,9 @@ STACKS_CORE_RPC_PORT=20443
 # STACKS_CORE_PROXY_HOST=127.0.0.1
 # STACKS_CORE_PROXY_PORT=20443
 
-# Configure additional stacks-node `POST /v2/tranascation` URLs for the /v2 proxy to mutlicast.
-# Can be a single URL or a comma-separated list of URLs.
-# STACKS_EXTRA_TX_POST_ENDPOINTS=http://another-node-a/v2/transactions,http://another-node-b/v2/transactions
+# Configure a path to a file containing additional stacks-node `POST /v2/tranascation` URLs for the /v2 proxy to mutlicast.
+# The file should be a newline-delimited list of URLs.
+# STACKS_API_EXTRA_TX_ENDPOINTS_FILE=./config/extra-tx-post-endpoints.txt
 
 # STACKS_FAUCET_NODE_HOST=<IP or hostname>
 # STACKS_FAUCET_NODE_PORT=<port number>

--- a/.env
+++ b/.env
@@ -29,6 +29,10 @@ STACKS_CORE_RPC_PORT=20443
 # STACKS_CORE_PROXY_HOST=127.0.0.1
 # STACKS_CORE_PROXY_PORT=20443
 
+# Configure additional stacks-node `POST /v2/tranascation` URLs for the /v2 proxy to mutlicast.
+# Can be a single URL or a comma-separated list of URLs.
+# STACKS_EXTRA_TX_POST_ENDPOINTS=http://another-node-a/v2/transactions,http://another-node-b/v2/transactions
+
 # STACKS_FAUCET_NODE_HOST=<IP or hostname>
 # STACKS_FAUCET_NODE_PORT=<port number>
 

--- a/config/extra-tx-post-endpoints.txt
+++ b/config/extra-tx-post-endpoints.txt
@@ -1,0 +1,4 @@
+http://another-node-a/v2/transactions
+http://another-node-b/v2/transactions
+# http://another-node-c/v2/transactions
+# http://another-node-d/v2/transactions

--- a/src/api/routes/core-node-rpc-proxy.ts
+++ b/src/api/routes/core-node-rpc-proxy.ts
@@ -1,12 +1,13 @@
 import * as express from 'express';
 import * as cors from 'cors';
 import { createProxyMiddleware, Options } from 'http-proxy-middleware';
-import { logger, parsePort } from '../../helpers';
+import { logError, logger, parsePort, pipelineAsync } from '../../helpers';
 import { Agent } from 'http';
 import * as fs from 'fs';
 import { addAsync } from '@awaitjs/express';
 import * as chokidar from 'chokidar';
 import * as jsoncParser from 'jsonc-parser';
+import fetch, { RequestInit } from 'node-fetch';
 
 export function GetStacksNodeProxyEndpoint() {
   // Use STACKS_CORE_PROXY env vars if available, otherwise fallback to `STACKS_CORE_RPC
@@ -78,6 +79,118 @@ export function createCoreNodeRpcProxyRouter(): express.Router {
     }
     return null;
   };
+
+  /**
+   * Check for any extra endpoints that have been configured for performing a "multicast" for a tx submission.
+   */
+  function getExtraTxPostEndpoints(): string[] | false {
+    const STACKS_EXTRA_TX_POST_ENDPOINTS_ENV_VAR = 'STACKS_EXTRA_TX_POST_ENDPOINTS';
+    const extraEndpoints = process.env[STACKS_EXTRA_TX_POST_ENDPOINTS_ENV_VAR];
+    if (!extraEndpoints) {
+      return false;
+    }
+    const endpointsArray = extraEndpoints.split(',').map(r => r.trim());
+    return endpointsArray;
+  }
+
+  /**
+   * Reads an http request stream into a Buffer.
+   */
+  async function readRequestBody(req: express.Request, maxSizeBytes = Infinity): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      let resultBuffer: Buffer = Buffer.alloc(0);
+      req.on('data', chunk => {
+        if (!Buffer.isBuffer(chunk)) {
+          reject(
+            new Error(
+              `Expected request body chunks to be Buffer, received ${chunk.constructor.name}`
+            )
+          );
+          req.destroy();
+          return;
+        }
+        resultBuffer = resultBuffer.length === 0 ? chunk : Buffer.concat([resultBuffer, chunk]);
+        if (resultBuffer.byteLength >= maxSizeBytes) {
+          reject(new Error(`Request body exceeded max byte size`));
+          req.destroy();
+          return;
+        }
+      });
+      req.on('end', () => {
+        if (!req.complete) {
+          return reject(
+            new Error('The connection was terminated while the message was still being sent')
+          );
+        }
+        resolve(resultBuffer);
+      });
+      req.on('error', error => reject(error));
+    });
+  }
+
+  router.postAsync('/transactions', async (req, res, next) => {
+    const extraEndpoints = getExtraTxPostEndpoints();
+    if (!extraEndpoints) {
+      next();
+      return;
+    }
+    const endpoints = [
+      // The primary proxy endpoint (the http response from this one will be returned to the client)
+      `http://${stacksNodeRpcEndpoint}/v2/transactions`,
+    ];
+    endpoints.push(...extraEndpoints);
+    logger.info(`Overriding POST /v2/transactions to multicast to ${endpoints.join(',')}}`);
+    const maxBodySize = 10_000_000; // 10 MB max POST body size
+    const reqBody = await readRequestBody(req, maxBodySize);
+    const reqHeaders: string[][] = [];
+    for (let i = 0; i < req.rawHeaders.length; i += 2) {
+      reqHeaders.push([req.rawHeaders[i], req.rawHeaders[i + 1]]);
+    }
+    const postFn = async (endpoint: string) => {
+      const reqOpts: RequestInit = {
+        method: 'POST',
+        agent: httpAgent,
+        body: reqBody,
+        headers: reqHeaders,
+      };
+      const proxyResult = await fetch(endpoint, reqOpts);
+      return proxyResult;
+    };
+
+    // Here's were we "multicast" the `/v2/transaction` POST, by concurrently sending the http request to all configured endpoints.
+    const results = await Promise.allSettled(endpoints.map(endpoint => postFn(endpoint)));
+
+    // Log any errors from requests to the extra endpoints, because only the first (non-extra) endpoint http response
+    // is proxied back through to the client.
+    results.slice(1).forEach(p => {
+      if (p.status === 'rejected') {
+        logError(`Error during POST /v2/transaction to extra endpoint: ${p.reason}`, p.reason);
+      } else {
+        if (!p.value.ok) {
+          logError(
+            `Response ${p.value.status} during POST /v2/transaction to extra endpoint ${p.value.url}`
+          );
+        }
+      }
+    });
+
+    // Proxy the result of the (non-extra) http response back to the client.
+    const mainResult = results[0];
+    if (mainResult.status === 'rejected') {
+      logError(
+        `Error in primary POST /v2/transaction proxy: ${mainResult.reason}`,
+        mainResult.reason
+      );
+      res.status(500).json({ error: mainResult.reason });
+    } else {
+      const proxyResp = mainResult.value;
+      res.status(proxyResp.status);
+      proxyResp.headers.forEach((value, name) => {
+        res.setHeader(name, value);
+      });
+      await pipelineAsync(proxyResp.body, res);
+    }
+  });
 
   const proxyOptions: Options = {
     agent: httpAgent,

--- a/src/api/routes/core-node-rpc-proxy.ts
+++ b/src/api/routes/core-node-rpc-proxy.ts
@@ -175,8 +175,8 @@ export function createCoreNodeRpcProxyRouter(): express.Router {
     // Here's were we "multicast" the `/v2/transaction` POST, by concurrently sending the http request to all configured endpoints.
     const results = await Promise.allSettled(endpoints.map(endpoint => postFn(endpoint)));
 
-    // Log any errors from requests to the extra endpoints, because only the first (non-extra) endpoint http response
-    // is proxied back through to the client.
+    // Only the first (non-extra) endpoint http response is proxied back through to the client, so ensure any errors from requests
+    // to the extra endpoints are logged.
     results.slice(1).forEach(p => {
       if (p.status === 'rejected') {
         logError(`Error during POST /v2/transaction to extra endpoint: ${p.reason}`, p.reason);

--- a/src/tests/test-helpers.ts
+++ b/src/tests/test-helpers.ts
@@ -37,3 +37,32 @@ export async function useWithCleanup<T extends [...Disposable<any>[]]>(
     }
   }
 }
+
+export type TestEnvVar = [EnvVarKey: string, EnvVarValue: string];
+
+/**
+ * Helper function for tests.
+ * Sets local process environment variables, and returns a function that restores them to the original values.
+ */
+export function withEnvVars(...envVars: TestEnvVar[]) {
+  const original: { exists: boolean; key: string; value: string | undefined }[] = [];
+  envVars.forEach(([k, v]) => {
+    original.push({
+      exists: k in process.env,
+      key: k,
+      value: v,
+    });
+  });
+  envVars.forEach(([k, v]) => {
+    process.env[k] = v;
+  });
+  return () => {
+    original.forEach(orig => {
+      if (!orig.exists) {
+        delete process.env[orig.key];
+      } else {
+        process.env[orig.key] = orig.value;
+      }
+    });
+  };
+}

--- a/src/tests/v2-proxy-tests.ts
+++ b/src/tests/v2-proxy-tests.ts
@@ -1,0 +1,85 @@
+import * as supertest from 'supertest';
+import { ChainID } from '@stacks/transactions';
+import { startApiServer } from '../api/init';
+import { PgDataStore, cycleMigrations, runMigrations } from '../datastore/postgres-store';
+import { PoolClient } from 'pg';
+import { useWithCleanup, withEnvVars } from './test-helpers';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as nock from 'nock';
+
+describe('v2-proxy tests', () => {
+  let db: PgDataStore;
+  let client: PoolClient;
+
+  beforeEach(async () => {
+    process.env.PG_DATABASE = 'postgres';
+    await cycleMigrations();
+    db = await PgDataStore.connect();
+    client = await db.pool.connect();
+  });
+
+  test('tx post multicast', async () => {
+    const primaryProxyEndpoint = 'proxy-stacks-node:12345';
+    const extraTxEndpoint = 'http://extra-tx-endpoint-a/test';
+    await useWithCleanup(
+      () => {
+        const restoreEnvVars = withEnvVars(
+          ['STACKS_CORE_PROXY_HOST', primaryProxyEndpoint.split(':')[0]],
+          ['STACKS_CORE_PROXY_PORT', primaryProxyEndpoint.split(':')[1]]
+        );
+        return [, () => restoreEnvVars()] as const;
+      },
+      () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stacks-api-unit-test-'));
+        const extraEndpointsFilePath = path.join(tempDir, 'extra-tx-endpoints.txt');
+        fs.writeFileSync(extraEndpointsFilePath, extraTxEndpoint, { flag: 'w' });
+        const restoreEnvVars = withEnvVars([
+          'STACKS_API_EXTRA_TX_ENDPOINTS_FILE',
+          extraEndpointsFilePath,
+        ]);
+        return [, () => restoreEnvVars()] as const;
+      },
+      async () => {
+        const apiServer = await startApiServer({
+          datastore: db,
+          chainId: ChainID.Mainnet,
+          httpLogLevel: 'debug',
+        });
+        return [apiServer, apiServer.terminate] as const;
+      },
+      async (_, __, api) => {
+        const primaryStubbedResponse = 'success stubbed response';
+        const extraStubbedResponse = 'extra success stubbed response';
+        const testRequest = 'fake-tx-data';
+        let mockedRequestBody = 'none';
+        nock(`http://${primaryProxyEndpoint}`)
+          .post('/v2/transactions', testRequest)
+          .once()
+          .reply(200, primaryStubbedResponse);
+        nock(extraTxEndpoint)
+          .post(() => true, testRequest)
+          .once()
+          .reply(200, (_url, body, cb) => {
+            // the "extra" endpoint responses are logged internally and not sent back to the client, so use this mock callback to
+            // test that this endpoint was called correctly
+            mockedRequestBody = body as string;
+            cb(null, extraStubbedResponse);
+          });
+        const postTxReq = await supertest(api.server).post(`/v2/transactions`).send(testRequest);
+        // test that main endpoint response was returned
+        expect(postTxReq.status).toBe(200);
+        expect(postTxReq.text).toBe(primaryStubbedResponse);
+        // test that the extra endpoint was queried
+        expect(mockedRequestBody).toBe(testRequest);
+      }
+    );
+  });
+
+  afterEach(async () => {
+    client.release();
+    await db?.close();
+    await runMigrations(undefined, 'down');
+  });
+});


### PR DESCRIPTION
Closes https://github.com/blockstack/stacks-blockchain-api/issues/765

Implements tx "multicast" ability where tx broadcasts to `POST /v2/transactions` can be forwarded to multiple configured stacks-nodes at once. 

A new environment variable `STACKS_API_EXTRA_TX_ENDPOINTS_FILE` is implemented which can be pointed at a file containing newline-delimitated URLs. When an http POST request is made to `/v2/transactions` it will be concurrently broadcasted to both the original proxied endpoint (e.g. `STACKS_CORE_PROXY_HOST`) and to each of the URLs defined in the file. The response from the original endpoint will proxied back to the client, and any response errors from the others will be logged. 


### Example config
Env var:
```
STACKS_API_EXTRA_TX_ENDPOINTS_FILE=/config/extra-tx-post-endpoints.txt
```
Contents of `extra-tx-post-endpoints.txt`:
```
http://another-node-a/v2/transactions
http://another-node-b/v2/transactions
http://another-node-c/v2/transactions
http://another-node-d/v2/transactions
```

Deployment note: the file is automatically refreshed and can be updated while the API is running, without any service restarts necessary.