### PR TITLE
Fix/stx addr perf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4159,13 +4159,13 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "c32check": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/c32check/-/c32check-1.1.2.tgz",
-      "integrity": "sha512-YgmbvOQ9HfoH7ptW80JP6WJdgoHJFGqFjxaFYvwD+bU5i3dJ44a1LI0yxdiA2n/tVKq9W92tYcFjTP5hGlvhcg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/c32check/-/c32check-1.1.3.tgz",
+      "integrity": "sha512-ADADE/PjAbJRlwpG3ShaOMbBUlJJZO7xaYSRD5Tub6PixQlgR4s36y9cvMf/YRGpkqX+QOxIdMw216iC320q9A==",
       "requires": {
         "base-x": "^3.0.8",
         "buffer": "^5.6.0",
-        "cross-sha256": "^1.1.2"
+        "cross-sha256": "^1.2.0"
       }
     },
     "cache-base": {
@@ -5133,19 +5133,11 @@
       }
     },
     "cross-sha256": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cross-sha256/-/cross-sha256-1.1.2.tgz",
-      "integrity": "sha512-ZMGqJvPZQY/hmFvTJyM4LGVZIvEqD58GrCWA28goaDdo6wGzjgxWKEDxVfahkNCF/ryxBNfHe3Ql/BMSwPPbcg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cross-sha256/-/cross-sha256-1.2.0.tgz",
+      "integrity": "sha512-KViLNMDZKV7jwFqjFx+rNhG26amnFYYQ0S+VaFlVvpk8tM+2XbFia/don/SjGHg9WQxnFVi6z64CGPuF3T+nNw==",
       "requires": {
-        "@types/node": "^8.0.0",
         "buffer": "^5.6.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.10.66",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
-          "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
-        }
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "bitcoinjs-lib": "^5.2.0",
     "bluebird": "^3.7.2",
     "bn.js": "^4.11.8",
-    "c32check": "^1.1.2",
+    "c32check": "^1.1.3",
     "chokidar": "^3.5.1",
     "coinselect": "^3.1.12",
     "compression": "^1.7.4",


### PR DESCRIPTION
Updates the `c32check` and transitive `cross-sha256` dependencies to latest versions which include a 4x speedup to the sha256 operation during Stacks address encoding. 

See changes to [`cross-sha256`](https://github.com/zone117x/cross-sha256/pull/1)

Caching the `require('crypto')` instance results in around 4x speedup in sha256 operations:
```
Running with cache enabled: true
384.29 hashes per ms; 10 iterations took 0.03ms; 
397.16 hashes per ms; 1000 iterations took 2.52ms; 
371.8 hashes per ms; 10000 iterations took 26.9ms; 
257.5 hashes per ms; 100000 iterations took 388.35ms; 

Running with cache enabled: false
82.33 hashes per ms; 10 iterations took 0.12ms; 
73.81 hashes per ms; 1000 iterations took 13.55ms; 
72.74 hashes per ms; 10000 iterations took 137.47ms; 
71.89 hashes per ms; 100000 iterations took 1391.01ms; 
```

For context see https://github.com/blockstack/stacks-blockchain-api/pull/821 (significant amount of Stacks API CPU usage spent inside of nodejs `require` calls).

These changes were patch bumps that could be updated via the package-lock.json file -- rather than waiting on updates from stacks.js libs to be merged and deployed. 