### PR TITLE
Remove regtest reference from openapi.yaml

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4,8 +4,6 @@ servers:
     description: Mainnet
   - url: https://stacks-node-api.testnet.stacks.co/
     description: Testnet
-  - url: https://stacks-node-api.regtest.stacks.co/
-    description: Regtest
   - url: http://localhost:3999/
     description: Local
 info:


### PR DESCRIPTION
## Description

This PR removes references for regtest from openapi.yaml.

For details refer to issue #784 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Are documentation updates required?
- [x] Link to documentation updates: [openapi.yaml](https://github.com/blockstack/stacks-blockchain-api/blob/develop/docs/openapi.yaml#L7-L8)

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @kyranjamie or @zone117x for review
