### PR TITLE
feat: client pkg export paths type

### DIFF
--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -11,3 +11,4 @@ export * from './socket-io';
 export * from './ws';
 export type * from './types';
 export * from 'openapi-fetch';
+export type { paths };


### PR DESCRIPTION
## Description

Exports the `paths` type from the client api package so the types can be reused in applications.

At the moment one need to do:
```ts
import type { paths } from "@stacks/blockchain-api-client/lib/generated/schema";
```
in order to access them.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @rafaelcr or @zone117x for review
