### PR TITLE
fix: export api version variable for openapi resolution

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "lint:openapi": "lint-openapi ./openapi.yaml",
     "generate:types": "ts-node ./scripts/generate-types.ts",
     "generate:schemas": "gulp && npm run generate:types",
-    "generate:resolved-spec": "API_VERSION=$(shx tail -n 1 ../.git-info) speccy resolve --output .tmp/openapi.resolved.yaml openapi.yaml && shx sed -i 'STACKS_API_VERSION' ${API_VERSION:-1.0.0} .tmp/openapi.resolved.yaml > /dev/null",
+    "generate:resolved-spec": "export API_VERSION=$(shx tail -n 1 ../.git-info) && speccy resolve --output .tmp/openapi.resolved.yaml openapi.yaml && shx sed -i 'STACKS_API_VERSION' ${API_VERSION:-1.0.0} .tmp/openapi.resolved.yaml > /dev/null",
     "generate:docs": "redoc-cli bundle --output .tmp/index.html .tmp/openapi.resolved.yaml",
     "generate:postman": "openapi2postmanv2 --spec .tmp/openapi.resolved.yaml --output .tmp/collection.json --options folderStrategy=Tags,requestParametersResolution=Example,exampleParametersResolution=Example",
     "validate:schemas": "rimraf .tmp && gulp flattenSchemas --silent && ts-node ./scripts/validate-schemas.ts",


### PR DESCRIPTION
## Description

This patch fixes a bug with OpenAPI versioning in Github pages where the `API_VERSION` variable would not be reflected in the resolved `openapi.yaml` file even though it was calculated correctly.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [x] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
N/A

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @kyranjamie or @zone117x for review
