### PR TITLE
feat: add cursor pagination to smart contract log events

### DIFF
--- a/src/api/routes/contract.ts
+++ b/src/api/routes/contract.ts
@@ -117,7 +117,7 @@ export const ContractRoutes: FastifyPluginAsync<
           offset: OffsetParam(),
           cursor: Type.Optional(
             Type.String({
-              description: 'Cursor for pagination',
+              description: 'Cursor for pagination in the format: indexBlockHash:txIndex:eventIndex',
             })
           ),
         }),
@@ -133,9 +133,9 @@ export const ContractRoutes: FastifyPluginAsync<
       const cursor = req.query.cursor;
 
       // Validate cursor format if provided
-      if (cursor && !cursor.match(/^\d+-\d+-\d+$/)) {
+      if (cursor && !cursor.match(/^[0-9a-fA-F]{64}:\d+:\d+$/)) {
         throw new InvalidRequestError(
-          'Invalid cursor format. Expected format: blockHeight-txIndex-eventIndex',
+          'Invalid cursor format. Expected format: indexBlockHash:txIndex:eventIndex',
           InvalidRequestErrorType.invalid_param
         );
       }
@@ -155,7 +155,7 @@ export const ContractRoutes: FastifyPluginAsync<
         total: eventsQuery.total || 0,
         results: parsedEvents as SmartContractLogTransactionEvent[],
         next_cursor: eventsQuery.nextCursor || null,
-        prev_cursor: null, // TODO: Implement prev_cursor as well
+        prev_cursor: eventsQuery.prevCursor || null,
         cursor: cursor || null,
       };
       await reply.send(response);

--- a/src/api/routes/contract.ts
+++ b/src/api/routes/contract.ts
@@ -9,7 +9,8 @@ import { LimitParam, OffsetParam } from '../schemas/params';
 import { InvalidRequestError, InvalidRequestErrorType, NotFoundError } from '../../errors';
 import { ClarityAbi } from '@stacks/transactions';
 import { SmartContractSchema } from '../schemas/entities/smart-contracts';
-import { TransactionEventSchema } from '../schemas/entities/transaction-events';
+import { SmartContractLogTransactionEvent } from '../schemas/entities/transaction-events';
+import { ContractEventListResponseSchema } from '../schemas/responses/responses';
 
 export const ContractRoutes: FastifyPluginAsync<
   Record<never, never>,
@@ -114,16 +115,14 @@ export const ContractRoutes: FastifyPluginAsync<
         querystring: Type.Object({
           limit: LimitParam(ResourceType.Contract, 'Limit', 'max number of events to fetch'),
           offset: OffsetParam(),
+          cursor: Type.Optional(
+            Type.String({
+              description: 'Cursor for pagination',
+            })
+          ),
         }),
         response: {
-          200: Type.Object(
-            {
-              limit: Type.Integer(),
-              offset: Type.Integer(),
-              results: Type.Array(TransactionEventSchema),
-            },
-            { description: 'List of events' }
-          ),
+          200: ContractEventListResponseSchema,
         },
       },
     },
@@ -131,16 +130,35 @@ export const ContractRoutes: FastifyPluginAsync<
       const { contract_id } = req.params;
       const limit = getPagingQueryLimit(ResourceType.Contract, req.query.limit);
       const offset = parsePagingQueryInput(req.query.offset ?? 0);
+      const cursor = req.query.cursor;
+
+      // Validate cursor format if provided
+      if (cursor && !cursor.match(/^\d+-\d+-\d+$/)) {
+        throw new InvalidRequestError(
+          'Invalid cursor format. Expected format: blockHeight-txIndex-eventIndex',
+          InvalidRequestErrorType.invalid_param
+        );
+      }
       const eventsQuery = await fastify.db.getSmartContractEvents({
         contractId: contract_id,
         limit,
         offset,
+        cursor,
       });
       if (!eventsQuery.found) {
         throw new NotFoundError(`cannot find events for contract by ID}`);
       }
-      const parsedEvents = eventsQuery.result.map(event => parseDbEvent(event));
-      await reply.send({ limit, offset, results: parsedEvents });
+      const parsedEvents = eventsQuery.result.map((event: any) => parseDbEvent(event));
+      const response = {
+        limit,
+        offset,
+        total: eventsQuery.total || 0,
+        results: parsedEvents as SmartContractLogTransactionEvent[],
+        next_cursor: eventsQuery.nextCursor || null,
+        prev_cursor: null, // TODO: Implement prev_cursor as well
+        cursor: cursor || null,
+      };
+      await reply.send(response);
     }
   );
 

--- a/src/api/schemas/entities/transaction-events.ts
+++ b/src/api/schemas/entities/transaction-events.ts
@@ -25,7 +25,7 @@ const AbstractTransactionEventSchema = Type.Object(
 );
 type AbstractTransactionEvent = Static<typeof AbstractTransactionEventSchema>;
 
-const SmartContractLogTransactionEventSchema = Type.Intersect(
+export const SmartContractLogTransactionEventSchema = Type.Intersect(
   [
     AbstractTransactionEventSchema,
     Type.Object({

--- a/src/api/schemas/responses/responses.ts
+++ b/src/api/schemas/responses/responses.ts
@@ -1,5 +1,5 @@
 import { Static, Type } from '@sinclair/typebox';
-import { Nullable, OptionalNullable, PaginatedCursorResponse, PaginatedResponse } from '../util';
+import { OptionalNullable, PaginatedCursorResponse, PaginatedResponse } from '../util';
 import { MempoolStatsSchema } from '../entities/mempool-transactions';
 import { MempoolTransactionSchema, TransactionSchema } from '../entities/transactions';
 import { MicroblockSchema } from '../entities/microblock';
@@ -7,7 +7,10 @@ import {
   AddressTransactionWithTransfersSchema,
   InboundStxTransferSchema,
 } from '../entities/addresses';
-import { TransactionEventSchema } from '../entities/transaction-events';
+import {
+  SmartContractLogTransactionEventSchema,
+  TransactionEventSchema,
+} from '../entities/transaction-events';
 import {
   BurnchainRewardSchema,
   BurnchainRewardSlotHolderSchema,
@@ -183,6 +186,10 @@ export type RunFaucetResponse = Static<typeof RunFaucetResponseSchema>;
 
 export const BlockListV2ResponseSchema = PaginatedCursorResponse(NakamotoBlockSchema);
 export type BlockListV2Response = Static<typeof BlockListV2ResponseSchema>;
+
+export const ContractEventListResponseSchema = PaginatedCursorResponse(
+  SmartContractLogTransactionEventSchema
+);
 
 export const BlockSignerSignatureResponseSchema = PaginatedResponse(SignerSignatureSchema);
 export type BlockSignerSignatureResponse = Static<typeof BlockSignerSignatureResponseSchema>;

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -556,6 +556,7 @@ export interface DbSmartContractEvent extends DbEventBase {
 export type DbCursorPaginatedFoundOrNot<T> = FoundOrNot<T> & {
   nextCursor?: string | null;
   prevCursor?: string | null;
+  currentCursor?: string | null;
   total: number;
 };
 

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -1,3 +1,4 @@
+import { FoundOrNot } from 'src/helpers';
 import { Block } from '../api/schemas/entities/block';
 import { SyntheticPoxEventName } from '../pox-helpers';
 import { PgBytea, PgJsonb, PgNumeric } from '@hirosystems/api-toolkit';
@@ -551,6 +552,12 @@ export interface DbSmartContractEvent extends DbEventBase {
   topic: string;
   value: string;
 }
+
+export type DbCursorPaginatedFoundOrNot<T> = FoundOrNot<T> & {
+  nextCursor?: string | null;
+  prevCursor?: string | null;
+  total: number;
+};
 
 export interface DbStxLockEvent extends DbEventBase {
   event_type: DbEventTypeId.StxLock;

--- a/tests/api/smart-contract.test.ts
+++ b/tests/api/smart-contract.test.ts
@@ -178,6 +178,10 @@ describe('smart contract tests', () => {
     expect(JSON.parse(fetchTx.text)).toEqual({
       limit: 20,
       offset: 0,
+      total: 1,
+      cursor: null,
+      next_cursor: null,
+      prev_cursor: null,
       results: [
         {
           event_index: 4,
@@ -193,6 +197,164 @@ describe('smart contract tests', () => {
     });
 
     db.eventEmitter.removeListener('smartContractLogUpdate', handler);
+  });
+
+  test('contract events cursor pagination', async () => {
+    const contractId = 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.test-contract';
+
+    // Create multiple blocks with contract events for pagination testing
+    for (let blockHeight = 1; blockHeight <= 10; blockHeight++) {
+      const blockBuilder = new TestBlockBuilder({
+        block_height: blockHeight,
+        block_hash: `0x${blockHeight.toString().padStart(64, '0')}`,
+        index_block_hash: `0x${blockHeight.toString().padStart(64, '0')}`,
+        parent_index_block_hash:
+          blockHeight > 1 ? `0x${(blockHeight - 1).toString().padStart(64, '0')}` : '0x00',
+        parent_block_hash:
+          blockHeight > 1 ? `0x${(blockHeight - 1).toString().padStart(64, '0')}` : '0x00',
+        block_time: 1594647996 + blockHeight,
+        burn_block_time: 1594647996 + blockHeight,
+        burn_block_height: 123 + blockHeight,
+      });
+
+      // Add 2 transactions per block, each with 1 contract event
+      for (let txIndex = 0; txIndex < 2; txIndex++) {
+        const txId = `0x${blockHeight.toString().padStart(2, '0')}${txIndex
+          .toString()
+          .padStart(62, '0')}`;
+
+        blockBuilder
+          .addTx({
+            tx_id: txId,
+            type_id: DbTxTypeId.Coinbase,
+            coinbase_payload: bufferToHex(Buffer.from('test-payload')),
+          })
+          .addTxContractLogEvent({
+            contract_identifier: contractId,
+            topic: 'test-topic',
+            value: bufferToHex(
+              Buffer.from(serializeCV(bufferCVFromString(`event-${blockHeight}-${txIndex}`)))
+            ),
+          });
+      }
+
+      const blockData = blockBuilder.build();
+      await db.update(blockData);
+    }
+
+    // Basic pagination with limit (no cursor)
+    const page1 = await supertest(api.server)
+      .get(`/extended/v1/contract/${encodeURIComponent(contractId)}/events?limit=3`)
+      .expect(200);
+
+    expect(page1.body).toMatchObject({
+      limit: 3,
+      offset: 0,
+      total: 20, // Total events for this contract
+      results: expect.arrayContaining([
+        expect.objectContaining({
+          event_type: 'smart_contract_log',
+          contract_log: expect.objectContaining({ contract_id: contractId }),
+        }),
+      ]),
+      next_cursor: expect.any(String),
+      prev_cursor: null,
+      cursor: null,
+    });
+
+    expect(page1.body.results).toHaveLength(3);
+    const firstPageResults = page1.body.results;
+    const nextCursor = page1.body.next_cursor;
+
+    // Use cursor for next page
+    const page2 = await supertest(api.server)
+      .get(
+        `/extended/v1/contract/${encodeURIComponent(
+          contractId
+        )}/events?limit=3&cursor=${nextCursor}`
+      )
+      .expect(200);
+
+    expect(page2.body).toMatchObject({
+      limit: 3,
+      offset: 0,
+      total: 20,
+      results: expect.arrayContaining([
+        expect.objectContaining({
+          event_type: 'smart_contract_log',
+          contract_log: expect.objectContaining({ contract_id: contractId }),
+        }),
+      ]),
+      next_cursor: expect.any(String),
+      prev_cursor: null,
+      cursor: nextCursor,
+    });
+
+    expect(page2.body.results).toHaveLength(3);
+
+    // Ensure different results between pages
+    const page1TxIds = firstPageResults.map((r: { tx_id: string }) => r.tx_id);
+    const page2TxIds = page2.body.results.map((r: { tx_id: string }) => r.tx_id);
+    expect(page1TxIds).not.toEqual(page2TxIds);
+
+    // Backward compatibility - offset pagination still works
+    const offsetPage = await supertest(api.server)
+      .get(`/extended/v1/contract/${encodeURIComponent(contractId)}/events?limit=3&offset=3`)
+      .expect(200);
+
+    expect(offsetPage.body).toMatchObject({
+      limit: 3,
+      offset: 3,
+      total: 20,
+      results: expect.any(Array),
+      next_cursor: expect.any(String),
+      prev_cursor: null,
+      cursor: null,
+    });
+
+    // Invalid cursor returns 400
+    const invalidCursor = await supertest(api.server)
+      .get(`/extended/v1/contract/${encodeURIComponent(contractId)}/events?cursor=invalid-cursor`)
+      .expect(400);
+
+    // Cursor format validation - should be "blockHeight-txIndex-eventIndex"
+    const validCursorFormat = await supertest(api.server)
+      .get(`/extended/v1/contract/${encodeURIComponent(contractId)}/events?cursor=10-1-0&limit=2`)
+      .expect(200);
+
+    expect(validCursorFormat.body.results).toHaveLength(2);
+
+    // Complete pagination flow to demonstrate cursor behavior
+    let currentCursor: string | null = null;
+    let pageCount = 0;
+    const maxPages = 10; // Safety limit
+    const allPages: any[] = [];
+
+    do {
+      const url: string = currentCursor
+        ? `/extended/v1/contract/${encodeURIComponent(
+            contractId
+          )}/events?limit=5&cursor=${currentCursor}`
+        : `/extended/v1/contract/${encodeURIComponent(contractId)}/events?limit=5`;
+
+      const response: any = await supertest(api.server).get(url).expect(200);
+
+      allPages.push(response.body);
+      currentCursor = response.body.next_cursor;
+      pageCount++;
+
+      if (pageCount >= maxPages) break; // Safety break
+    } while (currentCursor);
+
+    expect(pageCount).toBeGreaterThan(1); // Should have multiple pages
+    expect(currentCursor).toBeNull(); // Last page should have null next_cursor
+
+    // Verify no overlapping results across pages
+    const allTxIds: string[] = allPages.flatMap(page =>
+      (page.results as { tx_id: string }[]).map(r => r.tx_id)
+    );
+    const uniqueTxIds = [...new Set(allTxIds)];
+    expect(allTxIds.length).toBe(uniqueTxIds.length); // No duplicates
   });
 
   test('get contract by ID', async () => {


### PR DESCRIPTION
[wip] to add prev_cursor 

Fixes https://github.com/hirosystems/stacks-blockchain-api/issues/2349 by adding cursor-based pagination for events. This provides stable iteration through results, unlike offset-based pagination where responses can shift as new events are added.