### PR TITLE
feat: migrate default postgres schema

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@ PG_PORT=5490
 PG_USER=postgres
 PG_PASSWORD=postgres
 PG_DATABASE=stacks_blockchain_api
-PG_SCHEMA=public
+PG_SCHEMA=stacks_blockchain_api
 PG_SSL=false
 # Idle connection timeout in seconds, defaults to 30
 # PG_IDLE_TIMEOUT=30

--- a/tests/event-replay/import-export.test.ts
+++ b/tests/event-replay/import-export.test.ts
@@ -7,7 +7,7 @@ import { exportEventsAsTsv, importEventsFromTsv } from '../../src/event-replay/e
 import { startEventServer } from '../../src/event-stream/event-server';
 import { httpPostRequest } from '../../src/helpers';
 import { useWithCleanup } from '../api/test-helpers';
-import { migrate } from '../utils/test-helpers';
+import { createSchema, migrate } from '../utils/test-helpers';
 import { PgSqlClient, dangerousDropAllTables, databaseHasData } from '@hirosystems/api-toolkit';
 import { getConnectionArgs } from '../../src/datastore/connection';
 
@@ -27,7 +27,9 @@ describe('import/export tests', () => {
   });
 
   test('event import and export cycle - remote', async () => {
+    const args = getConnectionArgs();
     // Import from mocknet TSV
+    await createSchema(args);
     await importEventsFromTsv('tests/event-replay/tsv/mocknet.tsv', 'archival', true, true);
     const chainTip = await db.getChainTip(db.sql);
     expect(chainTip.block_height).toBe(28);
@@ -60,7 +62,9 @@ describe('import/export tests', () => {
   });
 
   test('event import and export cycle - local', async () => {
+    const args = getConnectionArgs();
     // Import from mocknet TSV
+    await createSchema(args);
     await importEventsFromTsv('tests/event-replay/tsv/mocknet.tsv', 'archival', true, true);
     const chainTip = await db.getChainTip(db.sql);
     expect(chainTip.block_height).toBe(28);


### PR DESCRIPTION
- Migrate schema from public to stacks-blockchain-api. Permission to start migration requires affirmative consent from user

Closes #2373 

BREAKING CHANGE: This change can be made without a full rebuild from genesis. However, it is considered breaking in the interest of data safety

## Testing information

Testing is recommended. Ensure `PG_OLD_SCHEMA` matches the current schema name in your database. `PG_SCHEMA` is pre-set, but can be modified as the user wishes. **Uncomment `PG_MIGRATE_SCHEMA_ON_STARTUP`** (app will fail to start until this is set as a value to prevent accidental migration)

## Checklist
- [x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @rafaelcr or @zone117x for review
