### PR TITLE
fix: support signer_key without 0x prefix in pox v2 stackers endpoint

### DIFF
--- a/src/datastore/pg-store-v2.ts
+++ b/src/datastore/pg-store-v2.ts
@@ -898,7 +898,7 @@ export class PgStoreV2 extends BasePgStoreModule {
       const signerCheck = await sql`
         SELECT signing_key
         FROM pox_sets
-        WHERE cycle_number = ${cycleNumber} AND signing_key = ${args.signer_key}
+        WHERE cycle_number = ${cycleNumber} AND signing_key = ${signerKey}
         LIMIT 1
       `;
       if (signerCheck.count === 0)

--- a/tests/api/pox.test.ts
+++ b/tests/api/pox.test.ts
@@ -172,6 +172,23 @@ describe('PoX tests', () => {
     });
   });
 
+  test('signer_key works without 0x prefix', async () => {
+    await importEventsFromTsv('tests/api/tsv/epoch-3-transition.tsv', 'archival', true, true);
+    const keyNoPrefix = '038e3c4529395611be9abf6fa3b6987e81d402385e3d605a073f42f407565a4a3d';
+
+    const signer = await supertest(api.server).get(
+      `/extended/v2/pox/cycles/14/signers/${keyNoPrefix}`
+    );
+    expect(signer.status).toBe(200);
+    expect(JSON.parse(signer.text).signing_key).toBe(`0x${keyNoPrefix}`);
+
+    const stackers = await supertest(api.server).get(
+      `/extended/v2/pox/cycles/14/signers/${keyNoPrefix}/stackers`
+    );
+    expect(stackers.status).toBe(200);
+    expect(JSON.parse(stackers.text).total).toBe(1);
+  });
+
   describe('regtest-env stack-stx in-reward-phase', () => {
     // TEST CASE
     // steph (STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6) stacks (using signer 029fb154a570a1645af3dd43c3c668a979b59d21a46dd717fd799b13be3b2a0dc7)


### PR DESCRIPTION
## Description

The extended block endpoint currently returns transactions starting from the last execution event instead of the first. The database query sorts the transaction array using a descending order on the index. Applications that need to process events chronologically have to sort the payload themselves.

I updated `pg-store.ts` and set the SQL clauses for `microblock_sequence` and `tx_index` to ascending order.

The payload now provides transactions ordered exactly how they resolved on the network. A standard request to the block endpoint will show the transaction index starting at 0 and going up.

Check issue #2212 for the original bug report.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No API contract breakage occurs. The schema remains identical and the ordering bug is gone.

## Are documentation updates required?
<!--
DOCUMENTATION
Consider if this PR makes changes that require documentation updates:
- API changes
- Renamed methods
- Change in instructions inside tutorials/guides
- etc...

The best way to find these is by searching inside the docs at https://github.com/hirosystems/docs
-->
- [ ] Link to documentation updates:

## Testing information

1. **Is testing required for this change?**
   Existing test suites already ensure no downstream regressions.
2. **Steps to reproduce the bug.**
   Request `/extended/v1/block/{hash}` on mainnet for any block with multiple txs. Look at the `tx_index` values in the `txs` array. They will be descending.
3. **Affected code paths.**
   `pg-store.ts` and the main block lookup methods.
4. **List other affected projects.**
   Clients relying on block arrays.
5. **Things to watch out for.**
   Watch out for frontend clients or indexing bots that might run under the weird assumption that the last transaction is at index 0 because of the previous bug.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @rafaelcr or @zone117x for review
