### PR TITLE
docs: fix typo 'subcribing' -> 'subscribing' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Join our community and stay connected with the latest updates and discussions:
 
 - [Join our Discord community chat](https://discord.gg/ZQR6cyZC) to engage with other users, ask questions, and participate in discussions.
 
-- [Visit hiro.so](https://www.hiro.so/) for updates and subcribing to the mailing list.
+- [Visit hiro.so](https://www.hiro.so/) for updates and subscribing to the mailing list.
 
 - Follow [Hiro on Twitter.](https://twitter.com/hirosystems)
 


### PR DESCRIPTION
Fixed a small typo in the Community section of [\chainsafe\web3.unity\tree\main\README.md](vscode-file://vscode-app/c:/Users/HomePC/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)