### PR TITLE
[Draft] Add stacker tuple in contract map API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -852,6 +852,11 @@ paths:
           schema:
             type: string
           description: The Stacks chain tip to query from
+        - name: stacker_tuple
+          in: query
+          schema:
+            type: string
+          description: Hex string to denote the value of a stacker inside a tuple clarity value
       x-codegen-request-body-name: key
       requestBody:
         description: Hex string serialization of the lookup key (which should be a Clarity value)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -852,11 +852,11 @@ paths:
           schema:
             type: string
           description: The Stacks chain tip to query from
-        - name: stacker_tuple
+        - name: map_key
           in: query
           schema:
             type: string
-          description: Hex string to denote the value of a stacker inside a tuple clarity value
+          description: Hex string to denote the value of a key inside a map of the contract
       x-codegen-request-body-name: key
       requestBody:
         description: Hex string serialization of the lookup key (which should be a Clarity value)


### PR DESCRIPTION
## Description

This is a documentation change PR. It adds a `stacker_tuple` in the body represented in hex string to denote the value of a stacker inside a tuple clarity value.

For details refer to issue #452 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [X] API reference/documentation update
- [ ] Other

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @kyranjamie or @zone117x for review
