### PR TITLE
ci: configure `next` branch releases

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,8 +7,8 @@
       "prerelease": true
     },
     {
-      "name": "nakamoto",
-      "channel": "nakamoto",
+      "name": "next",
+      "channel": "next",
       "prerelease": true
     }
   ],
@@ -44,7 +44,13 @@
         "pkgRoot": "./client"
       }
     ],
-    "@semantic-release/github",
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "draftRelease": true
+      }
+    ],
     "@semantic-release/changelog",
     "@semantic-release/git"
   ]


### PR DESCRIPTION
Configures the `next` branch to generate API prereleases (e.g. v9.0.0-next.1).

Also, changes the default `@semantic-release/github` behavior to not automatically publish releases but use drafts only instead, so we can:
1. Choose not to publish one when it's not necessary (like `next` or `beta`) to avoid confusing exchanges and other partners subscribed to the releases feed
2. Pre-edit the release contents with our rich markdown format before issuing the actual release

`@semantic-release/github` does not have a way to select which branches generate releases.