### PR TITLE
fix(rosetta): emit block-1 genesis state ops via other_transactions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - master
       - develop
       - beta
-      - nakamoto
+      - rosetta
     tags-ignore:
       - "**"
     paths-ignore:

--- a/.releaserc
+++ b/.releaserc
@@ -7,8 +7,8 @@
       "prerelease": true
     },
     {
-      "name": "nakamoto",
-      "channel": "nakamoto",
+      "name": "rosetta",
+      "channel": "rosetta",
       "prerelease": true
     }
   ],
@@ -44,7 +44,6 @@
         "pkgRoot": "./client"
       }
     ],
-    "@semantic-release/github",
     "@semantic-release/changelog",
     "@semantic-release/git"
   ]

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -35,7 +35,14 @@ import {
   StxUnlockEvent,
   DbPoxSyntheticEvent,
 } from '../../datastore/common';
-import { unwrapOptional, FoundOrNot, unixEpochToIso, EMPTY_HASH_256, ChainID, NETWORK_CHAIN_ID } from '../../helpers';
+import {
+  unwrapOptional,
+  FoundOrNot,
+  unixEpochToIso,
+  EMPTY_HASH_256,
+  ChainID,
+  NETWORK_CHAIN_ID,
+} from '../../helpers';
 import { serializePostCondition, serializePostConditionMode } from '../serializers/post-conditions';
 import {
   getOperations,

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -12,6 +12,7 @@ import {
 } from '@stacks/codec';
 
 import {
+  OtherTransactionIdentifier,
   RosettaBlock,
   RosettaParentBlockIdentifier,
   RosettaTransaction,
@@ -36,10 +37,19 @@ import {
 } from '../../datastore/common';
 import { unwrapOptional, FoundOrNot, unixEpochToIso, EMPTY_HASH_256, ChainID } from '../../helpers';
 import { serializePostCondition, serializePostConditionMode } from '../serializers/post-conditions';
-import { getOperations, parseTransactionMemo } from '../../rosetta/rosetta-helpers';
+import {
+  getOperations,
+  getOperationsFromEvents,
+  parseTransactionMemo,
+} from '../../rosetta/rosetta-helpers';
 import { PgStore } from '../../datastore/pg-store';
 import { SyntheticPoxEventName } from '../../pox-helpers';
 import { logger } from '../../logger';
+import {
+  buildGenesisChunkTxId,
+  GENESIS_CHUNK_EVENT_SIZE,
+  parseGenesisChunkTxId,
+} from '../rosetta-constants';
 
 import {
   AbstractMempoolTransaction,
@@ -497,13 +507,18 @@ export function parseDbEvent(dbEvent: DbEvent): TransactionEvent {
  * @param blockHash -- hexadecimal hash string
  * @param blockHeight -- number
  */
+export interface RosettaBlockWithOtherTransactions {
+  block: RosettaBlock;
+  otherTransactions: OtherTransactionIdentifier[];
+}
+
 export async function getRosettaBlockFromDataStore(
   db: PgStore,
   fetchTransactions: boolean,
   chainId: ChainID,
   blockHash?: string,
   blockHeight?: number
-): Promise<FoundOrNot<RosettaBlock>> {
+): Promise<FoundOrNot<RosettaBlockWithOtherTransactions>> {
   return await db.sqlTransaction(async sql => {
     let blockQuery: FoundOrNot<DbBlock>;
     if (blockHash) {
@@ -518,15 +533,20 @@ export async function getRosettaBlockFromDataStore(
       return { found: false };
     }
     const dbBlock = blockQuery.result;
-    let blockTxs = {} as FoundOrNot<RosettaTransaction[]>;
-    blockTxs.found = false;
+    let transactions: RosettaTransaction[] = [];
+    let otherTransactions: OtherTransactionIdentifier[] = [];
     if (fetchTransactions) {
-      blockTxs = await getRosettaBlockTransactionsFromDataStore({
+      const blockTxs = await getRosettaBlockTransactionsFromDataStore({
         blockHash: dbBlock.block_hash,
         indexBlockHash: dbBlock.index_block_hash,
+        blockHeight: dbBlock.block_height,
         db,
         chainId,
       });
+      if (blockTxs.found) {
+        transactions = blockTxs.result.transactions;
+        otherTransactions = blockTxs.result.otherTransactions;
+      }
     }
 
     const parentBlockHash = dbBlock.parent_block_hash;
@@ -562,12 +582,12 @@ export async function getRosettaBlockFromDataStore(
       block_identifier: { index: dbBlock.block_height, hash: dbBlock.block_hash },
       parent_block_identifier,
       timestamp: timestamp,
-      transactions: blockTxs.found ? blockTxs.result : [],
+      transactions,
       metadata: {
         burn_block_height: dbBlock.burn_block_height,
       },
     };
-    return { found: true, result: apiBlock };
+    return { found: true, result: { block: apiBlock, otherTransactions } };
   });
 }
 
@@ -726,11 +746,17 @@ async function parseRosettaTxDetail(opts: {
   minerRewards: DbMinerReward[];
   unlockingEvents: StxUnlockEvent[];
   chainId: ChainID;
+  /**
+   * When true, skip fetching this tx's events because they are being emitted separately as
+   * synthetic chunked transactions via the rosetta `other_transactions` mechanism. Used for the
+   * block-1 genesis state tx, which carries ~330k STX mint events representing pre-upgrade
+   * (stacks 1.0) balances.
+   */
+  skipEventFetch?: boolean;
 }): Promise<RosettaTransaction> {
   return await opts.db.sqlTransaction(async sql => {
     let events: DbEvent[] = [];
-    if (opts.block_height > 1) {
-      // only return events of blocks at height greater than 1
+    if (!opts.skipEventFetch) {
       const eventsQuery = await opts.db.getTxEvents({
         txId: opts.tx.tx_id,
         indexBlockHash: opts.indexBlockHash,
@@ -794,12 +820,74 @@ async function getRosettaBlockTxFromDataStore(opts: {
   });
 }
 
+/**
+ * Build a synthetic RosettaTransaction representing a single chunk of the block-1 genesis
+ * state tx's event-derived operations. Called when `/block/transaction` is invoked with a
+ * synthetic tx id of the form `{origTxId}:genesis-chunk:{i}`.
+ *
+ * The chunk contains up to GENESIS_CHUNK_EVENT_SIZE ops derived from events starting at
+ * `event_index` offset = chunkIndex * GENESIS_CHUNK_EVENT_SIZE. This lets consumers page
+ * through the ~330k pre-upgrade (stacks 1.0) balance mint events concurrently without
+ * blowing up the `/block` response size.
+ */
+async function getRosettaGenesisChunkTransactionFromDataStore(opts: {
+  synthesizedTxId: string;
+  origTxId: string;
+  chunkIndex: number;
+  db: PgStore;
+  chainId: ChainID;
+}): Promise<FoundOrNot<RosettaTransaction>> {
+  return await opts.db.sqlTransaction(async sql => {
+    const txQuery = await opts.db.getTx({ txId: opts.origTxId, includeUnanchored: false });
+    if (!txQuery.found) {
+      return { found: false };
+    }
+    const origTx = txQuery.result;
+
+    // Only chunk the genesis state tx at block 1. Reject synthetic ids that reference a tx
+    // at any other height so we do not fabricate data for arbitrary tx ids.
+    const blockQuery = await opts.db.getBlock({ hash: origTx.block_hash });
+    if (!blockQuery.found || blockQuery.result.block_height !== 1) {
+      return { found: false };
+    }
+
+    const offset = opts.chunkIndex * GENESIS_CHUNK_EVENT_SIZE;
+    const eventsQuery = await opts.db.getTxEvents({
+      txId: opts.origTxId,
+      indexBlockHash: origTx.index_block_hash,
+      limit: GENESIS_CHUNK_EVENT_SIZE,
+      offset,
+    });
+    if (eventsQuery.results.length === 0) {
+      return { found: false };
+    }
+
+    const operations = await getOperationsFromEvents(
+      origTx,
+      opts.db,
+      opts.chainId,
+      eventsQuery.results
+    );
+    const rosettaTx: RosettaTransaction = {
+      transaction_identifier: { hash: opts.synthesizedTxId },
+      operations,
+    };
+    return { found: true, result: rosettaTx };
+  });
+}
+
 async function getRosettaBlockTransactionsFromDataStore(opts: {
   blockHash: string;
   indexBlockHash: string;
+  blockHeight: number;
   db: PgStore;
   chainId: ChainID;
-}): Promise<FoundOrNot<RosettaTransaction[]>> {
+}): Promise<
+  FoundOrNot<{
+    transactions: RosettaTransaction[];
+    otherTransactions: OtherTransactionIdentifier[];
+  }>
+> {
   return await opts.db.sqlTransaction(async sql => {
     const blockQuery = await opts.db.getBlock({ hash: opts.blockHash });
     if (!blockQuery.found) {
@@ -818,8 +906,29 @@ async function getRosettaBlockTransactionsFromDataStore(opts: {
     const unlockingEvents = await opts.db.getUnlockedAddressesAtBlock(blockQuery.result);
 
     const transactions: RosettaTransaction[] = [];
+    const otherTransactions: OtherTransactionIdentifier[] = [];
 
+    // At block 1, the stacks genesis state tx carries ~330k STX mint events representing
+    // pre-upgrade (stacks 1.0) balances. Returning all of those ops inline blows up response
+    // size (~150 MB), so for any tx at block 1 whose event count exceeds
+    // GENESIS_CHUNK_EVENT_SIZE we split its event-derived operations into deterministic
+    // chunks and expose them via `other_transactions`. The tx itself still appears in
+    // `transactions[]` with only its static (fee / sender / coinbase / etc.) ops.
     for (const tx of txsQuery.result) {
+      let skipEventFetch = false;
+      if (opts.blockHeight === 1) {
+        const eventCount = await opts.db.getTxEventCount({
+          txId: tx.tx_id,
+          indexBlockHash: opts.indexBlockHash,
+        });
+        if (eventCount > GENESIS_CHUNK_EVENT_SIZE) {
+          const numChunks = Math.ceil(eventCount / GENESIS_CHUNK_EVENT_SIZE);
+          for (let i = 0; i < numChunks; i++) {
+            otherTransactions.push({ hash: buildGenesisChunkTxId(tx.tx_id, i) });
+          }
+          skipEventFetch = true;
+        }
+      }
       const rosettaTx = await parseRosettaTxDetail({
         block_height: blockQuery.result.block_height,
         indexBlockHash: opts.indexBlockHash,
@@ -828,11 +937,12 @@ async function getRosettaBlockTransactionsFromDataStore(opts: {
         minerRewards,
         unlockingEvents,
         chainId: opts.chainId,
+        skipEventFetch,
       });
       transactions.push(rosettaTx);
     }
 
-    return { found: true, result: transactions };
+    return { found: true, result: { transactions, otherTransactions } };
   });
 }
 
@@ -842,6 +952,20 @@ export async function getRosettaTransactionFromDataStore(
   chainId: ChainID
 ): Promise<FoundOrNot<RosettaTransaction>> {
   return await db.sqlTransaction(async sql => {
+    // Synthetic tx ids (e.g. `0x2f07...:genesis-chunk:3`) are emitted by block 1 via
+    // `other_transactions`. Resolve them to a slice of event-derived operations on the
+    // original genesis state tx.
+    const chunkInfo = parseGenesisChunkTxId(txId);
+    if (chunkInfo) {
+      return await getRosettaGenesisChunkTransactionFromDataStore({
+        synthesizedTxId: txId,
+        origTxId: chunkInfo.origTxId,
+        chunkIndex: chunkInfo.chunkIndex,
+        db,
+        chainId,
+      });
+    }
+
     const txQuery = await db.getTx({ txId, includeUnanchored: false });
     if (!txQuery.found) {
       return { found: false };

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -35,7 +35,7 @@ import {
   StxUnlockEvent,
   DbPoxSyntheticEvent,
 } from '../../datastore/common';
-import { unwrapOptional, FoundOrNot, unixEpochToIso, EMPTY_HASH_256, ChainID } from '../../helpers';
+import { unwrapOptional, FoundOrNot, unixEpochToIso, EMPTY_HASH_256, ChainID, NETWORK_CHAIN_ID } from '../../helpers';
 import { serializePostCondition, serializePostConditionMode } from '../serializers/post-conditions';
 import {
   getOperations,
@@ -48,6 +48,8 @@ import { logger } from '../../logger';
 import {
   buildGenesisChunkTxId,
   GENESIS_CHUNK_EVENT_SIZE,
+  GENESIS_CHUNK_TX_EVENT_COUNT,
+  GENESIS_CHUNK_TX_ID,
   parseGenesisChunkTxId,
 } from '../rosetta-constants';
 
@@ -507,7 +509,7 @@ export function parseDbEvent(dbEvent: DbEvent): TransactionEvent {
  * @param blockHash -- hexadecimal hash string
  * @param blockHeight -- number
  */
-export interface RosettaBlockWithOtherTransactions {
+interface RosettaBlockWithOtherTransactions {
   block: RosettaBlock;
   otherTransactions: OtherTransactionIdentifier[];
 }
@@ -909,20 +911,15 @@ async function getRosettaBlockTransactionsFromDataStore(opts: {
     const otherTransactions: OtherTransactionIdentifier[] = [];
 
     // At block 1, the stacks genesis state tx carries ~330k STX mint events representing
-    // pre-upgrade (stacks 1.0) balances. Returning all of those ops inline blows up response
-    // size (~150 MB), so for any tx at block 1 whose event count exceeds
-    // GENESIS_CHUNK_EVENT_SIZE we split its event-derived operations into deterministic
+    // pre-upgrade (stacks 1.0) balances. Returning all of those ops inline blows up response size
+    // (~150 MB), so we split the genesis state tx's event-derived operations into deterministic
     // chunks and expose them via `other_transactions`. The tx itself still appears in
     // `transactions[]` with only its static (fee / sender / coinbase / etc.) ops.
     for (const tx of txsQuery.result) {
       let skipEventFetch = false;
-      if (opts.blockHeight === 1) {
-        const eventCount = await opts.db.getTxEventCount({
-          txId: tx.tx_id,
-          indexBlockHash: opts.indexBlockHash,
-        });
-        if (eventCount > GENESIS_CHUNK_EVENT_SIZE) {
-          const numChunks = Math.ceil(eventCount / GENESIS_CHUNK_EVENT_SIZE);
+      if (opts.blockHeight === 1 && opts.chainId === NETWORK_CHAIN_ID.mainnet) {
+        if (tx.tx_id === GENESIS_CHUNK_TX_ID) {
+          const numChunks = Math.ceil(GENESIS_CHUNK_TX_EVENT_COUNT / GENESIS_CHUNK_EVENT_SIZE);
           for (let i = 0; i < numChunks; i++) {
             otherTransactions.push({ hash: buildGenesisChunkTxId(tx.tx_id, i) });
           }

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -27,6 +27,39 @@ export const RosettaConstants = {
   VestingSchedule: 'VestingSchedule',
 };
 
+// Block 1 includes the stacks genesis state transaction, which encodes the
+// pre-upgrade (stacks 1.0) balances as roughly 330k STX mint events. Returning
+// all of those ops in a single `/block` response would produce a ~150 MB JSON
+// payload, which no gateway or consumer in the pipeline can handle. We therefore
+// split the genesis state tx's event-derived operations into deterministic
+// chunks and surface them via Rosetta's `other_transactions` mechanism, so
+// consumers can fetch each chunk concurrently via `/block/transaction`.
+export const GENESIS_CHUNK_EVENT_SIZE = 1000;
+export const GENESIS_CHUNK_TX_ID_SEPARATOR = ':genesis-chunk:';
+
+export function buildGenesisChunkTxId(origTxId: string, chunkIndex: number): string {
+  return `${origTxId}${GENESIS_CHUNK_TX_ID_SEPARATOR}${chunkIndex}`;
+}
+
+export function parseGenesisChunkTxId(
+  txId: string
+): { origTxId: string; chunkIndex: number } | null {
+  const idx = txId.lastIndexOf(GENESIS_CHUNK_TX_ID_SEPARATOR);
+  if (idx < 0) {
+    return null;
+  }
+  const origTxId = txId.slice(0, idx);
+  const chunkStr = txId.slice(idx + GENESIS_CHUNK_TX_ID_SEPARATOR.length);
+  if (!/^\d+$/.test(chunkStr)) {
+    return null;
+  }
+  const chunkIndex = Number(chunkStr);
+  if (!Number.isInteger(chunkIndex) || chunkIndex < 0) {
+    return null;
+  }
+  return { origTxId, chunkIndex };
+}
+
 export function getRosettaNetworkName(chainId: ChainID): string {
   if (getChainIDNetwork(chainId) === 'mainnet') {
     return RosettaNetworks.mainnet;

--- a/src/api/rosetta-constants.ts
+++ b/src/api/rosetta-constants.ts
@@ -35,6 +35,9 @@ export const RosettaConstants = {
 // chunks and surface them via Rosetta's `other_transactions` mechanism, so
 // consumers can fetch each chunk concurrently via `/block/transaction`.
 export const GENESIS_CHUNK_EVENT_SIZE = 1000;
+export const GENESIS_CHUNK_TX_ID =
+  '0x2f079994c9bd92b2272258b9de73e278824d76efe1b5a83a3b00941f9559de8a';
+export const GENESIS_CHUNK_TX_EVENT_COUNT = 330_441;
 export const GENESIS_CHUNK_TX_ID_SEPARATOR = ':genesis-chunk:';
 
 export function buildGenesisChunkTxId(origTxId: string, chunkIndex: number): string {

--- a/src/api/routes/rosetta/block.ts
+++ b/src/api/routes/rosetta/block.ts
@@ -37,8 +37,11 @@ export function createRosettaBlockRouter(db: PgStore, chainId: ChainID): express
         return;
       }
       const blockResponse: RosettaBlockResponse = {
-        block: block.result,
+        block: block.result.block,
       };
+      if (block.result.otherTransactions.length > 0) {
+        blockResponse.other_transactions = block.result.otherTransactions;
+      }
       res.json(blockResponse);
     })
   );
@@ -63,7 +66,7 @@ export function createRosettaBlockRouter(db: PgStore, chainId: ChainID): express
         return;
       }
 
-      res.json(transaction.result);
+      res.json({ transaction: transaction.result });
     })
   );
 

--- a/src/api/routes/rosetta/network.ts
+++ b/src/api/routes/rosetta/network.ts
@@ -61,7 +61,7 @@ export function createRosettaNetworkRouter(db: PgStore, chainId: ChainID): expre
           if (!genesis.found) {
             throw RosettaErrors[RosettaErrorsTypes.blockNotFound];
           }
-          return { block: block.result, genesis: genesis.result };
+          return { block: block.result.block, genesis: genesis.result.block };
         });
         block = results.block;
         genesis = results.genesis;

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -1646,46 +1646,6 @@ export class PgStore extends BasePgStore {
   }
 
   /**
-   * Returns the total number of events (stx_lock, stx, ft, nft, contract_log) associated with a
-   * given tx. Used by rosetta `/block` when deciding how many `other_transactions` chunks to emit
-   * for the stacks genesis state tx at block 1.
-   */
-  async getTxEventCount(args: { txId: string; indexBlockHash: string }): Promise<number> {
-    return await this.sqlTransaction(async sql => {
-      const [stxLockRes, stxRes, ftRes, nftRes, logRes] = await Promise.all([
-        sql<{ c: string }[]>`
-          SELECT COUNT(*)::text AS c FROM stx_lock_events
-          WHERE tx_id = ${args.txId} AND index_block_hash = ${args.indexBlockHash}
-            AND microblock_canonical = true
-        `,
-        sql<{ c: string }[]>`
-          SELECT COUNT(*)::text AS c FROM stx_events
-          WHERE tx_id = ${args.txId} AND index_block_hash = ${args.indexBlockHash}
-            AND microblock_canonical = true
-        `,
-        sql<{ c: string }[]>`
-          SELECT COUNT(*)::text AS c FROM ft_events
-          WHERE tx_id = ${args.txId} AND index_block_hash = ${args.indexBlockHash}
-            AND microblock_canonical = true
-        `,
-        sql<{ c: string }[]>`
-          SELECT COUNT(*)::text AS c FROM nft_events
-          WHERE tx_id = ${args.txId} AND index_block_hash = ${args.indexBlockHash}
-            AND microblock_canonical = true
-        `,
-        sql<{ c: string }[]>`
-          SELECT COUNT(*)::text AS c FROM contract_logs
-          WHERE tx_id = ${args.txId} AND index_block_hash = ${args.indexBlockHash}
-            AND microblock_canonical = true
-        `,
-      ]);
-      return [stxLockRes, stxRes, ftRes, nftRes, logRes]
-        .map(r => Number(r[0]?.c ?? 0))
-        .reduce((a, b) => a + b, 0);
-    });
-  }
-
-  /**
    * TODO investigate if this method needs be deprecated in favor of {@link getTransactionEvents}
    */
   async getTxEvents(args: {

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -1646,6 +1646,46 @@ export class PgStore extends BasePgStore {
   }
 
   /**
+   * Returns the total number of events (stx_lock, stx, ft, nft, contract_log) associated with a
+   * given tx. Used by rosetta `/block` when deciding how many `other_transactions` chunks to emit
+   * for the stacks genesis state tx at block 1.
+   */
+  async getTxEventCount(args: { txId: string; indexBlockHash: string }): Promise<number> {
+    return await this.sqlTransaction(async sql => {
+      const [stxLockRes, stxRes, ftRes, nftRes, logRes] = await Promise.all([
+        sql<{ c: string }[]>`
+          SELECT COUNT(*)::text AS c FROM stx_lock_events
+          WHERE tx_id = ${args.txId} AND index_block_hash = ${args.indexBlockHash}
+            AND microblock_canonical = true
+        `,
+        sql<{ c: string }[]>`
+          SELECT COUNT(*)::text AS c FROM stx_events
+          WHERE tx_id = ${args.txId} AND index_block_hash = ${args.indexBlockHash}
+            AND microblock_canonical = true
+        `,
+        sql<{ c: string }[]>`
+          SELECT COUNT(*)::text AS c FROM ft_events
+          WHERE tx_id = ${args.txId} AND index_block_hash = ${args.indexBlockHash}
+            AND microblock_canonical = true
+        `,
+        sql<{ c: string }[]>`
+          SELECT COUNT(*)::text AS c FROM nft_events
+          WHERE tx_id = ${args.txId} AND index_block_hash = ${args.indexBlockHash}
+            AND microblock_canonical = true
+        `,
+        sql<{ c: string }[]>`
+          SELECT COUNT(*)::text AS c FROM contract_logs
+          WHERE tx_id = ${args.txId} AND index_block_hash = ${args.indexBlockHash}
+            AND microblock_canonical = true
+        `,
+      ]);
+      return [stxLockRes, stxRes, ftRes, nftRes, logRes]
+        .map(r => Number(r[0]?.c ?? 0))
+        .reduce((a, b) => a + b, 0);
+    });
+  }
+
+  /**
    * TODO investigate if this method needs be deprecated in favor of {@link getTransactionEvents}
    */
   async getTxEvents(args: {

--- a/src/rosetta/json-schemas/rosetta-account-balance-request.schema.json
+++ b/src/rosetta/json-schemas/rosetta-account-balance-request.schema.json
@@ -13,6 +13,12 @@
     },
     "block_identifier": {
       "$ref": "./rosetta-partial-block-identifier.schema.json"
+    },
+    "currencies": {
+      "type": "array",
+      "items": {
+        "$ref": "./rosetta-currency.schema.json"
+      }
     }
   }
 }

--- a/src/rosetta/rosetta-helpers.ts
+++ b/src/rosetta/rosetta-helpers.ts
@@ -135,6 +135,28 @@ export async function getOperations(
   return await getOperationsInternal(tx, db, chainID, minerRewards, events, stxUnlockEvents);
 }
 
+/**
+ * Build a RosettaOperation list from a slice of events alone, bypassing the per-tx-type static
+ * operations (fee / sender / receiver / coinbase / etc.) that `getOperations` normally prepends.
+ * Used to construct synthetic chunked transactions for the stacks genesis state tx in block 1.
+ */
+export async function getOperationsFromEvents(
+  tx: DbTx | BaseTx,
+  db: PgStore,
+  chainID: ChainID,
+  events: DbEvent[]
+): Promise<RosettaOperation[]> {
+  const operations: RosettaOperation[] = [];
+  if (db instanceof PgStore) {
+    return await db.sqlTransaction(async _sql => {
+      await processEvents(db, events, tx as BaseTx, operations, chainID);
+      return operations;
+    });
+  }
+  await processEvents(db, events, tx as BaseTx, operations, chainID);
+  return operations;
+}
+
 async function getOperationsInternal(
   tx: DbTx | DbMempoolTx | BaseTx,
   db: PgStore,
@@ -533,10 +555,13 @@ function makeSenderOperation(
   };
 
   if (memo) {
-    sender.metadata = {
-      ...sender.metadata,
-      memo: parseTransactionMemo(memo),
-    };
+    const parsedMemo = parseTransactionMemo(memo);
+    if (parsedMemo) {
+      sender.metadata = {
+        ...sender.metadata,
+        memo: parsedMemo,
+      };
+    }
   }
 
   return sender;
@@ -606,10 +631,13 @@ function makeReceiverOperation(
   };
 
   if (memo) {
-    receiver.metadata = {
-      ...receiver.metadata,
-      memo: parseTransactionMemo(memo),
-    };
+    const parsedMemo = parseTransactionMemo(memo);
+    if (parsedMemo) {
+      receiver.metadata = {
+        ...receiver.metadata,
+        memo: parsedMemo,
+      };
+    }
   }
 
   return receiver;

--- a/src/rosetta/types.ts
+++ b/src/rosetta/types.ts
@@ -676,7 +676,7 @@ export interface RosettaBlockResponse {
 /**
  * The transaction_identifier uniquely identifies a transaction in a particular network and block or in the mempool.
  */
-interface OtherTransactionIdentifier {
+export interface OtherTransactionIdentifier {
   /**
    * Any transactions that are attributable only to a block (ex: a block event) should use the hash of the block as the identifier.
    */

--- a/tests/rosetta-construction/construction.test.ts
+++ b/tests/rosetta-construction/construction.test.ts
@@ -2118,7 +2118,7 @@ describe('Rosetta Construction', () => {
     };
     expect(query2.status).toBe(200);
     expect(query2.type).toBe('application/json');
-    expect(query2.body.operations[1]).toStrictEqual(expectedResponse);
+    expect(query2.body.transaction.operations[1]).toStrictEqual(expectedResponse);
   });
 
   //---------------------

--- a/tests/rosetta-construction/construction.test.ts
+++ b/tests/rosetta-construction/construction.test.ts
@@ -2063,10 +2063,10 @@ describe('Rosetta Construction', () => {
     expect(stxOpsTx.operations).toContainEqual(expect.objectContaining(expectedStackStxOp));
     expect(stxOpsTx.operations).toContainEqual(expect.objectContaining(expectedStxLockOp));
 
-    expect(blockTxOpsQuery.body.operations).toContainEqual(
+    expect(blockTxOpsQuery.body.transaction.operations).toContainEqual(
       expect.objectContaining(expectedStackStxOp)
     );
-    expect(blockTxOpsQuery.body.operations).toContainEqual(
+    expect(blockTxOpsQuery.body.transaction.operations).toContainEqual(
       expect.objectContaining(expectedStxLockOp)
     );
 

--- a/tests/rosetta/api.test.ts
+++ b/tests/rosetta/api.test.ts
@@ -408,7 +408,7 @@ describe('Rosetta API', () => {
       });
     expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
-    expect(JSON.parse(query1.text)).toEqual({
+    expect(JSON.parse(query1.text).transaction).toEqual({
       transaction_identifier: {
         hash: tx.tx_id,
       },
@@ -607,7 +607,7 @@ describe('Rosetta API', () => {
       });
     expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
-    expect(JSON.parse(query1.text)).toEqual({
+    expect(JSON.parse(query1.text).transaction).toEqual({
       transaction_identifier: {
         hash: '0xc152de9376bab4fc27291c9cd088643698290a12bb511d768f873cb3d280eb48',
       },
@@ -769,7 +769,7 @@ describe('Rosetta API', () => {
       });
     expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
-    expect(JSON.parse(query1.text)).toEqual({
+    expect(JSON.parse(query1.text).transaction).toEqual({
       operations: [
         {
           account: {
@@ -799,7 +799,7 @@ describe('Rosetta API', () => {
       });
     expect(query2.status).toBe(200);
     expect(query2.type).toBe('application/json');
-    expect(JSON.parse(query2.text)).toEqual({
+    expect(JSON.parse(query2.text).transaction).toEqual({
       operations: [
         {
           account: {
@@ -870,7 +870,7 @@ describe('Rosetta API', () => {
         });
       expect(query1.status).toBe(200);
       expect(query1.type).toBe('application/json');
-      expect(query1.body).toEqual({
+      expect(query1.body.transaction).toEqual({
         transaction_identifier: {
           hash: txTenureChange1.tx_id,
         },

--- a/tests/rosetta/block.test.ts
+++ b/tests/rosetta/block.test.ts
@@ -395,7 +395,7 @@ describe('/block tests', () => {
       });
     expect(query5.status).toBe(200);
     expect(query5.type).toBe('application/json');
-    const result5 = JSON.parse(query5.text);
+    const result5 = JSON.parse(query5.text).transaction;
     // No operation, ignored due to missing metadata.
     expect(result5.operations[1]).toEqual(undefined);
   });

--- a/tests/rosetta/block.test.ts
+++ b/tests/rosetta/block.test.ts
@@ -100,7 +100,7 @@ describe('/block tests', () => {
       });
     expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
-    const result = JSON.parse(query1.text);
+    const result = JSON.parse(query1.text).transaction;
     expect(result.transaction_identifier.hash).toEqual('0x1112');
     expect(result.operations[1].metadata).toEqual({
       contract_id: 'ST27W5M8BRKA7C5MZE2R1S1F4XTPHFWFRNHA9M04Y.hello-world',
@@ -183,7 +183,7 @@ describe('/block tests', () => {
       });
     expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
-    const result1 = JSON.parse(query1.text);
+    const result1 = JSON.parse(query1.text).transaction;
     expect(result1.operations[1]).toEqual({
       account: {
         address: 'SP3WV3VC6GM1WF215SDHP0MESQ3BNXHB1N6TPB70S',
@@ -269,7 +269,7 @@ describe('/block tests', () => {
       });
     expect(query2.status).toBe(200);
     expect(query2.type).toBe('application/json');
-    const result2 = JSON.parse(query2.text);
+    const result2 = JSON.parse(query2.text).transaction;
     expect(result2.operations[1]).toEqual({
       account: {
         address: 'SP3WV3VC6GM1WF215SDHP0MESQ3BNXHB1N6TPB70S',
@@ -318,7 +318,7 @@ describe('/block tests', () => {
       });
     expect(query3.status).toBe(200);
     expect(query3.type).toBe('application/json');
-    const result3 = JSON.parse(query3.text);
+    const result3 = JSON.parse(query3.text).transaction;
     expect(result3.operations[1]).toEqual({
       account: {
         address: 'SP3WV3VC6GM1WF215SDHP0MESQ3BNXHB1N6TPB70S',
@@ -565,7 +565,7 @@ describe('/block tests', () => {
       });
     expect(query1.status).toBe(200);
     expect(query1.type).toBe('application/json');
-    const result = JSON.parse(query1.text);
+    const result = JSON.parse(query1.text).transaction;
     expect(result.transaction_identifier.hash).toEqual('0x1112');
     expect(result.operations[2].metadata).toEqual({ memo: 'memo-1' });
     expect(result.operations[2].operation_identifier.index).toEqual(2);
@@ -619,7 +619,7 @@ describe('/block tests', () => {
       });
     expect(query2.status).toBe(200);
     expect(query2.type).toBe('application/json');
-    const result2 = JSON.parse(query2.text);
+    const result2 = JSON.parse(query2.text).transaction;
     expect(result2.transaction_identifier.hash).toEqual('0x1113');
     expect(result2.operations[2].metadata).toEqual({ memo: 'memo-1' });
     expect(result2.operations[3].metadata).toEqual({ memo: 'memo-1' });

--- a/tests/rosetta/genesis-chunk-ops.test.ts
+++ b/tests/rosetta/genesis-chunk-ops.test.ts
@@ -1,0 +1,169 @@
+import {
+  BaseTx,
+  DbAssetEventTypeId,
+  DbEvent,
+  DbEventTypeId,
+  DbTxAnchorMode,
+  DbTxStatus,
+  DbTxTypeId,
+} from '../../src/datastore/common';
+import { getOperationsFromEvents } from '../../src/rosetta/rosetta-helpers';
+import { RosettaOperationType } from '../../src/api/rosetta-constants';
+
+// Live integration test: we fetch real genesis state transaction events from Hiro's public
+// stacks-blockchain-api (same data model as the rosetta service) and feed them through
+// `getOperationsFromEvents` to validate that the synthetic chunk code path produces rosetta
+// operations whose (recipient, amount) pairs exactly match the upstream on-chain events.
+//
+// This proves end-to-end that the chunking approach can parse the real ~330k genesis mint
+// events the rosetta service was silently dropping.
+
+const HIRO_API = 'https://api.mainnet.hiro.so';
+const GENESIS_TX_ID = '0x2f079994c9bd92b2272258b9de73e278824d76efe1b5a83a3b00941f9559de8a';
+const EXPECTED_EVENT_COUNT = 330441;
+const MAINNET_CHAIN_ID = 0x00000001;
+
+interface HiroStxAssetEvent {
+  event_index: number;
+  event_type: 'stx_asset';
+  tx_id: string;
+  asset: {
+    asset_event_type: 'mint' | 'transfer' | 'burn';
+    sender: string;
+    recipient: string;
+    amount: string;
+  };
+}
+
+async function fetchGenesisTxMeta(): Promise<{ event_count: number }> {
+  const res = await fetch(
+    `${HIRO_API}/extended/v1/tx/${GENESIS_TX_ID}?event_offset=0&event_limit=0`
+  );
+  if (!res.ok) throw new Error(`hiro tx fetch failed: ${res.status}`);
+  const body = (await res.json()) as { event_count: number };
+  return { event_count: body.event_count };
+}
+
+async function fetchGenesisEvents(offset: number, limit: number): Promise<HiroStxAssetEvent[]> {
+  const url = `${HIRO_API}/extended/v1/tx/${GENESIS_TX_ID}?event_offset=${offset}&event_limit=${limit}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`hiro events fetch failed: ${res.status}`);
+  const body = (await res.json()) as { events: HiroStxAssetEvent[] };
+  return body.events;
+}
+
+function toDbStxMintEvent(e: HiroStxAssetEvent): DbEvent {
+  if (e.event_type !== 'stx_asset' || e.asset.asset_event_type !== 'mint') {
+    throw new Error(`expected stx_asset/mint event, got ${JSON.stringify(e)}`);
+  }
+  return {
+    event_index: e.event_index,
+    tx_id: e.tx_id,
+    tx_index: 7,
+    block_height: 1,
+    canonical: true,
+    event_type: DbEventTypeId.StxAsset,
+    asset_event_type_id: DbAssetEventTypeId.Mint,
+    amount: BigInt(e.asset.amount),
+    sender: e.asset.sender || undefined,
+    recipient: e.asset.recipient,
+  };
+}
+
+function makeGenesisBaseTx(): BaseTx {
+  return {
+    fee_rate: BigInt(0),
+    sender_address: 'SP000000000000000000002Q6VF78',
+    sponsored: false,
+    nonce: 0,
+    tx_id: GENESIS_TX_ID,
+    anchor_mode: 3 as DbTxAnchorMode,
+    status: DbTxStatus.Success,
+    type_id: DbTxTypeId.TokenTransfer,
+  };
+}
+
+describe('genesis chunk op construction against real mainnet data', () => {
+  // Stand-in for PgStore. `processEvents` does not touch the db for stx_asset/mint events,
+  // and our `getOperationsFromEvents` branches on `instanceof PgStore` so a plain object
+  // skips the sqlTransaction wrapping.
+  const fakeDb = {} as any;
+
+  test('hiro reports the expected genesis event count, and our chunking math matches', async () => {
+    const { event_count } = await fetchGenesisTxMeta();
+    expect(event_count).toBe(EXPECTED_EVENT_COUNT);
+    // Chunk size 1000 => ceil(330441 / 1000) = 331 chunks.
+    expect(Math.ceil(event_count / 1000)).toBe(331);
+  });
+
+  test('parses the first 50 real genesis mint events into correct mint operations', async () => {
+    const hiroEvents = await fetchGenesisEvents(0, 50);
+    expect(hiroEvents.length).toBe(50);
+    // Sanity: event_index is contiguous starting at 0.
+    hiroEvents.forEach((e, i) => expect(e.event_index).toBe(i));
+
+    const dbEvents = hiroEvents.map(toDbStxMintEvent);
+    const ops = await getOperationsFromEvents(
+      makeGenesisBaseTx() as any,
+      fakeDb,
+      MAINNET_CHAIN_ID,
+      dbEvents
+    );
+
+    expect(ops).toHaveLength(50);
+    ops.forEach((op, i) => {
+      const src = hiroEvents[i];
+      expect(op.type).toBe(RosettaOperationType.Mint);
+      expect(op.status).toBe('success');
+      expect(op.operation_identifier.index).toBe(i);
+      expect(op.account?.address).toBe(src.asset.recipient);
+      expect(op.amount?.value).toBe(src.asset.amount);
+      expect(op.amount?.currency.symbol).toBe('STX');
+      expect(op.amount?.currency.decimals).toBe(6);
+    });
+  });
+
+  test('parses mid-range genesis events (offset=1000) — proves chunk boundary slicing', async () => {
+    const hiroEvents = await fetchGenesisEvents(1000, 20);
+    expect(hiroEvents.length).toBe(20);
+    hiroEvents.forEach((e, i) => expect(e.event_index).toBe(1000 + i));
+
+    const dbEvents = hiroEvents.map(toDbStxMintEvent);
+    const ops = await getOperationsFromEvents(
+      makeGenesisBaseTx() as any,
+      fakeDb,
+      MAINNET_CHAIN_ID,
+      dbEvents
+    );
+
+    expect(ops).toHaveLength(20);
+    // Op index restarts at 0 per chunk, independent of event_index.
+    expect(ops[0].operation_identifier.index).toBe(0);
+    expect(ops[0].account?.address).toBe(hiroEvents[0].asset.recipient);
+    expect(ops[0].amount?.value).toBe(hiroEvents[0].asset.amount);
+  });
+
+  test('parses the tail of the event stream — proves last chunk boundary works', async () => {
+    // Hiro caps event_limit at 100. Fetch the last 100 events. The final event_index must be
+    // event_count - 1, which is what a consumer paginating through all 331 chunks would see
+    // when they reach the last chunk.
+    const tailOffset = EXPECTED_EVENT_COUNT - 100;
+    const hiroEvents = await fetchGenesisEvents(tailOffset, 100);
+    expect(hiroEvents.length).toBe(100);
+    expect(hiroEvents[0].event_index).toBe(tailOffset);
+    expect(hiroEvents[99].event_index).toBe(EXPECTED_EVENT_COUNT - 1);
+
+    const dbEvents = hiroEvents.map(toDbStxMintEvent);
+    const ops = await getOperationsFromEvents(
+      makeGenesisBaseTx() as any,
+      fakeDb,
+      MAINNET_CHAIN_ID,
+      dbEvents
+    );
+
+    expect(ops).toHaveLength(100);
+    expect(ops.every(op => op.type === RosettaOperationType.Mint)).toBe(true);
+    expect(ops[0].account?.address).toBe(hiroEvents[0].asset.recipient);
+    expect(ops[99].account?.address).toBe(hiroEvents[99].asset.recipient);
+  });
+});

--- a/tests/rosetta/genesis-chunk-tx-id.test.ts
+++ b/tests/rosetta/genesis-chunk-tx-id.test.ts
@@ -1,0 +1,44 @@
+import {
+  buildGenesisChunkTxId,
+  GENESIS_CHUNK_TX_ID_SEPARATOR,
+  parseGenesisChunkTxId,
+} from '../../src/api/rosetta-constants';
+
+describe('genesis chunk tx id helpers', () => {
+  const genesisTxId = '0x2f079994c9bd92b2272258b9de73e278824d76efe1b5a83a3b00941f9559de8a';
+
+  test('round-trips a normal chunk index', () => {
+    const synthetic = buildGenesisChunkTxId(genesisTxId, 42);
+    expect(synthetic).toBe(`${genesisTxId}${GENESIS_CHUNK_TX_ID_SEPARATOR}42`);
+    expect(parseGenesisChunkTxId(synthetic)).toEqual({
+      origTxId: genesisTxId,
+      chunkIndex: 42,
+    });
+  });
+
+  test('round-trips chunk index 0', () => {
+    const synthetic = buildGenesisChunkTxId(genesisTxId, 0);
+    expect(parseGenesisChunkTxId(synthetic)).toEqual({
+      origTxId: genesisTxId,
+      chunkIndex: 0,
+    });
+  });
+
+  test('rejects a non-synthetic tx id', () => {
+    expect(parseGenesisChunkTxId(genesisTxId)).toBeNull();
+  });
+
+  test('rejects a synthetic id with a non-numeric chunk suffix', () => {
+    expect(parseGenesisChunkTxId(`${genesisTxId}${GENESIS_CHUNK_TX_ID_SEPARATOR}abc`)).toBeNull();
+    expect(parseGenesisChunkTxId(`${genesisTxId}${GENESIS_CHUNK_TX_ID_SEPARATOR}-1`)).toBeNull();
+    expect(parseGenesisChunkTxId(`${genesisTxId}${GENESIS_CHUNK_TX_ID_SEPARATOR}1.5`)).toBeNull();
+    expect(parseGenesisChunkTxId(`${genesisTxId}${GENESIS_CHUNK_TX_ID_SEPARATOR}`)).toBeNull();
+  });
+
+  test('parses using the last separator so multiple occurrences in the original tx id do not break', () => {
+    const weirdTxId = `0xdead${GENESIS_CHUNK_TX_ID_SEPARATOR}beef`;
+    const synthetic = buildGenesisChunkTxId(weirdTxId, 7);
+    const parsed = parseGenesisChunkTxId(synthetic);
+    expect(parsed).toEqual({ origTxId: weirdTxId, chunkIndex: 7 });
+  });
+});


### PR DESCRIPTION
Builds on the work started in https://github.com/hirosystems/stacks-blockchain-api/pull/2538
Fixes performance and response shapes