### PR TITLE
fix: api versioning

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,9 +8,6 @@ on:
       - master
     types:
       - completed
-  push:
-    branches:
-      - 'master'
   workflow_dispatch:
 
 jobs:
@@ -18,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
## Description

This patch makes sure the repository is fetched with tags, so when the API docs Github pages files get built they are versioned correctly from the latest release tag.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
N/A

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @kyranjamie or @zone117x for review
