### PR TITLE
feat: add new endpoint `/extended/v2/smart-contracts/:contract_id/print-events`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,13 +8,12 @@
       "type": "node",
       "request": "launch",
       "name": "start: api",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register"],
+      "runtimeArgs": ["--import", "tsx"],
       "args": ["${workspaceFolder}/src/index.ts"],
       "outputCapture": "std",
       "internalConsoleOptions": "openOnSessionStart",
       "env": {
-        "NODE_ENV": "development",
-        "TS_NODE_SKIP_IGNORE": "true"
+        "NODE_ENV": "development"
       }
     },
     {
@@ -24,7 +23,7 @@
       "skipFiles": [
         "<node_internals>/**"
       ],
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register"],
+      "runtimeArgs": ["--import", "tsx"],
       "args": ["${workspaceFolder}/src/index.ts"],
       "outputCapture": "std",
       "internalConsoleOptions": "openOnSessionStart",
@@ -32,8 +31,7 @@
       "postDebugTask": "npm: testenv:stop",
       "env": {
         "STACKS_CHAIN_ID": "0x80000000",
-        "NODE_ENV": "development",
-        "TS_NODE_SKIP_IGNORE": "true"
+        "NODE_ENV": "development"
       },
       "killBehavior": "polite",
     },
@@ -44,7 +42,7 @@
       "skipFiles": [
         "<node_internals>/**"
       ],
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register"],
+      "runtimeArgs": ["--import", "tsx"],
       "args": ["${workspaceFolder}/src/index.ts"],
       "outputCapture": "std",
       "internalConsoleOptions": "openOnSessionStart",
@@ -53,8 +51,7 @@
       "env": {
         "STACKS_API_MODE": "writeonly",
         "STACKS_CHAIN_ID": "0x80000000",
-        "NODE_ENV": "development",
-        "TS_NODE_SKIP_IGNORE": "true"
+        "NODE_ENV": "development"
       },
       "killBehavior": "polite",
     },
@@ -65,12 +62,7 @@
       "skipFiles": [
         "<node_internals>/**"
       ],
-      "runtimeArgs": [
-        "-r",
-        "ts-node/register/transpile-only",
-        "-r",
-        "tsconfig-paths/register"
-      ],
+      "runtimeArgs": ["--import", "tsx"],
       "args": [
         "${workspaceFolder}/src/index.ts"
       ],
@@ -80,8 +72,7 @@
         "STACKS_BLOCKCHAIN_API_PORT": "3998",
         "STACKS_API_MODE": "readonly",
         "STACKS_CHAIN_ID": "0x00000001",
-        "NODE_ENV": "production",
-        "TS_NODE_SKIP_IGNORE": "true"
+        "NODE_ENV": "production"
       },
       "killBehavior": "polite",
     },
@@ -96,7 +87,6 @@
         "--test",
         "--test-global-setup=./tests/api/setup.ts",
         "--test-concurrency=1",
-        // "--test-name-pattern", "websocket notifications",
         "./tests/api/**/*.test.ts"
       ],
       "outputCapture": "std",
@@ -135,7 +125,6 @@
         "--test",
         "--test-global-setup=./tests/snp/setup.ts",
         "--test-concurrency=1",
-        // "--test-name-pattern", "websocket notifications",
         "./tests/snp/**/*.test.ts"
       ],
       "outputCapture": "std",

--- a/migrations/1774500000000_contract-log-counts.ts
+++ b/migrations/1774500000000_contract-log-counts.ts
@@ -1,0 +1,24 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+export const up = (pgm: MigrationBuilder) => {
+  pgm.createTable('contract_log_counts', {
+    contract_identifier: {
+      type: 'text',
+      notNull: true,
+      primaryKey: true,
+    },
+    count: {
+      type: 'integer',
+      notNull: true,
+      default: 0,
+    },
+  });
+  pgm.sql(`
+    INSERT INTO contract_log_counts (contract_identifier, count)
+    (SELECT contract_identifier, COUNT(*) AS count FROM contract_logs WHERE canonical = true AND microblock_canonical = true GROUP BY contract_identifier)
+  `);
+};
+
+export const down = (pgm: MigrationBuilder) => {
+  pgm.dropTable('contract_log_counts');
+};

--- a/src/api/routes/contract.ts
+++ b/src/api/routes/contract.ts
@@ -1,7 +1,6 @@
 import { getPagingQueryLimit, parsePagingQueryInput, ResourceType } from '../pagination.js';
 import { parseDbEvent } from '../controllers/db-controller.js';
 import { handleChainTipCache } from '../controllers/cache-controller.js';
-
 import { FastifyPluginAsync } from 'fastify';
 import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Server } from 'node:http';
@@ -101,9 +100,11 @@ export const ContractRoutes: FastifyPluginAsync<
     {
       preHandler: handleChainTipCache,
       schema: {
+        deprecated: true,
         operationId: 'get_contract_events_by_id',
         summary: 'Get contract events',
-        description: 'Retrieves a list of events that have been triggered by a given `contract_id`',
+        description:
+          '**NOTE:** This endpoint is deprecated in favor of `get_smart_contract_print_events`.\n\nRetrieves a list of events that have been triggered by a given `contract_id`',
         tags: ['Smart Contracts'],
         params: Type.Object({
           contract_id: Type.String({

--- a/src/api/routes/v2/schemas.ts
+++ b/src/api/routes/v2/schemas.ts
@@ -57,6 +57,31 @@ export const BlockCursorParamSchema = Type.String({
   description: 'Cursor for block pagination',
 });
 
+export const TransactionEventCursorParamSchema = Type.String({
+  pattern: '^[0-9]+:[0-9]+:[0-9]+:[0-9]+$',
+  description:
+    'Cursor for transaction event pagination (block_height:microblock_sequence:tx_index:event_index)',
+});
+
+export function parseEventCursor(cursor: string): {
+  block_height: number;
+  microblock_sequence: number;
+  tx_index: number;
+  event_index: number;
+} {
+  const [block_height, microblock_sequence, tx_index, event_index] = cursor.split(':').map(Number);
+  return { block_height, microblock_sequence, tx_index, event_index };
+}
+
+export function buildEventCursor(row: {
+  block_height: number;
+  microblock_sequence: number;
+  tx_index: number;
+  event_index: number;
+}): string {
+  return `${row.block_height}:${row.microblock_sequence}:${row.tx_index}:${row.event_index}`;
+}
+
 export type BlockIdParam =
   | { type: 'height'; height: number }
   | { type: 'hash'; hash: string }

--- a/src/api/routes/v2/smart-contracts.ts
+++ b/src/api/routes/v2/smart-contracts.ts
@@ -1,10 +1,16 @@
 import { handleChainTipCache } from '../../controllers/cache-controller.js';
-import { SmartContractStatusParamsSchema } from './schemas.js';
+import { SmartContractStatusParamsSchema, TransactionEventCursorParamSchema } from './schemas.js';
 import { parseDbSmartContractStatusArray } from './helpers.js';
 import { FastifyPluginAsync } from 'fastify';
-import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Server } from 'node:http';
 import { SmartContractStatusListSchema } from '../../schemas/entities/smart-contracts.js';
+import { SmartContractLogEventListResponseSchema } from '../../schemas/responses/responses.js';
+import { CursorOffsetParam, LimitParam } from '../../schemas/params.js';
+import { getPagingQueryLimit, ResourceType } from '../../pagination.js';
+import { NotFoundError } from '../../../errors.js';
+import { SmartContractLogTransactionEvent } from '../../schemas/entities/transaction-events.js';
+import codec from '@stacks/codec';
 
 export const SmartContractRoutesV2: FastifyPluginAsync<
   Record<never, never>,
@@ -31,6 +37,70 @@ export const SmartContractRoutesV2: FastifyPluginAsync<
       const result = await fastify.db.v2.getSmartContractStatus(query);
       const resultArray = parseDbSmartContractStatusArray(query, result);
       await reply.send(resultArray);
+    }
+  );
+
+  fastify.get(
+    '/:contract_id/print-events',
+    {
+      preHandler: handleChainTipCache,
+      schema: {
+        operationId: 'get_smart_contract_print_events',
+        summary: 'Get smart contract print events',
+        description: `Retrieves print events (contract log events) for a given smart contract.`,
+        tags: ['Smart Contracts'],
+        params: Type.Object({
+          contract_id: Type.String({
+            description: 'Contract identifier formatted as `<contract_address>.<contract_name>`',
+            examples: ['SP000000000000000000002Q6VF78.pox-3'],
+          }),
+        }),
+        querystring: Type.Object({
+          limit: LimitParam(ResourceType.Event),
+          offset: CursorOffsetParam({ resource: ResourceType.Event }),
+          cursor: Type.Optional(TransactionEventCursorParamSchema),
+        }),
+        response: {
+          200: SmartContractLogEventListResponseSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const limit = getPagingQueryLimit(ResourceType.Event, req.query.limit);
+      const eventQuery = await fastify.db.v2.getSmartContractEvents({
+        contractId: req.params.contract_id,
+        limit,
+        offset: req.query.offset,
+        cursor: req.query.cursor,
+      });
+      if (req.query.cursor && !eventQuery.current_cursor) {
+        throw new NotFoundError('Cursor not found');
+      }
+      const events: SmartContractLogTransactionEvent[] = eventQuery.results.map(r => {
+        const parsedClarityValue = codec.decodeClarityValueToRepr(r.value);
+        return {
+          event_index: r.event_index,
+          event_type: 'smart_contract_log' as const,
+          tx_id: r.tx_id,
+          contract_log: {
+            contract_id: r.contract_identifier,
+            topic: r.topic,
+            value: {
+              hex: r.value,
+              repr: parsedClarityValue,
+            },
+          },
+        };
+      });
+      await reply.send({
+        limit: eventQuery.limit,
+        offset: eventQuery.offset,
+        total: eventQuery.total,
+        next_cursor: eventQuery.next_cursor,
+        prev_cursor: eventQuery.prev_cursor,
+        cursor: eventQuery.current_cursor,
+        results: events,
+      });
     }
   );
 

--- a/src/api/schemas/entities/transaction-events.ts
+++ b/src/api/schemas/entities/transaction-events.ts
@@ -24,7 +24,7 @@ const AbstractTransactionEventSchema = Type.Object(
   }
 );
 
-const SmartContractLogTransactionEventSchema = Type.Intersect(
+export const SmartContractLogTransactionEventSchema = Type.Intersect(
   [
     AbstractTransactionEventSchema,
     Type.Object({

--- a/src/api/schemas/responses/responses.ts
+++ b/src/api/schemas/responses/responses.ts
@@ -7,7 +7,10 @@ import {
   AddressTransactionWithTransfersSchema,
   InboundStxTransferSchema,
 } from '../entities/addresses.js';
-import { TransactionEventSchema } from '../entities/transaction-events.js';
+import {
+  SmartContractLogTransactionEventSchema,
+  TransactionEventSchema,
+} from '../entities/transaction-events.js';
 import {
   BurnchainRewardSchema,
   BurnchainRewardSlotHolderSchema,
@@ -183,6 +186,13 @@ export type RunFaucetResponse = Static<typeof RunFaucetResponseSchema>;
 
 export const BlockListV2ResponseSchema = PaginatedCursorResponse(NakamotoBlockSchema);
 export type BlockListV2Response = Static<typeof BlockListV2ResponseSchema>;
+
+export const SmartContractLogEventListResponseSchema = PaginatedCursorResponse(
+  SmartContractLogTransactionEventSchema
+);
+export type SmartContractLogEventListResponse = Static<
+  typeof SmartContractLogEventListResponseSchema
+>;
 
 export const BlockSignerSignatureResponseSchema = PaginatedResponse(SignerSignatureSchema);
 export type BlockSignerSignatureResponse = Static<typeof BlockSignerSignatureResponseSchema>;

--- a/src/datastore/pg-store-v2.ts
+++ b/src/datastore/pg-store-v2.ts
@@ -11,6 +11,8 @@ import {
   PoxSignerLimitParamSchema,
   BlockIdParam,
   BlockSignerSignatureLimitParamSchema,
+  parseEventCursor,
+  buildEventCursor,
 } from '../api/routes/v2/schemas.js';
 import { InvalidRequestError, InvalidRequestErrorType } from '../errors.js';
 import { FoundOrNot, normalizeHashString } from '../helpers.js';
@@ -34,6 +36,7 @@ import {
   DbCursorPaginatedResult,
   PoxSyntheticEventQueryResult,
   DbBurnBlockPoxTx,
+  DbSmartContractEvent,
 } from './common.js';
 import {
   BLOCK_COLUMNS,
@@ -1225,5 +1228,181 @@ export class PgStoreV2 extends BasePgStoreModule {
       burnchainLockHeight,
       burnchainUnlockHeight,
     };
+  }
+
+  async getSmartContractEvents(args: {
+    contractId: string;
+    limit: number;
+    offset?: number;
+    cursor?: string;
+  }): Promise<DbCursorPaginatedResult<DbSmartContractEvent>> {
+    return await this.sqlTransaction(async sql => {
+      const limit = args.limit;
+      const offset = args.offset ?? 0;
+      const contractId = args.contractId;
+
+      // Resolve cursor components or default to the latest event for this contract
+      let cursorValues: {
+        block_height: number;
+        microblock_sequence: number;
+        tx_index: number;
+        event_index: number;
+      } | null = null;
+      if (args.cursor) {
+        cursorValues = parseEventCursor(args.cursor);
+      }
+
+      const orderCols = sql`block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC`;
+      const canonicalFilter = sql`canonical = true AND microblock_canonical = true AND contract_identifier = ${contractId}`;
+
+      const cursorFilter = cursorValues
+        ? sql`AND (block_height, microblock_sequence, tx_index, event_index) <= (${cursorValues.block_height}, ${cursorValues.microblock_sequence}, ${cursorValues.tx_index}, ${cursorValues.event_index})`
+        : sql``;
+
+      type EventRow = {
+        event_index: number;
+        tx_id: string;
+        tx_index: number;
+        block_height: number;
+        microblock_sequence: number;
+        canonical: boolean;
+        contract_identifier: string;
+        topic: string;
+        value: string;
+        total: number;
+        next_block_height: number | null;
+        next_microblock_sequence: number | null;
+        next_tx_index: number | null;
+        next_event_index: number | null;
+        prev_block_height: number | null;
+        prev_microblock_sequence: number | null;
+        prev_tx_index: number | null;
+        prev_event_index: number | null;
+      };
+
+      const eventsQuery = await sql<EventRow[]>`
+        WITH cursor_event AS (
+          SELECT block_height, microblock_sequence, tx_index, event_index
+          FROM contract_logs
+          WHERE ${canonicalFilter} ${cursorFilter}
+          ORDER BY ${orderCols}
+          OFFSET ${offset}
+          LIMIT 1
+        ),
+        selected_events AS (
+          SELECT event_index, tx_id, tx_index, block_height, microblock_sequence,
+                 canonical, contract_identifier, topic, value
+          FROM contract_logs
+          WHERE ${canonicalFilter}
+            AND (block_height, microblock_sequence, tx_index, event_index) <= (
+              SELECT block_height, microblock_sequence, tx_index, event_index FROM cursor_event
+            )
+          ORDER BY ${orderCols}
+          LIMIT ${limit}
+        ),
+        top_of_page AS (
+          SELECT block_height, microblock_sequence, tx_index, event_index
+          FROM selected_events
+          ORDER BY ${orderCols}
+          LIMIT 1
+        ),
+        next_page AS (
+          SELECT block_height, microblock_sequence, tx_index, event_index
+          FROM contract_logs
+          WHERE ${canonicalFilter}
+            AND (block_height, microblock_sequence, tx_index, event_index) > (
+              SELECT block_height, microblock_sequence, tx_index, event_index FROM top_of_page
+            )
+          ORDER BY block_height ASC, microblock_sequence ASC, tx_index ASC, event_index ASC
+          OFFSET ${limit - 1}
+          LIMIT 1
+        ),
+        prev_page AS (
+          SELECT block_height, microblock_sequence, tx_index, event_index
+          FROM contract_logs
+          WHERE ${canonicalFilter}
+            AND (block_height, microblock_sequence, tx_index, event_index) < (
+              SELECT block_height, microblock_sequence, tx_index, event_index FROM top_of_page
+            )
+          ORDER BY ${orderCols}
+          OFFSET ${limit - 1}
+          LIMIT 1
+        ),
+        event_count AS (
+          SELECT COALESCE(count, 0)::int AS total
+          FROM contract_log_counts
+          WHERE contract_identifier = ${contractId}
+        )
+        SELECT
+          (SELECT total FROM event_count) AS total,
+          se.*,
+          np.block_height AS next_block_height,
+          np.microblock_sequence AS next_microblock_sequence,
+          np.tx_index AS next_tx_index,
+          np.event_index AS next_event_index,
+          pp.block_height AS prev_block_height,
+          pp.microblock_sequence AS prev_microblock_sequence,
+          pp.tx_index AS prev_tx_index,
+          pp.event_index AS prev_event_index
+        FROM selected_events se
+        LEFT JOIN next_page np ON true
+        LEFT JOIN prev_page pp ON true
+        ORDER BY se.block_height DESC, se.microblock_sequence DESC, se.tx_index DESC, se.event_index DESC
+      `;
+
+      const events: DbSmartContractEvent[] = eventsQuery.map(r => ({
+        event_index: r.event_index,
+        tx_id: r.tx_id,
+        tx_index: r.tx_index,
+        block_height: r.block_height,
+        canonical: r.canonical,
+        event_type: DbEventTypeId.SmartContractLog,
+        contract_identifier: r.contract_identifier,
+        topic: r.topic,
+        value: r.value,
+      }));
+
+      const total = eventsQuery[0]?.total ?? 0;
+
+      const nextCursor =
+        eventsQuery[0]?.next_block_height != null
+          ? buildEventCursor({
+              block_height: eventsQuery[0].next_block_height,
+              microblock_sequence: eventsQuery[0].next_microblock_sequence!,
+              tx_index: eventsQuery[0].next_tx_index!,
+              event_index: eventsQuery[0].next_event_index!,
+            })
+          : null;
+
+      const prevCursor =
+        eventsQuery[0]?.prev_block_height != null
+          ? buildEventCursor({
+              block_height: eventsQuery[0].prev_block_height,
+              microblock_sequence: eventsQuery[0].prev_microblock_sequence!,
+              tx_index: eventsQuery[0].prev_tx_index!,
+              event_index: eventsQuery[0].prev_event_index!,
+            })
+          : null;
+
+      const firstRow = eventsQuery[0];
+      const currentCursor = firstRow
+        ? buildEventCursor({
+            block_height: firstRow.block_height,
+            microblock_sequence: firstRow.microblock_sequence,
+            tx_index: firstRow.tx_index,
+            event_index: firstRow.event_index,
+          })
+        : null;
+
+      return {
+        limit,
+        offset,
+        results: events,
+        total,
+        next_cursor: nextCursor,
+        prev_cursor: prevCursor,
+        current_cursor: currentCursor,
+      };
+    });
   }
 }

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -1824,6 +1824,19 @@ export class PgWriteStore extends PgStore {
       `;
       assert(res.count === batch.length, `Expecting ${batch.length} inserts, got ${res.count}`);
     }
+    // Update contract_log_counts
+    const countDeltas = new Map<string, number>();
+    for (const v of values) {
+      countDeltas.set(v.contract_identifier, (countDeltas.get(v.contract_identifier) ?? 0) + 1);
+    }
+    for (const [contractId, count] of countDeltas) {
+      await sql`
+        INSERT INTO contract_log_counts (contract_identifier, count)
+        VALUES (${contractId}, ${count})
+        ON CONFLICT (contract_identifier)
+        DO UPDATE SET count = contract_log_counts.count + EXCLUDED.count
+      `;
+    }
   }
 
   async updateSmartContractEvent(sql: PgSqlClient, tx: DbTx, event: DbSmartContractEvent) {
@@ -1844,6 +1857,13 @@ export class PgWriteStore extends PgStore {
     };
     await sql`
       INSERT INTO contract_logs ${sql(values)}
+    `;
+    // Update contract_log_counts
+    await sql`
+      INSERT INTO contract_log_counts (contract_identifier, count)
+      VALUES (${event.contract_identifier}, 1)
+      ON CONFLICT (contract_identifier)
+      DO UPDATE SET count = contract_log_counts.count + 1
     `;
   }
 
@@ -3629,15 +3649,27 @@ export class PgWriteStore extends PgStore {
       }
     });
     q.enqueue(async () => {
-      const contractLogResult = await sql`
-        UPDATE contract_logs
-        SET canonical = ${canonical}
-        WHERE index_block_hash = ${indexBlockHash} AND canonical != ${canonical}
+      const contractLogResult = await sql<{ contract_identifier: string; delta: number }[]>`
+        WITH updated AS (
+          UPDATE contract_logs
+          SET canonical = ${canonical}
+          WHERE index_block_hash = ${indexBlockHash} AND canonical != ${canonical}
+          RETURNING contract_identifier
+        )
+        SELECT contract_identifier, COUNT(*)::int AS delta FROM updated GROUP BY contract_identifier
       `;
+      for (const row of contractLogResult) {
+        await sql`
+          UPDATE contract_log_counts
+          SET count = count + ${canonical ? row.delta : -row.delta}
+          WHERE contract_identifier = ${row.contract_identifier}
+        `;
+      }
+      const totalCount = contractLogResult.reduce((sum, r) => sum + r.delta, 0);
       if (canonical) {
-        updatedEntities.markedCanonical.contractLogs += contractLogResult.count;
+        updatedEntities.markedCanonical.contractLogs += totalCount;
       } else {
-        updatedEntities.markedNonCanonical.contractLogs += contractLogResult.count;
+        updatedEntities.markedNonCanonical.contractLogs += totalCount;
       }
     });
     q.enqueue(async () => {

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -1824,10 +1824,12 @@ export class PgWriteStore extends PgStore {
       `;
       assert(res.count === batch.length, `Expecting ${batch.length} inserts, got ${res.count}`);
     }
-    // Update contract_log_counts
+    // Update contract_log_counts (only for canonical events)
     const countDeltas = new Map<string, number>();
     for (const v of values) {
-      countDeltas.set(v.contract_identifier, (countDeltas.get(v.contract_identifier) ?? 0) + 1);
+      if (v.canonical) {
+        countDeltas.set(v.contract_identifier, (countDeltas.get(v.contract_identifier) ?? 0) + 1);
+      }
     }
     for (const [contractId, count] of countDeltas) {
       await sql`
@@ -1858,13 +1860,15 @@ export class PgWriteStore extends PgStore {
     await sql`
       INSERT INTO contract_logs ${sql(values)}
     `;
-    // Update contract_log_counts
-    await sql`
-      INSERT INTO contract_log_counts (contract_identifier, count)
-      VALUES (${event.contract_identifier}, 1)
-      ON CONFLICT (contract_identifier)
-      DO UPDATE SET count = contract_log_counts.count + 1
-    `;
+    // Update contract_log_counts (only for canonical events)
+    if (event.canonical) {
+      await sql`
+        INSERT INTO contract_log_counts (contract_identifier, count)
+        VALUES (${event.contract_identifier}, 1)
+        ON CONFLICT (contract_identifier)
+        DO UPDATE SET count = contract_log_counts.count + 1
+      `;
+    }
   }
 
   async updatePoxSetsBatch(sql: PgSqlClient, block: DbBlock, poxSet: DbPoxSetSigners) {

--- a/tests/api/smart-contracts/print-events.test.ts
+++ b/tests/api/smart-contracts/print-events.test.ts
@@ -1,0 +1,289 @@
+import supertest from 'supertest';
+import { startApiServer, ApiServer } from '../../../src/api/init.ts';
+import { PgWriteStore } from '../../../src/datastore/pg-write-store.ts';
+import { PgSqlClient } from '@stacks/api-toolkit';
+import { migrate } from '../../test-helpers.ts';
+import { TestBlockBuilder } from '../test-builders.ts';
+import { beforeEach, afterEach, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { STACKS_TESTNET } from '@stacks/network';
+
+const CONTRACT_ID = 'SP000000000000000000002Q6VF78.pox-3';
+
+describe('smart contract print events v2', () => {
+  let db: PgWriteStore;
+  let client: PgSqlClient;
+  let api: ApiServer;
+
+  beforeEach(async () => {
+    await migrate('up');
+    db = await PgWriteStore.connect({
+      usageName: 'tests',
+      withNotifier: true,
+      skipMigrations: true,
+    });
+    client = db.sql;
+    api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
+  });
+
+  afterEach(async () => {
+    await api.terminate();
+    await db?.close();
+    await migrate('down');
+  });
+
+  test('returns empty results for contract with no events', async () => {
+    // Create a block with no contract log events
+    const block = new TestBlockBuilder({
+      block_height: 1,
+      index_block_hash: '0x' + '01'.padStart(64, '0'),
+    })
+      .addTx()
+      .build();
+    await db.update(block);
+
+    const { body } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events`
+    );
+    assert.equal(body.total, 0);
+    assert.equal(body.results.length, 0);
+    assert.equal(body.cursor, null);
+    assert.equal(body.next_cursor, null);
+    assert.equal(body.prev_cursor, null);
+  });
+
+  test('returns contract log events with correct shape', async () => {
+    const block = new TestBlockBuilder({
+      block_height: 1,
+      index_block_hash: '0x' + '01'.padStart(64, '0'),
+    })
+      .addTx({ tx_id: '0x' + 'aa'.padStart(64, '0') })
+      .addTxContractLogEvent({ contract_identifier: CONTRACT_ID, topic: 'print' })
+      .build();
+    await db.update(block);
+
+    const { body } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events`
+    );
+    assert.equal(body.total, 1);
+    assert.equal(body.results.length, 1);
+    const event = body.results[0];
+    assert.equal(event.event_type, 'smart_contract_log');
+    assert.equal(event.tx_id, '0x' + 'aa'.padStart(64, '0'));
+    assert.equal(event.contract_log.contract_id, CONTRACT_ID);
+    assert.equal(event.contract_log.topic, 'print');
+    assert.ok(event.contract_log.value.hex);
+    assert.ok(event.contract_log.value.repr);
+    assert.equal(typeof event.event_index, 'number');
+  });
+
+  test('cursor pagination forward and backward', async () => {
+    // Create 7 events across 3 blocks to test pagination
+    for (let i = 1; i <= 3; i++) {
+      const builder = new TestBlockBuilder({
+        block_height: i,
+        index_block_hash: `0x${i.toString().padStart(64, '0')}`,
+        parent_index_block_hash: `0x${(i - 1).toString().padStart(64, '0')}`,
+      }).addTx({ tx_id: `0x${(i * 10).toString().padStart(64, '0')}` });
+
+      // Add 2 events per block (except block 3 gets 3)
+      const eventCount = i === 3 ? 3 : 2;
+      for (let j = 0; j < eventCount; j++) {
+        builder.addTxContractLogEvent({
+          contract_identifier: CONTRACT_ID,
+          topic: 'print',
+        });
+      }
+      await db.update(builder.build());
+    }
+
+    // Total should be 7 events
+    const { body: firstPage } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events?limit=3`
+    );
+    assert.equal(firstPage.total, 7);
+    assert.equal(firstPage.results.length, 3);
+    assert.equal(firstPage.limit, 3);
+    assert.equal(firstPage.offset, 0);
+    assert.notEqual(firstPage.cursor, null);
+    // Latest events should be from block 3 (highest block_height)
+    assert.equal(firstPage.results[0].contract_log.contract_id, CONTRACT_ID);
+    // At the latest page, there's no next_cursor
+    assert.equal(firstPage.next_cursor, null);
+    // But there should be a prev_cursor to go to older events
+    assert.notEqual(firstPage.prev_cursor, null);
+
+    // Navigate to previous page (older events)
+    const { body: secondPage } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events?limit=3&cursor=${firstPage.prev_cursor}`
+    );
+    assert.equal(secondPage.results.length, 3);
+    assert.notEqual(secondPage.next_cursor, null);
+    assert.notEqual(secondPage.prev_cursor, null);
+
+    // Navigate to the oldest page
+    const { body: thirdPage } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events?limit=3&cursor=${secondPage.prev_cursor}`
+    );
+    assert.equal(thirdPage.results.length, 1);
+    // Oldest page has no prev_cursor
+    assert.equal(thirdPage.prev_cursor, null);
+    // But should have next_cursor to go back to newer events
+    assert.notEqual(thirdPage.next_cursor, null);
+
+    // Navigate back to the second page using next_cursor
+    const { body: backToSecond } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events?limit=3&cursor=${thirdPage.next_cursor}`
+    );
+    assert.equal(backToSecond.results.length, 3);
+    assert.equal(backToSecond.cursor, secondPage.cursor);
+  });
+
+  test('cursor with same cursor returns same page', async () => {
+    for (let i = 1; i <= 5; i++) {
+      const block = new TestBlockBuilder({
+        block_height: i,
+        index_block_hash: `0x${i.toString().padStart(64, '0')}`,
+        parent_index_block_hash: `0x${(i - 1).toString().padStart(64, '0')}`,
+      })
+        .addTx({ tx_id: `0x${(i * 10).toString().padStart(64, '0')}` })
+        .addTxContractLogEvent({ contract_identifier: CONTRACT_ID, topic: 'print' })
+        .build();
+      await db.update(block);
+    }
+
+    const { body: page1 } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events?limit=2`
+    );
+    assert.equal(page1.results.length, 2);
+    assert.notEqual(page1.cursor, null);
+
+    // Fetching with the same cursor should return the same page
+    const { body: page1Again } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events?limit=2&cursor=${page1.cursor}`
+    );
+    assert.equal(page1Again.cursor, page1.cursor);
+    assert.equal(page1Again.results.length, page1.results.length);
+    assert.deepEqual(page1Again.results, page1.results);
+  });
+
+  test('high cursor returns latest events', async () => {
+    const block = new TestBlockBuilder({
+      block_height: 1,
+      index_block_hash: '0x' + '01'.padStart(64, '0'),
+    })
+      .addTx()
+      .addTxContractLogEvent({ contract_identifier: CONTRACT_ID })
+      .build();
+    await db.update(block);
+
+    // A cursor far in the future just returns the latest events
+    const { body } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events?cursor=999999:0:0:0`
+    );
+    assert.equal(body.total, 1);
+    assert.equal(body.results.length, 1);
+  });
+
+  test('events are ordered newest first', async () => {
+    for (let i = 1; i <= 3; i++) {
+      const block = new TestBlockBuilder({
+        block_height: i,
+        index_block_hash: `0x${i.toString().padStart(64, '0')}`,
+        parent_index_block_hash: `0x${(i - 1).toString().padStart(64, '0')}`,
+      })
+        .addTx({ tx_id: `0x${(i * 10).toString().padStart(64, '0')}` })
+        .addTxContractLogEvent({ contract_identifier: CONTRACT_ID, topic: 'print' })
+        .build();
+      await db.update(block);
+    }
+
+    const { body } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events?limit=10`
+    );
+    assert.equal(body.results.length, 3);
+    // Results should be in descending order (newest first)
+    // Block 3 tx should come first
+    assert.equal(body.results[0].tx_id, `0x${(30).toString().padStart(64, '0')}`);
+    assert.equal(body.results[1].tx_id, `0x${(20).toString().padStart(64, '0')}`);
+    assert.equal(body.results[2].tx_id, `0x${(10).toString().padStart(64, '0')}`);
+  });
+
+  test('only returns events for the specified contract', async () => {
+    const otherContract = 'SP000000000000000000002Q6VF78.other-contract';
+
+    const block = new TestBlockBuilder({
+      block_height: 1,
+      index_block_hash: '0x' + '01'.padStart(64, '0'),
+    })
+      .addTx({ tx_id: '0x' + 'aa'.padStart(64, '0') })
+      .addTxContractLogEvent({ contract_identifier: CONTRACT_ID, topic: 'print' })
+      .addTxContractLogEvent({ contract_identifier: otherContract, topic: 'print' })
+      .addTxContractLogEvent({ contract_identifier: CONTRACT_ID, topic: 'print' })
+      .build();
+    await db.update(block);
+
+    const { body } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events`
+    );
+    assert.equal(body.total, 2);
+    assert.equal(body.results.length, 2);
+    for (const event of body.results) {
+      assert.equal(event.contract_log.contract_id, CONTRACT_ID);
+    }
+
+    const { body: otherBody } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${otherContract}/print-events`
+    );
+    assert.equal(otherBody.total, 1);
+    assert.equal(otherBody.results.length, 1);
+    assert.equal(otherBody.results[0].contract_log.contract_id, otherContract);
+  });
+
+  test('respects limit parameter', async () => {
+    const block = new TestBlockBuilder({
+      block_height: 1,
+      index_block_hash: '0x' + '01'.padStart(64, '0'),
+    })
+      .addTx({ tx_id: '0x' + 'aa'.padStart(64, '0') })
+      .addTxContractLogEvent({ contract_identifier: CONTRACT_ID })
+      .addTxContractLogEvent({ contract_identifier: CONTRACT_ID })
+      .addTxContractLogEvent({ contract_identifier: CONTRACT_ID })
+      .addTxContractLogEvent({ contract_identifier: CONTRACT_ID })
+      .addTxContractLogEvent({ contract_identifier: CONTRACT_ID })
+      .build();
+    await db.update(block);
+
+    const { body } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events?limit=2`
+    );
+    assert.equal(body.limit, 2);
+    assert.equal(body.total, 5);
+    assert.equal(body.results.length, 2);
+  });
+
+  test('contract_log_counts table is maintained correctly', async () => {
+    const block = new TestBlockBuilder({
+      block_height: 1,
+      index_block_hash: '0x' + '01'.padStart(64, '0'),
+    })
+      .addTx({ tx_id: '0x' + 'aa'.padStart(64, '0') })
+      .addTxContractLogEvent({ contract_identifier: CONTRACT_ID })
+      .addTxContractLogEvent({ contract_identifier: CONTRACT_ID })
+      .addTxContractLogEvent({ contract_identifier: CONTRACT_ID })
+      .build();
+    await db.update(block);
+
+    // Verify count table directly
+    const countResult = await client`
+      SELECT count FROM contract_log_counts WHERE contract_identifier = ${CONTRACT_ID}
+    `;
+    assert.equal(countResult[0].count, 3);
+
+    // Verify total in API matches
+    const { body } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events`
+    );
+    assert.equal(body.total, 3);
+  });
+});

--- a/tests/api/smart-contracts/print-events.test.ts
+++ b/tests/api/smart-contracts/print-events.test.ts
@@ -286,4 +286,118 @@ describe('smart contract print events v2', () => {
     );
     assert.equal(body.total, 3);
   });
+
+  test('contract_log_counts stays consistent across re-orgs', async () => {
+    const ibh = (i: number) => `0x${i.toString().padStart(64, '0')}`;
+
+    // Block 1: 2 print events on the canonical chain
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        index_block_hash: ibh(1),
+        parent_index_block_hash: ibh(0),
+      })
+        .addTx({ tx_id: ibh(0x1001) })
+        .addTxContractLogEvent({ contract_identifier: CONTRACT_ID, topic: 'print' })
+        .addTxContractLogEvent({ contract_identifier: CONTRACT_ID, topic: 'print' })
+        .build()
+    );
+
+    // Block 2: 3 print events on the canonical chain
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        index_block_hash: ibh(2),
+        parent_index_block_hash: ibh(1),
+      })
+        .addTx({ tx_id: ibh(0x2001) })
+        .addTxContractLogEvent({ contract_identifier: CONTRACT_ID, topic: 'print' })
+        .addTxContractLogEvent({ contract_identifier: CONTRACT_ID, topic: 'print' })
+        .addTxContractLogEvent({ contract_identifier: CONTRACT_ID, topic: 'print' })
+        .build()
+    );
+
+    // Block 3: 1 print event on the canonical chain
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 3,
+        index_block_hash: ibh(3),
+        parent_index_block_hash: ibh(2),
+      })
+        .addTx({ tx_id: ibh(0x3001) })
+        .addTxContractLogEvent({ contract_identifier: CONTRACT_ID, topic: 'print' })
+        .build()
+    );
+
+    // Verify: 2 + 3 + 1 = 6 events total
+    let countResult = await client`
+      SELECT count FROM contract_log_counts WHERE contract_identifier = ${CONTRACT_ID}
+    `;
+    assert.equal(countResult[0].count, 6);
+    let { body } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events`
+    );
+    assert.equal(body.total, 6);
+    assert.equal(body.results.length, 6);
+
+    // --- Trigger a re-org ---
+    // Create an alternative block 2b (fork at height 2) that builds on block 1.
+    // This goes in as non-canonical because it doesn't extend past the current tip (height 3).
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        index_block_hash: ibh(0xb2),
+        parent_index_block_hash: ibh(1),
+      })
+        .addTx({ tx_id: ibh(0xb201) })
+        .addTxContractLogEvent({ contract_identifier: CONTRACT_ID, topic: 'print' })
+        .build()
+    );
+
+    // Block 3b on the fork
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 3,
+        index_block_hash: ibh(0xb3),
+        parent_index_block_hash: ibh(0xb2),
+      })
+        .addTx({ tx_id: ibh(0xb301) })
+        .build()
+    );
+
+    // Block 4b extends the fork past the original tip (height 3) — triggers re-org.
+    // Original blocks 2 and 3 become non-canonical (losing 3 + 1 = 4 events).
+    // Fork blocks 2b and 3b become canonical (gaining 1 + 0 = 1 event).
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 4,
+        index_block_hash: ibh(0xb4),
+        parent_index_block_hash: ibh(0xb3),
+      })
+        .addTx({ tx_id: ibh(0xb401) })
+        .build()
+    );
+
+    // After re-org: block 1 (2 events) + block 2b (1 event) = 3 canonical events
+    countResult = await client`
+      SELECT count FROM contract_log_counts WHERE contract_identifier = ${CONTRACT_ID}
+    `;
+    assert.equal(countResult[0].count, 3);
+
+    // API should reflect the same total
+    ({ body } = await supertest(api.server).get(
+      `/extended/v2/smart-contracts/${CONTRACT_ID}/print-events`
+    ));
+    assert.equal(body.total, 3);
+    assert.equal(body.results.length, 3);
+
+    // Verify the remaining events come from the correct blocks/txs
+    const txIds = body.results.map((e: { tx_id: string }) => e.tx_id);
+    // Block 2b event + block 1 events (newest first)
+    assert.ok(txIds.includes(ibh(0xb201)), 'should include fork block 2b tx');
+    assert.ok(txIds.includes(ibh(0x1001)), 'should include original block 1 tx');
+    // Original block 2 and 3 txs should NOT be present
+    assert.ok(!txIds.includes(ibh(0x2001)), 'should not include orphaned block 2 tx');
+    assert.ok(!txIds.includes(ibh(0x3001)), 'should not include orphaned block 3 tx');
+  });
 });


### PR DESCRIPTION
* Cursor pagination based on `block_height:microblock_sequence:tx_index:event_index`
* Response objects keep same shape as `/extended/v1/contracts/:contract_id/events`, which is now marked as deprecated