### PR TITLE
Fix name transfer owner

### DIFF
--- a/src/bns-helpers.ts
+++ b/src/bns-helpers.ts
@@ -156,6 +156,23 @@ export function getFunctionName(tx_id: string, transactions: CoreNodeParsedTxMes
   return contract_function_name;
 }
 
+export function getNewOwner(
+  tx_id: string,
+  transactions: CoreNodeParsedTxMessage[]
+): Address | undefined {
+  for (const tx of transactions) {
+    if (tx.core_tx.txid === tx_id) {
+      if (tx.parsed_tx.payload.typeId === TransactionPayloadTypeID.ContractCall) {
+        if (
+          tx.parsed_tx.payload.functionArgs.length >= 3 &&
+          tx.parsed_tx.payload.functionArgs[2].type === ClarityType.PrincipalStandard
+        )
+          return tx.parsed_tx.payload.functionArgs[2].address;
+      }
+    }
+  }
+}
+
 export function GetStacksNetwork(chainId: ChainID) {
   const network = chainId === ChainID.Mainnet ? new StacksMainnet() : new StacksTestnet();
   network.coreApiUrl = `http://${getCoreNodeEndpoint()}`;

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -64,6 +64,7 @@ import {
 } from '@stacks/transactions';
 import {
   getFunctionName,
+  getNewOwner,
   parseNameRawValue,
   parseNamespaceRawValue,
   parseResolver,
@@ -380,13 +381,20 @@ function parseDataStoreTxEventData(
           const functionName = getFunctionName(event.txid, parsedTxs);
           if (nameFunctions.includes(functionName)) {
             const attachment = parseNameRawValue(event.contract_event.raw_value);
+            let name_address = addressToString(attachment.attachment.metadata.tx_sender);
+            if (functionName === 'name-transfer') {
+              const new_owner = getNewOwner(event.txid, parsedTxs);
+              if (new_owner) {
+                name_address = addressToString(new_owner);
+              }
+            }
             const name: DbBnsName = {
               name: attachment.attachment.metadata.name.concat(
                 '.',
                 attachment.attachment.metadata.namespace
               ),
               namespace_id: attachment.attachment.metadata.namespace,
-              address: addressToString(attachment.attachment.metadata.tx_sender),
+              address: name_address,
               expire_block: 0,
               registered_at: blockData.block_height,
               zonefile_hash: attachment.attachment.hash,

--- a/src/tests-bns/bns-integration-tests.ts
+++ b/src/tests-bns/bns-integration-tests.ts
@@ -465,6 +465,12 @@ describe('BNS integration tests', () => {
   });
 
   test('name-transfer contract call', async () => {
+    //name owned by address before calling name-transfer
+    const query1 = await supertest(api.server).get(`/v1/names/${name}.${namespace}`);
+    expect(query1.status).toBe(200);
+    expect(query1.type).toBe('application/json');
+    expect(query1.body.address).toBe(address);
+
     //name transfer
     const txOptions: SignedContractCallOptions = {
       contractAddress: deployedTo,
@@ -506,6 +512,7 @@ describe('BNS integration tests', () => {
       expect(query1.type).toBe('application/json');
       expect(query1.body.zonefile).toBe('');
       expect(query1.body.status).toBe('name-transfer');
+      expect(query1.body.address).toBe(address2);
     } catch (err: any) {
       throw new Error('Error post transaction: ' + err.message);
     }


### PR DESCRIPTION
## Description
This PR fixes the issue with `name-transfer` owner.  BNS names were being shown by the old owner after transfer to the new owner. 

closes #779 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
NO

## Are documentation updates required?
NO

## Testing information

The integration test is updated to cover this scenario.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] @zone117x for review
