### PR TITLE
docs: comprehensive documentation and grammar improvements

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,10 +24,10 @@ managing this repository. At a glance, this means:
 ## I. Branch Naming Conventions
 
 - In addition to master and develop branches, these are the standards for features, fixes, chores and releases, 
-  1. **features** All feature branches must be created under **feat/**,
-  2. **bug-fixes** All fixes must be created under **fix/**,
-  3. **chores** Ad-hoc tasks that are not features, minor housekeeping, maintenance tasks should be created under **chores/**
-  4. Avoid branches being grouped under your usernames
+  1. **features**: All feature branches must be created under **feat/**.
+  2. **bug-fixes**: All fixes must be created under **fix/**.
+  3. **chores**: Ad-hoc tasks that are not features, minor housekeeping, maintenance tasks should be created under **chores/**.
+  4. Avoid branches being grouped under your usernames.
   
 ## II. Handling PRs
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -59,7 +59,7 @@ managing this repository. At a glance, this means:
   2. Ensure [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) are used in the PR. When properly annotated, the commit messages will automatically update the changelog.
   
 
-- If a PR fails to get a review from a second maintainer after a few days, the first maintainer should ping others for review. If it still lingers around for **over a week without a second maintainer’s approval**,the first maintainer can go ahead and merge it.
+- If a PR fails to get a review from a second maintainer after a few days, the first maintainer should ping others for review. If it still lingers around for **over a week without a second maintainer’s approval**, the first maintainer can go ahead and merge it.
 
 - If the only issues holding up a merge are **trivial fixes**
   (typos, syntax errors, etc.), and the author doesn't respond in a day or two,

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -54,7 +54,7 @@ managing this repository. At a glance, this means:
     - descriptive
     - sentence case
     - If instead the PR author took the time to craft individual, informative messages for each commit, then use the `Rebase and merge` method,to honor that work and preserve the history of the changes.
-    - For less clear-cut cases, a simple heuristic you can follow is that if there are more "dirty" commits than "clean" commits,then prefer squash, else do a rebase.
+    - For less clear-cut cases, a simple heuristic you can follow is that if there are more "dirty" commits than "clean" commits, then prefer squash, else do a rebase.
 
   2. Ensure [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) are used in the PR. When properly annotated, the commit messages will automatically update the changelog.
   

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ could be run:
 
 This version of the replay process relies on parquet files processing instead of TSV files.
 
-There are some improvements on the replay process and this version is is, around, 10x times faster than the previous (V1) one.
+There are some improvements on the replay process and this version is around 10x times faster than the previous (V1) one.
 
 __Note: the previous event-replay version is still available and can be used as well, for the same purpose.__
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Join our community and stay connected with the latest updates and discussions:
 
 - [Join our Discord community chat](https://discord.gg/ZQR6cyZC) to engage with other users, ask questions, and participate in discussions.
 
-- [Visit hiro.so](https://www.hiro.so/) for updates and subcribing to the mailing list.
+- [Visit hiro.so](https://www.hiro.so/) for updates and subscribing to the mailing list.
 
 - Follow [Hiro on Twitter.](https://twitter.com/hirosystems)
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Please **do not** use the issue tracker for personal support requests or to ask 
 Development of this product happens in the open on GitHub, and we are grateful to the community for contributing bug fixes and improvements. Read below to learn how you can take part in improving the product.
 
 ### Code of Conduct
-Please read our [Code of Conduct](../../../.github/blob/main/CODE_OF_CONDUCT.md) since we expect project participants to adhere to it.
+Please read our [Code of Conduct](https://github.com/hirosystems/.github/blob/main/CODE_OF_CONDUCT.md) since we expect project participants to adhere to it.
 
 ### Contributing Guide
 

--- a/overview.md
+++ b/overview.md
@@ -1,6 +1,6 @@
 ![API architecture!](api-architecture.png)
 
-* The `stacks-node` has it's own minimal set of http endpoints referred to as `RPC endpoints`
+* The `stacks-node` has its own minimal set of http endpoints referred to as `RPC endpoints`
   * The `stacks-blockchain-api` allows clients to access these endpoints by proxying them through to a load-balanced pool of `stacks-nodes`.
   * See: https://github.com/blockstack/stacks-blockchain/blob/master/docs/rpc-endpoints.md -- some common ones:
     * `POST /v2/transactions` - broadcast a tx.

--- a/running_an_api.md
+++ b/running_an_api.md
@@ -14,8 +14,8 @@ Please note that the following guide is meant for a Unix-like OS (Linux/MacOS) -
     - [Starting postgres](#starting-postgres)
     - [Stopping Postgres](#stopping-postgres)
   - [Stacks Blockchain API](#stacks-blockchain-api)
-    - [Starting stacks-blockchain-api](#starting-stacks-blockchain-api)
-    - [Stopping stacks-blockchain-api](#stopping-stacks-blockchain-api)
+    - [Starting Stacks Blockchain API](#starting-stacks-blockchain-api)
+    - [Stopping Stacks Blockchain API](#stopping-stacks-blockchain-api)
   - [Stacks Blockchain](#stacks-blockchain)
     - [Starting stacks-blockchain](#starting-stacks-blockchain)
     - [Stopping stacks-blockchain](#stopping-stacks-blockchain)
@@ -150,7 +150,7 @@ The other Environment Variables to pay attention to:
 - `STACKS_CORE_RPC_HOST`: Set this to your **stacks blockchain** node. In this guide, we'll be using a container named `stacks-blockchain`.
 - `API_DOCS_URL`: Set this to enable your docs API http://localhost:3999/doc.
 
-### Starting stacks-blockchain-api
+### Starting Stacks Blockchain API
 
 ```bash
 docker run -d --rm \
@@ -172,7 +172,7 @@ a86a26da6c5a   blockstack/stacks-blockchain-api   "docker-entrypoint.s…"   1 m
 
 **Note**: on initial sync, it will take several minutes for port `3999` to become available.
 
-### Stopping stacks-blockchain-api
+### Stopping Stacks Blockchain API
 
 To stop the stacks-blockchain-api service (this will also remove the container):
 

--- a/running_an_api.md
+++ b/running_an_api.md
@@ -3,7 +3,7 @@
 In this document, we'll go over how to run a [stacks-blockchain-api](https://github.com/hirosystems/stacks-blockchain-api) instance.  
 There are several components involved here to have a working setup, and we'll go over each.  
 We'll focus on the **easy** path to get the services running, which today is using Docker.  
-Please note that the following guide is meant for a Unix-like OS (Linux/MacOS) - the commands *may* work on Windows but will likely need some adjustments (PR's welcome!).
+Please note that the following guide is meant for a Unix-like OS (Linux/MacOS) - the commands *may* work on Windows but will likely need some adjustments (PRs welcome!).
 
 - [Running a stacks-blockchain API instance with Docker](#running-a-stacks-blockchain-api-instance-with-docker)
   - [Requirements](#requirements)

--- a/running_api_from_source.md
+++ b/running_api_from_source.md
@@ -2,7 +2,7 @@
 
 In this document, we'll go over how to run a [stacks-blockchain-api](https://github.com/hirosystems/stacks-blockchain-api) instance.  
 There are several components involved here to have a working setup, and we'll go over each.  
-Please note that the following guide is targeted for Debian based systems - that in mind, most of the commands will work on other Unix systems with some small adjustments.
+Please note that the following guide is targeted for Debian based systems. With that in mind, most of the commands will work on other Unix systems with some small adjustments.
 
 - [Running a stacks-blockchain API instance from source](#running-a-stacks-blockchain-api-instance-from-source)
   - [Requirements](#requirements)


### PR DESCRIPTION
### Description

I've been going through the documentation and found several small issues to tidy up:

- **README.md**: Fixed "subscribing" typo, broken CoC link, and "is is" grammar.
- **overview.md**: Fixed "it's" -> "its" possessive grammar.
- **MAINTAINERS.md**: Standardized list formatting and fixed missing spaces.
- **running_an_api.md**: Fixed "PR's" typo and capitalized section titles for consistency.
- **running_api_from_source.md**: Smoothed out grammar in the intro.

Small quality-of-life improvements for readers!

### Checklist

- [x] Documentation updated