### PR TITLE
New VSCode Launch Option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,12 +17,26 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Launch: app",
+      "name": "Launch: app dev mainnet",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register"],
       "args": ["${workspaceFolder}/src/index.ts"],
       "outputCapture": "std",
       "internalConsoleOptions": "openOnSessionStart",
       "env": {
+        "NODE_ENV": "development",
+        "TS_NODE_SKIP_IGNORE": "true"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch: app dev testnet",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register"],
+      "args": ["${workspaceFolder}/src/index.ts"],
+      "outputCapture": "std",
+      "internalConsoleOptions": "openOnSessionStart",
+      "env": {
+        "STACKS_CHAIN_ID": "0x80000000",
         "NODE_ENV": "development",
         "TS_NODE_SKIP_IGNORE": "true"
       }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:btc-faucet": "npm run test -- --config ./tests/jest.config.btc-faucet.js",
     "test:snp": "npm run test -- --config ./tests/jest.config.snp.js",
     "test:integration": "concurrently \"docker compose -f docker/docker-compose.dev.postgres.yml up --force-recreate -V\" \"cross-env NODE_ENV=test jest --config ./tests/jest.config.js --no-cache --runInBand; npm run devenv:stop:pg\"",
+    "test:integration:api": "concurrently \"docker compose -f docker/docker-compose.dev.postgres.yml up --force-recreate -V\" \"cross-env NODE_ENV=test jest --config ./tests/jest.config.api.js --no-cache --runInBand; npm run devenv:stop:pg\"",
     "test:integration:subnets": "concurrently --hide \"devenv:deploy:subnets\" \"npm:devenv:deploy:subnets\" \"cross-env NODE_ENV=test jest --config ./tests/jest.config.subnets.js --no-cache --runInBand; npm run devenv:stop:subnets\"",
     "test:integration:2.5": "concurrently --hide \"devenv:deploy-krypton\" \"npm:devenv:deploy-krypton\" \"cross-env NODE_ENV=test jest --config ./tests/jest.config.2.5.js --no-cache --runInBand; npm run devenv:stop-krypton\"",
     "test:integration:rosetta": "concurrently \"npm:devenv:deploy-krypton\" \"cross-env NODE_ENV=test jest --config ./tests/jest.config.rosetta.js --no-cache --runInBand; npm run devenv:stop-krypton\"",


### PR DESCRIPTION
```
chore: add additional launch options for VSCode

chore: add integration test option to run API test suite
```

Use the following template to create your pull request

## Description

New launch option added for VSCode to automatically run the API with the testnet flag in place. This allows a user to run the backing docker containers separately
=
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @rafaelcr or @zone117x for review
