### PR TITLE
fix: optimize etag generation for principal activity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          # platforms: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          platforms: 'linux/amd64,linux/arm64'
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,11 +322,11 @@ jobs:
       issues: write
       pull-requests: write
     runs-on: ubuntu-latest
-    needs:
-      - lint
-      - test
-      - test-2_5
-      - test-rosetta
+    # needs:
+    #   - lint
+    #   - test
+    #   - test-2_5
+    #   - test-rosetta
     steps:
       - name: Generate release bot app token
         id: generate_token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,7 @@ jobs:
 
       - name: Upgrade to latest npm
         run: |
-          npm install -g npm@latest
+          npm install -g npm@~11.10.0
           npm -v
 
       - name: Get bot user ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,11 +322,11 @@ jobs:
       issues: write
       pull-requests: write
     runs-on: ubuntu-latest
-    # needs:
-    #   - lint
-    #   - test
-    #   - test-2_5
-    #   - test-rosetta
+    needs:
+      - lint
+      - test
+      - test-2_5
+      - test-rosetta
     steps:
       - name: Generate release bot app token
         id: generate_token
@@ -403,8 +403,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          # platforms: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          platforms: 'linux/amd64,linux/arm64'
+          platforms: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)

--- a/.releaserc
+++ b/.releaserc
@@ -44,7 +44,12 @@
         "pkgRoot": "./client"
       }
     ],
-    "@semantic-release/github",
+    [
+      "@semantic-release/github",
+      {
+        "draftRelease": true
+      }
+    ],
     "@semantic-release/changelog",
     "@semantic-release/git"
   ]

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -4487,10 +4487,27 @@ export class PgStore extends BasePgStore {
         UNION
         (
           SELECT '0x' || encode(tx_id, 'hex') AS tx_id
-          FROM nft_events
-          WHERE (sender = ${principal} OR recipient = ${principal})
-            AND canonical = true
-            AND microblock_canonical = true
+          FROM (
+            (
+              SELECT tx_id, block_height, microblock_sequence, tx_index, event_index
+              FROM nft_events
+              WHERE sender = ${principal}
+                AND canonical = true
+                AND microblock_canonical = true
+              ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+              LIMIT 1
+            )
+            UNION ALL
+            (
+              SELECT tx_id, block_height, microblock_sequence, tx_index, event_index
+              FROM nft_events
+              WHERE recipient = ${principal}
+                AND canonical = true
+                AND microblock_canonical = true
+              ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+              LIMIT 1
+            )
+          ) AS combined
           ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
           LIMIT 1
         )


### PR DESCRIPTION
Divide the `nft_events` query into two sub-queries so the OR condition does not force postgres to use a filtered index scan that takes a long time.