### PR TITLE
Add support for sponsor nonce in the transactions

### DIFF
--- a/docs/entities/transactions/base-transaction.schema.json
+++ b/docs/entities/transactions/base-transaction.schema.json
@@ -31,6 +31,9 @@
       "type": "string",
       "description": "Address of the transaction initiator"
     },
+    "sponsor_nonce": {
+      "type": "integer"
+    },
     "sponsored": {
       "type": "boolean",
       "description": "Denotes whether the originating account is the same as the paying account"

--- a/docs/generated.d.ts
+++ b/docs/generated.d.ts
@@ -1080,6 +1080,7 @@ export interface BaseTransaction {
    * Address of the transaction initiator
    */
   sender_address: string;
+  sponsor_nonce?: number;
   /**
    * Denotes whether the originating account is the same as the paying account
    */

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -651,6 +651,7 @@ function parseDbBaseTx(dbTx: DbTx | DbMempoolTx): BaseTransaction {
   const tx: BaseTransaction = {
     tx_id: dbTx.tx_id,
     nonce: dbTx.nonce,
+    sponsor_nonce: dbTx.sponsor_nonce,
     fee_rate: dbTx.fee_rate.toString(10),
     sender_address: dbTx.sender_address,
     sponsored: dbTx.sponsored,

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -137,6 +137,7 @@ export interface BaseTx {
   sender_address: string;
   sponsored: boolean;
   sponsor_address: string | undefined;
+  sponsor_nonce?: number | undefined;
   nonce: number;
   tx_id: string;
   anchor_mode: DbTxAnchorMode;
@@ -1056,6 +1057,10 @@ export function createDbMempoolTxFromCoreMsg(msg: {
   const dbTx: DbMempoolTx = {
     pruned: false,
     nonce: Number(msg.txData.auth.originCondition.nonce),
+    sponsor_nonce:
+      msg.txData.auth.typeId === TransactionAuthTypeID.Sponsored
+        ? Number(msg.txData.auth.sponsorCondition.nonce)
+        : undefined,
     tx_id: msg.txId,
     raw_tx: msg.rawTx,
     type_id: parseEnum(DbTxTypeId, msg.txData.payload.typeId as number),
@@ -1079,11 +1084,11 @@ export function createDbTxFromCoreMsg(msg: CoreNodeParsedTxMessage): DbTx {
   const dbTx: DbTx = {
     tx_id: coreTx.txid,
     tx_index: coreTx.tx_index,
-    nonce: Number(
+    nonce: Number(parsedTx.auth.originCondition.nonce),
+    sponsor_nonce:
       parsedTx.auth.typeId === TransactionAuthTypeID.Sponsored
-        ? parsedTx.auth.sponsorCondition.nonce
-        : parsedTx.auth.originCondition.nonce
-    ),
+        ? Number(parsedTx.auth.sponsorCondition.nonce)
+        : undefined,
     raw_tx: msg.raw_tx,
     index_block_hash: msg.index_block_hash,
     parent_index_block_hash: msg.parent_index_block_hash,

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -136,8 +136,8 @@ export interface BaseTx {
   fee_rate: bigint;
   sender_address: string;
   sponsored: boolean;
-  sponsor_address: string | undefined;
-  sponsor_nonce?: number | undefined;
+  sponsor_address?: string;
+  sponsor_nonce?: number;
   nonce: number;
   tx_id: string;
   anchor_mode: DbTxAnchorMode;

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -2017,7 +2017,12 @@ export class PgDataStore
             `
             SELECT nonce
             FROM mempool_txs
-            WHERE ((sender_address = $1 AND sponsored = false) OR (sponsor_address = $1 AND sponsored= true)) AND nonce = ANY($2)
+            WHERE sender_address = $1 AND nonce = ANY($2)
+            AND pruned = false
+            UNION
+            SELECT sponsor_nonce as nonce
+            FROM mempool_txs
+            WHERE sponsor_address = $1 AND sponsored= true AND sponsor_nonce = ANY($2)
             AND pruned = false
             `,
             [args.stxAddress, expectedNonces]

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -2001,19 +2001,8 @@ export class PgDataStore
       }
 
       let possibleNextNonce = 0;
-      if (
-        lastExecutedTxNonce !== null ||
-        lastExecutedTxSponsorNonce !== null ||
-        lastMempoolTxNonce !== null ||
-        lastMempoolTxSponsorNonce !== null
-      ) {
-        possibleNextNonce =
-          Math.max(
-            lastExecutedTxNonce ?? 0,
-            lastExecutedTxSponsorNonce ?? 0,
-            lastMempoolTxNonce ?? 0,
-            lastMempoolTxSponsorNonce ?? 0
-          ) + 1;
+      if (lastExecutedTxNonce !== null || lastMempoolTxNonce !== null) {
+        possibleNextNonce = Math.max(lastExecutedTxNonce ?? 0, lastMempoolTxNonce ?? 0) + 1;
       }
       const detectedMissingNonces: number[] = [];
       if (lastExecutedTxNonce !== null && lastMempoolTxNonce !== null) {

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -521,7 +521,7 @@ interface MempoolTxQueryResult {
   tx_id: Buffer;
 
   nonce: number;
-  sponsor_nonce: number;
+  sponsor_nonce?: number;
   type_id: number;
   anchor_mode: number;
   status: number;
@@ -573,7 +573,7 @@ interface TxQueryResult {
   burn_block_time: number;
   parent_burn_block_time: number;
   nonce: number;
-  sponsor_nonce: number;
+  sponsor_nonce?: number;
   type_id: number;
   anchor_mode: number;
   status: number;
@@ -1961,7 +1961,7 @@ export class PgDataStore
         `
         SELECT MAX(sponsor_nonce) nonce
         FROM txs
-        WHERE sponsor_address = $1 AND sponsored= true
+        WHERE sponsor_address = $1 AND sponsored = true
         AND canonical = true AND microblock_canonical = true
         `,
         [args.stxAddress]

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -1987,10 +1987,19 @@ export class PgDataStore
         [args.stxAddress]
       );
 
-      const lastExecutedTxNonce = executedTxNonce.rows[0]?.nonce ?? null;
+      let lastExecutedTxNonce = executedTxNonce.rows[0]?.nonce ?? null;
       const lastExecutedTxSponsorNonce = executedTxSponsorNonce.rows[0]?.nonce ?? null;
-      const lastMempoolTxNonce = mempoolTxNonce.rows[0]?.nonce ?? null;
+      if (lastExecutedTxNonce != null || lastExecutedTxSponsorNonce != null) {
+        lastExecutedTxNonce = Math.max(lastExecutedTxNonce ?? 0, lastExecutedTxSponsorNonce ?? 0);
+      }
+
+      let lastMempoolTxNonce = mempoolTxNonce.rows[0]?.nonce ?? null;
       const lastMempoolTxSponsorNonce = mempoolTxSponsorNonce.rows[0]?.nonce ?? null;
+
+      if (lastMempoolTxNonce != null || lastMempoolTxSponsorNonce != null) {
+        lastMempoolTxNonce = Math.max(lastMempoolTxNonce ?? 0, lastMempoolTxSponsorNonce ?? 0);
+      }
+
       let possibleNextNonce = 0;
       if (
         lastExecutedTxNonce !== null ||

--- a/src/migrations/1584619633448_txs.ts
+++ b/src/migrations/1584619633448_txs.ts
@@ -77,6 +77,9 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     sponsor_address: {
       type: 'string'
     },
+    sponsor_nonce: {
+      type: 'integer'
+    },
     sender_address: {
       type: 'string',
       notNull: true,

--- a/src/migrations/1591291822107_mempool_txs.ts
+++ b/src/migrations/1591291822107_mempool_txs.ts
@@ -45,6 +45,9 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     sponsor_address: {
       type: 'string'
     },
+    sponsor_nonce: {
+      type: 'integer'
+    },
     sender_address: {
       type: 'string',
       notNull: true,

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -7544,7 +7544,7 @@ describe('api tests', () => {
       tx_type: 'contract_call',
       fee_rate: '300',
       is_unanchored: false,
-      nonce: 2,
+      nonce: 0,
       anchor_mode: 'any',
       sender_address: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y',
       sponsor_address: 'SP2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7GB36ZAR0',
@@ -7566,6 +7566,7 @@ describe('api tests', () => {
       execution_cost_runtime: 0,
       execution_cost_write_count: 0,
       execution_cost_write_length: 0,
+      sponsor_nonce: 2,
     };
     const fetchTx = await supertest(api.server).get(`/extended/v1/tx/${dbTx.tx_id}`);
     expect(fetchTx.status).toBe(200);

--- a/src/tests/api-tests.ts
+++ b/src/tests/api-tests.ts
@@ -7770,6 +7770,201 @@ describe('api tests', () => {
     expect(JSON.parse(sponsoredStxResAfter.text)).toEqual(expectedSponsoredRespAfter);
   });
 
+  test('address - sponsor nonces', async () => {
+    const dbBlock: DbBlock = {
+      block_hash: '0xff',
+      index_block_hash: '0x1234',
+      parent_index_block_hash: '0x5678',
+      parent_block_hash: '0x5678',
+      parent_microblock_hash: '',
+      parent_microblock_sequence: 0,
+      block_height: 1,
+      burn_block_time: 1594647995,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
+      canonical: true,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
+    };
+    const txBuilder = await makeContractCall({
+      contractAddress: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y',
+      contractName: 'hello-world',
+      functionName: 'fn-name',
+      functionArgs: [{ type: ClarityType.Int, value: BigInt(556) }],
+      fee: new BN(200),
+      senderKey: 'b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001',
+      nonce: new BN(0),
+      sponsored: true,
+      anchorMode: AnchorMode.Any,
+    });
+    const sponsoredTx = await sponsorTransaction({
+      transaction: txBuilder,
+      sponsorPrivateKey: '381314da39a45f43f45ffd33b5d8767d1a38db0da71fea50ed9508e048765cf301',
+      fee: new BN(300),
+      sponsorNonce: new BN(2),
+    });
+    const serialized = sponsoredTx.serialize();
+    const tx = readTransaction(new BufferReader(serialized));
+    const dbTx = createDbTxFromCoreMsg({
+      core_tx: {
+        raw_tx: '0x' + serialized.toString('hex'),
+        status: 'success',
+        raw_result: '0x0100000000000000000000000000000001', // u1
+        txid: '0x' + txBuilder.txid(),
+        tx_index: 2,
+        contract_abi: null,
+        microblock_hash: null,
+        microblock_parent_hash: null,
+        microblock_sequence: null,
+        execution_cost: {
+          read_count: 0,
+          read_length: 0,
+          runtime: 0,
+          write_count: 0,
+          write_length: 0,
+        },
+      },
+      nonce: 0,
+      raw_tx: Buffer.alloc(0),
+      parsed_tx: tx,
+      sender_address: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y',
+      sponsor_address: 'SP2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7GB36ZAR0',
+      index_block_hash: dbBlock.index_block_hash,
+      parent_index_block_hash: dbBlock.parent_index_block_hash,
+      parent_block_hash: dbBlock.parent_block_hash,
+      microblock_hash: '',
+      microblock_sequence: I32_MAX,
+      block_hash: dbBlock.block_hash,
+      block_height: dbBlock.block_height,
+      burn_block_time: dbBlock.burn_block_time,
+      parent_burn_block_hash: '0xaa',
+      parent_burn_block_time: 1626122935,
+    });
+    const contractAbi: ClarityAbi = {
+      functions: [
+        {
+          name: 'fn-name',
+          args: [{ name: 'arg1', type: 'int128' }],
+          access: 'public',
+          outputs: { type: 'bool' },
+        },
+      ],
+      variables: [],
+      maps: [],
+      fungible_tokens: [],
+      non_fungible_tokens: [],
+    };
+    const smartContract: DbSmartContract = {
+      tx_id: dbTx.tx_id,
+      canonical: true,
+      contract_id: 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y.hello-world',
+      block_height: dbBlock.block_height,
+      source_code: '()',
+      abi: JSON.stringify(contractAbi),
+    };
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: dbTx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [smartContract],
+        },
+      ],
+    });
+
+    const senderAddress = 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y';
+    const sponsor_address = 'SP2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7GB36ZAR0';
+
+    //sender nonce
+    const expectedResp = {
+      detected_missing_nonces: [],
+      last_executed_tx_nonce: 0,
+      last_mempool_tx_nonce: null,
+      possible_next_nonce: 1,
+    };
+    const sender_nonces = await supertest(api.server).get(
+      `/extended/v1/address/${senderAddress}/nonces`
+    );
+    expect(sender_nonces.status).toBe(200);
+    expect(sender_nonces.type).toBe('application/json');
+    expect(JSON.parse(sender_nonces.text)).toEqual(expectedResp);
+
+    //sponsor_nonce
+    const expectedResp2 = {
+      detected_missing_nonces: [],
+      last_executed_tx_nonce: 2,
+      last_mempool_tx_nonce: null,
+      possible_next_nonce: 3,
+    };
+    const sponsor_nonces = await supertest(api.server).get(
+      `/extended/v1/address/${sponsor_address}/nonces`
+    );
+    expect(sponsor_nonces.status).toBe(200);
+    expect(sponsor_nonces.type).toBe('application/json');
+    expect(JSON.parse(sponsor_nonces.text)).toEqual(expectedResp2);
+
+    const mempoolTx: DbMempoolTx = {
+      tx_id: '0x521234',
+      anchor_mode: 3,
+      nonce: 1,
+      raw_tx: Buffer.from('test-raw-mempool-tx'),
+      type_id: DbTxTypeId.Coinbase,
+      status: 1,
+      post_conditions: Buffer.from([0x01, 0xf5]),
+      fee_rate: 1234n,
+      sponsored: true,
+      sponsor_address: sponsor_address,
+      sender_address: senderAddress,
+      sponsor_nonce: 3,
+      origin_hash_mode: 1,
+      coinbase_payload: Buffer.from('hi'),
+      pruned: false,
+      receipt_time: 1616063078,
+    };
+    await db.updateMempoolTxs({ mempoolTxs: [mempoolTx] });
+
+    //mempool sender nonce
+    const expectedResp3 = {
+      detected_missing_nonces: [],
+      last_executed_tx_nonce: 0,
+      last_mempool_tx_nonce: 1,
+      possible_next_nonce: 2,
+    };
+    const mempool_sender_nonces = await supertest(api.server).get(
+      `/extended/v1/address/${senderAddress}/nonces`
+    );
+    expect(mempool_sender_nonces.status).toBe(200);
+    expect(mempool_sender_nonces.type).toBe('application/json');
+    expect(JSON.parse(mempool_sender_nonces.text)).toEqual(expectedResp3);
+
+    //mempool sponsor_nonce
+    const expectedResp4 = {
+      detected_missing_nonces: [],
+      last_executed_tx_nonce: 2,
+      last_mempool_tx_nonce: 3,
+      possible_next_nonce: 4,
+    };
+    const mempool_sponsor_nonces = await supertest(api.server).get(
+      `/extended/v1/address/${sponsor_address}/nonces`
+    );
+    expect(mempool_sponsor_nonces.status).toBe(200);
+    expect(mempool_sponsor_nonces.type).toBe('application/json');
+    expect(JSON.parse(mempool_sponsor_nonces.text)).toEqual(expectedResp4);
+  });
+
   test('tx store and processing', async () => {
     const dbBlock: DbBlock = {
       block_hash: '0xff',


### PR DESCRIPTION

## Description
This PR fixes the problem with sponsor nonce in the API.  The possible next nonce could be incorrect because of the absence of sponsor_nonce for sponsored transactions.   This PR has added a field `sponsor_nonce` in the `txs` and the mempool table which will be set only in case of sponsored transactions just like the sponsored address. 

closes #1133 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Are documentation updates required?

## Testing information
_yet to add_

## Checklist
- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @rafaelcr 
