### PR TITLE
feat: tx list function name fuzzy search

### DIFF
--- a/migrations/1728654359950_idx-contract-call-function-name-trgm.js
+++ b/migrations/1728654359950_idx-contract-call-function-name-trgm.js
@@ -1,0 +1,29 @@
+/** @param { import("node-pg-migrate").MigrationBuilder } pgm */
+exports.up = pgm => {
+  pgm.sql(`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM pg_available_extensions
+        WHERE name = 'pg_trgm'
+      ) THEN
+        CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+        CREATE INDEX IF NOT EXISTS idx_contract_call_function_name_trgm
+        ON txs
+        USING gin (contract_call_function_name gin_trgm_ops);
+      END IF;
+    END
+    $$;
+  `);
+};
+
+/** @param { import("node-pg-migrate").MigrationBuilder } pgm */
+exports.down = pgm => {
+  pgm.sql(`
+    DROP INDEX IF EXISTS idx_contract_call_function_name_trgm;
+  `);
+
+  pgm.sql('DROP EXTENSION IF EXISTS pg_trgm;');
+};

--- a/src/api/routes/tx.ts
+++ b/src/api/routes/tx.ts
@@ -113,6 +113,12 @@ export const TxRoutes: FastifyPluginAsync<
               examples: [1706745599],
             })
           ),
+          search_term: Type.Optional(
+            Type.String({
+              description: 'Option to search for transactions by a search term',
+              examples: ['swap'],
+            })
+          ),
           contract_id: Type.Optional(
             Type.String({
               description: 'Option to filter results by contract ID',
@@ -178,6 +184,11 @@ export const TxRoutes: FastifyPluginAsync<
         contractId = req.query.contract_id;
       }
 
+      let searchTerm: string | undefined;
+      if (typeof req.query.search_term === 'string') {
+        searchTerm = req.query.search_term;
+      }
+
       const { results: txResults, total } = await fastify.db.getTxList({
         offset,
         limit,
@@ -188,6 +199,7 @@ export const TxRoutes: FastifyPluginAsync<
         startTime: req.query.start_time,
         endTime: req.query.end_time,
         contractId,
+        searchTerm,
         functionName: req.query.function_name,
         nonce: req.query.nonce,
         order: req.query.order,


### PR DESCRIPTION
Implemented fuzzy search for transaction list query using the `pg_trgm` extension, starting with indexing the `contract_call_function_name` column. Future plan is to expand the index to cover more columns, improving search flexibility, e.g.:
```
CREATE INDEX idx_search_term_trgm
ON public.txs
USING gin (
  contract_call_function_name gin_trgm_ops,
  contract_name gin_trgm_ops
  memo gin_trgm_ops
  ....
);
```