### PR TITLE
chore: remove unused uuid package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,6 @@
         "tiny-secp256k1": "2.2.1",
         "ts-unused-exports": "7.0.3",
         "undici": "6.21.2",
-        "uuid": "8.3.2",
         "ws": "7.5.10",
         "zone-file": "2.0.0-beta.3"
       },
@@ -99,7 +98,6 @@
         "@types/split2": "2.1.6",
         "@types/supertest": "2.0.11",
         "@types/tiny-secp256k1": "2.0.1",
-        "@types/uuid": "7.0.5",
         "@typescript-eslint/eslint-plugin": "5.46.1",
         "@typescript-eslint/parser": "5.51.0",
         "concurrently": "7.3.0",
@@ -4732,12 +4730,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-7.0.5.tgz",
-      "integrity": "sha512-hKB88y3YHL8oPOs/CNlaXtjWn93+Bs48sDQR37ZUqG2tLeCS7EA1cmnkKsuQsub9OKEB/y/Rw9zqJqqNSbqVlQ==",
-      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
@@ -17945,6 +17937,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
     "tiny-secp256k1": "2.2.1",
     "ts-unused-exports": "7.0.3",
     "undici": "6.21.2",
-    "uuid": "8.3.2",
     "ws": "7.5.10",
     "zone-file": "2.0.0-beta.3"
   },
@@ -179,7 +178,6 @@
     "@types/split2": "2.1.6",
     "@types/supertest": "2.0.11",
     "@types/tiny-secp256k1": "2.0.1",
-    "@types/uuid": "7.0.5",
     "@typescript-eslint/eslint-plugin": "5.46.1",
     "@typescript-eslint/parser": "5.51.0",
     "concurrently": "7.3.0",


### PR DESCRIPTION
## Description

While exploring the codebase, I noticed that the uuid package that is defined in the dependencies of the project is actually not used, so it can be removed.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @rafaelcr or @zone117x for review
