### PR TITLE
fix: perserve block boundaries for v3 transaction cursors

### DIFF
--- a/src/api/schemas/v3/cursors.ts
+++ b/src/api/schemas/v3/cursors.ts
@@ -1,4 +1,4 @@
-import { ObjectOptions, TSchema, Type } from '@sinclair/typebox';
+import { ObjectOptions, Static, TSchema, Type } from '@sinclair/typebox';
 import { pagingQueryLimits, ResourceType } from '../../pagination.js';
 import { Nullable } from '../v1/util.js';
 
@@ -58,8 +58,10 @@ export const TransactionCursorSchema = Type.String({
     'Cursor for paginating transactions. Format: block_height:microblock_sequence:tx_index',
   pattern: '^[0-9]+:[0-9]+:[0-9]+$',
 });
+export type TransactionCursor = Static<typeof TransactionCursorSchema>;
 
 export const MempoolTransactionCursorSchema = Type.String({
   pattern: '^\\d+:(0x)?[a-fA-F0-9]{64}$',
   description: 'Cursor for paginating mempool transactions. Format: receipt_time:tx_id',
 });
+export type MempoolTransactionCursor = Static<typeof MempoolTransactionCursorSchema>;

--- a/src/datastore/v3/helpers.ts
+++ b/src/datastore/v3/helpers.ts
@@ -1,0 +1,42 @@
+import { TransactionCursor } from '../../api/schemas/v3/cursors.js';
+import { I32_MAX } from '../../helpers.js';
+
+const MAX_TX_INDEX = 0x7fff;
+
+export type TransactionCursorRow = {
+  block_height: number;
+  microblock_sequence: number;
+  tx_index: number;
+};
+
+const parseTransactionCursor = (cursor: TransactionCursor): TransactionCursorRow => {
+  const [blockHeightStr, microblockSequenceStr, txIndexStr] = cursor.split(':');
+  return {
+    block_height: parseInt(blockHeightStr, 10),
+    microblock_sequence: parseInt(microblockSequenceStr, 10),
+    tx_index: parseInt(txIndexStr, 10),
+  };
+};
+
+/**
+ * Resolves a transaction cursor to a transaction cursor row.
+ * @param cursor - The transaction cursor.
+ * @param exactCursorExists - A function that checks if a cursor exists.
+ * @returns The transaction cursor row.
+ */
+export const resolveTransactionCursor = async (
+  cursor: TransactionCursor,
+  exactCursorExists: (cursor: TransactionCursorRow) => Promise<boolean>
+): Promise<TransactionCursorRow> => {
+  const parsed = parseTransactionCursor(cursor);
+  if (parsed.microblock_sequence !== 0 || parsed.tx_index !== 0) {
+    return parsed;
+  }
+  if (await exactCursorExists(parsed)) {
+    return parsed;
+  }
+  return { ...parsed, microblock_sequence: I32_MAX, tx_index: MAX_TX_INDEX };
+};
+
+export const encodeTransactionCursor = (tx: TransactionCursorRow): TransactionCursor =>
+  `${tx.block_height}:${tx.microblock_sequence}:${tx.tx_index}`;

--- a/src/datastore/v3/pg-store-v3.ts
+++ b/src/datastore/v3/pg-store-v3.ts
@@ -19,6 +19,8 @@ import { normalizeHashString } from '../../helpers.js';
 import { BlockIdParam } from '../../api/routes/v2/schemas.js';
 import { InvalidRequestError, InvalidRequestErrorType } from '../../errors.js';
 import { TransactionIncludeField } from '../../api/schemas/v3/entities/transactions.js';
+import type { TransactionCursor } from '../../api/schemas/v3/cursors.js';
+import { encodeTransactionCursor, resolveTransactionCursor } from './helpers.js';
 
 export class PgStoreV3 extends BasePgStoreModule {
   /**
@@ -28,19 +30,27 @@ export class PgStoreV3 extends BasePgStoreModule {
    */
   async getTransactionSummaries(args: {
     limit: number;
-    cursor?: string;
+    cursor?: TransactionCursor;
   }): Promise<DbCursorPaginatedResult<DbTransactionSummary>> {
     return await this.sqlTransaction(async sql => {
       let cursorFilter = sql``;
       if (args.cursor) {
-        const parts = args.cursor.split(':');
-        const [blockHeightStr, microblockSequenceStr, txIndexStr] = parts;
-        const blockHeight = parseInt(blockHeightStr, 10);
-        const microblockSequence = parseInt(microblockSequenceStr, 10);
-        const txIndex = parseInt(txIndexStr, 10);
+        const cursor = await resolveTransactionCursor(args.cursor, async cursor => {
+          const exactCursorQuery = await sql<{ exists: boolean }[]>`
+            SELECT EXISTS (
+              SELECT 1
+              FROM txs
+              WHERE canonical = true
+                AND microblock_canonical = true
+                AND (block_height, microblock_sequence, tx_index)
+                    = (${cursor.block_height}, ${cursor.microblock_sequence}, ${cursor.tx_index})
+            ) AS exists
+          `;
+          return exactCursorQuery[0]?.exists ?? false;
+        });
         cursorFilter = sql`
           AND (block_height, microblock_sequence, tx_index)
-              <= (${blockHeight}, ${microblockSequence}, ${txIndex})
+              <= (${cursor.block_height}, ${cursor.microblock_sequence}, ${cursor.tx_index})
         `;
       }
       const resultQuery = await sql<
@@ -62,15 +72,10 @@ export class PgStoreV3 extends BasePgStoreModule {
       const total = resultQuery.count > 0 ? resultQuery[0].total : 0;
 
       const nextResult = resultQuery[resultQuery.length - 1];
-      const nextCursor =
-        hasNextPage && nextResult
-          ? `${nextResult.block_height}:${nextResult.microblock_sequence}:${nextResult.tx_index}`
-          : null;
+      const nextCursor = hasNextPage && nextResult ? encodeTransactionCursor(nextResult) : null;
 
       const firstResult = results[0];
-      const currentCursor = firstResult
-        ? `${firstResult.block_height}:${firstResult.microblock_sequence}:${firstResult.tx_index}`
-        : null;
+      const currentCursor = firstResult ? encodeTransactionCursor(firstResult) : null;
 
       let prevCursor: string | null = null;
       if (firstResult) {
@@ -88,12 +93,11 @@ export class PgStoreV3 extends BasePgStoreModule {
                   ${firstResult.tx_index}
                 )
           ORDER BY block_height ASC, microblock_sequence ASC, tx_index ASC
-          OFFSET ${args.limit - 1}
-          LIMIT 1
+          LIMIT ${args.limit}
         `;
         if (prevPageQuery.length > 0) {
-          const prevPage = prevPageQuery[0];
-          prevCursor = `${prevPage.block_height}:${prevPage.microblock_sequence}:${prevPage.tx_index}`;
+          const prevPage = prevPageQuery[prevPageQuery.length - 1];
+          prevCursor = encodeTransactionCursor(prevPage);
         }
       }
 
@@ -117,19 +121,28 @@ export class PgStoreV3 extends BasePgStoreModule {
   async getPrincipalTransactionSummaries(args: {
     principal: Principal;
     limit: number;
-    cursor?: string;
+    cursor?: TransactionCursor;
   }): Promise<DbCursorPaginatedResult<DbPrincipalTransactionSummary>> {
     return await this.sqlTransaction(async sql => {
       let cursorFilter = sql``;
       if (args.cursor) {
-        const parts = args.cursor.split(':');
-        const [blockHeightStr, microblockSequenceStr, txIndexStr] = parts;
-        const blockHeight = parseInt(blockHeightStr, 10);
-        const microblockSequence = parseInt(microblockSequenceStr, 10);
-        const txIndex = parseInt(txIndexStr, 10);
+        const cursor = await resolveTransactionCursor(args.cursor, async cursor => {
+          const exactCursorQuery = await sql<{ exists: boolean }[]>`
+            SELECT EXISTS (
+              SELECT 1
+              FROM principal_txs
+              WHERE canonical = true
+                AND microblock_canonical = true
+                AND principal = ${args.principal}
+                AND (block_height, microblock_sequence, tx_index)
+                    = (${cursor.block_height}, ${cursor.microblock_sequence}, ${cursor.tx_index})
+            ) AS exists
+          `;
+          return exactCursorQuery[0]?.exists ?? false;
+        });
         cursorFilter = sql`
           AND (block_height, microblock_sequence, tx_index)
-              <= (${blockHeight}, ${microblockSequence}, ${txIndex})
+              <= (${cursor.block_height}, ${cursor.microblock_sequence}, ${cursor.tx_index})
         `;
       }
       const resultQuery = await sql<
@@ -182,15 +195,10 @@ export class PgStoreV3 extends BasePgStoreModule {
       const total = resultQuery.count > 0 ? resultQuery[0].total : 0;
 
       const nextResult = resultQuery[resultQuery.length - 1];
-      const nextCursor =
-        hasNextPage && nextResult
-          ? `${nextResult.block_height}:${nextResult.microblock_sequence}:${nextResult.tx_index}`
-          : null;
+      const nextCursor = hasNextPage && nextResult ? encodeTransactionCursor(nextResult) : null;
 
       const firstResult = results[0];
-      const currentCursor = firstResult
-        ? `${firstResult.block_height}:${firstResult.microblock_sequence}:${firstResult.tx_index}`
-        : null;
+      const currentCursor = firstResult ? encodeTransactionCursor(firstResult) : null;
 
       let prevCursor: string | null = null;
       if (firstResult) {
@@ -209,12 +217,11 @@ export class PgStoreV3 extends BasePgStoreModule {
                   ${firstResult.tx_index}
                 )
           ORDER BY block_height ASC, microblock_sequence ASC, tx_index ASC
-          OFFSET ${args.limit - 1}
-          LIMIT 1
+          LIMIT ${args.limit}
         `;
         if (prevPageQuery.length > 0) {
-          const prevPage = prevPageQuery[0];
-          prevCursor = `${prevPage.block_height}:${prevPage.microblock_sequence}:${prevPage.tx_index}`;
+          const prevPage = prevPageQuery[prevPageQuery.length - 1];
+          prevCursor = encodeTransactionCursor(prevPage);
         }
       }
 
@@ -278,11 +285,12 @@ export class PgStoreV3 extends BasePgStoreModule {
           WHERE pruned = false
             AND (receipt_time, tx_id) > (${firstResult.receipt_time}, ${firstResult.tx_id})
           ORDER BY receipt_time ASC, tx_id ASC
-          OFFSET ${args.limit - 1}
-          LIMIT 1
+          LIMIT ${args.limit}
         `;
         prevCursor =
-          prevPageQuery.length > 0 ? encodeMempoolTxSummaryCursor(prevPageQuery[0]) : null;
+          prevPageQuery.length > 0
+            ? encodeMempoolTxSummaryCursor(prevPageQuery[prevPageQuery.length - 1])
+            : null;
       }
 
       return {
@@ -305,7 +313,7 @@ export class PgStoreV3 extends BasePgStoreModule {
   async getBlockTransactionSummaries(args: {
     block: BlockIdParam;
     limit: number;
-    cursor?: string;
+    cursor?: TransactionCursor;
   }): Promise<DbCursorPaginatedResult<DbTransactionSummary>> {
     return await this.sqlTransaction(async sql => {
       const blockFilter =
@@ -332,14 +340,23 @@ export class PgStoreV3 extends BasePgStoreModule {
 
       let cursorFilter = sql``;
       if (args.cursor) {
-        const parts = args.cursor.split(':');
-        const [blockHeightStr, microblockSequenceStr, txIndexStr] = parts;
-        const blockHeight = parseInt(blockHeightStr, 10);
-        const microblockSequence = parseInt(microblockSequenceStr, 10);
-        const txIndex = parseInt(txIndexStr, 10);
+        const cursor = await resolveTransactionCursor(args.cursor, async cursor => {
+          const exactCursorQuery = await sql<{ exists: boolean }[]>`
+            SELECT EXISTS (
+              SELECT 1
+              FROM txs
+              WHERE canonical = true
+                AND microblock_canonical = true
+                AND index_block_hash = ${index_block_hash}
+                AND (block_height, microblock_sequence, tx_index)
+                    = (${cursor.block_height}, ${cursor.microblock_sequence}, ${cursor.tx_index})
+            ) AS exists
+          `;
+          return exactCursorQuery[0]?.exists ?? false;
+        });
         cursorFilter = sql`
           AND (block_height, microblock_sequence, tx_index)
-              <= (${blockHeight}, ${microblockSequence}, ${txIndex})
+              <= (${cursor.block_height}, ${cursor.microblock_sequence}, ${cursor.tx_index})
         `;
       }
 
@@ -358,15 +375,10 @@ export class PgStoreV3 extends BasePgStoreModule {
       const results = hasNextPage ? resultQuery.slice(0, args.limit) : resultQuery;
 
       const nextResult = resultQuery[resultQuery.length - 1];
-      const nextCursor =
-        hasNextPage && nextResult
-          ? `${nextResult.block_height}:${nextResult.microblock_sequence}:${nextResult.tx_index}`
-          : null;
+      const nextCursor = hasNextPage && nextResult ? encodeTransactionCursor(nextResult) : null;
 
       const firstResult = results[0];
-      const currentCursor = firstResult
-        ? `${firstResult.block_height}:${firstResult.microblock_sequence}:${firstResult.tx_index}`
-        : null;
+      const currentCursor = firstResult ? encodeTransactionCursor(firstResult) : null;
 
       let prevCursor: string | null = null;
       if (firstResult) {
@@ -385,12 +397,11 @@ export class PgStoreV3 extends BasePgStoreModule {
                   ${firstResult.tx_index}
                 )
           ORDER BY block_height ASC, microblock_sequence ASC, tx_index ASC
-          OFFSET ${args.limit - 1}
-          LIMIT 1
+          LIMIT ${args.limit}
         `;
         if (prevPageQuery.length > 0) {
-          const prevPage = prevPageQuery[0];
-          prevCursor = `${prevPage.block_height}:${prevPage.microblock_sequence}:${prevPage.tx_index}`;
+          const prevPage = prevPageQuery[prevPageQuery.length - 1];
+          prevCursor = encodeTransactionCursor(prevPage);
         }
       }
 

--- a/tests/api/v3/blocks.test.ts
+++ b/tests/api/v3/blocks.test.ts
@@ -438,6 +438,46 @@ describe('blocks', () => {
       });
     });
 
+    test('should preserve exact height:0:0 transaction cursors', async () => {
+      await db.update(
+        new TestBlockBuilder({
+          block_height: 1,
+          index_block_hash: hex(1),
+          parent_index_block_hash: hex(0),
+          parent_block_hash: hex(0),
+        })
+          .addTx({
+            tx_id: hex(0x1001),
+            tx_index: 0,
+            microblock_sequence: 0,
+          })
+          .addTx({
+            tx_id: hex(0x1002),
+            tx_index: 1,
+            microblock_sequence: I32_MAX,
+          })
+          .build()
+      );
+
+      const response = await api.fastifyApp.inject({
+        method: 'GET',
+        url: '/extended/v3/blocks/1/transactions',
+        query: {
+          limit: '1',
+          cursor: '1:0:0',
+        },
+      });
+      assert.equal(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.equal(body.results.length, 1);
+      assert.equal(body.results[0].tx_id, hex(0x1001));
+      assert.deepEqual(body.cursor, {
+        next: null,
+        previous: `1:${I32_MAX}:1`,
+        current: '1:0:0',
+      });
+    });
+
     test('should return 304 when ETag matches and refresh ETag per block', async () => {
       await db.update(
         new TestBlockBuilder({

--- a/tests/api/v3/blocks.test.ts
+++ b/tests/api/v3/blocks.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'node:assert/strict';
 import { TestBlockBuilder } from '../test-builders.ts';
 import { DbTxStatus, DbTxTypeId } from '../../../src/datastore/common.ts';
 import { hex } from '../test-helpers.ts';
+import { I32_MAX } from '../../../src/helpers.ts';
 
 const SENDER = 'SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27';
 const RECIPIENT = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
@@ -401,6 +402,40 @@ describe('blocks', () => {
       // The page before tx_index=0 is the first row of this block — there is no earlier row.
       assert.equal(body.cursor.previous, '2:0:1');
       assert.equal(body.cursor.current, '2:0:0');
+    });
+
+    test('should allow block-boundary cursors for anchored transactions', async () => {
+      await db.update(
+        new TestBlockBuilder({
+          block_height: 1,
+          index_block_hash: hex(1),
+          parent_index_block_hash: hex(0),
+          parent_block_hash: hex(0),
+        })
+          .addTx({
+            tx_id: hex(0x1001),
+            microblock_sequence: I32_MAX,
+          })
+          .build()
+      );
+
+      const response = await api.fastifyApp.inject({
+        method: 'GET',
+        url: '/extended/v3/blocks/1/transactions',
+        query: {
+          limit: '1',
+          cursor: '1:0:0',
+        },
+      });
+      assert.equal(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.equal(body.results.length, 1);
+      assert.equal(body.results[0].tx_id, hex(0x1001));
+      assert.deepEqual(body.cursor, {
+        next: null,
+        previous: null,
+        current: `1:${I32_MAX}:0`,
+      });
     });
 
     test('should return 304 when ETag matches and refresh ETag per block', async () => {

--- a/tests/api/v3/principals.test.ts
+++ b/tests/api/v3/principals.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'node:assert/strict';
 import { TestBlockBuilder } from '../test-builders.ts';
 import { DbTxStatus, DbTxTypeId } from '../../../src/datastore/common.ts';
 import { hex } from '../test-helpers.ts';
+import { I32_MAX } from '../../../src/helpers.ts';
 
 describe('principals', () => {
   let db: PgWriteStore;
@@ -313,6 +314,67 @@ describe('principals', () => {
         next: '8:0:4',
         previous: '10:0:4',
         current: '9:0:4',
+      });
+
+      // Fetch a partial page that has fewer than `limit` newer rows. The previous
+      // cursor should still point back to the first available row.
+      const partialPreviousPage = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/principals/${emptyPrincipal}/transactions`,
+        query: {
+          limit: '5',
+          cursor: '12:0:2',
+        },
+      });
+      assert.equal(partialPreviousPage.statusCode, 200);
+      const partialPreviousBody = JSON.parse(partialPreviousPage.body);
+      assert.equal(partialPreviousBody.results.length, 5);
+      assert.deepEqual(partialPreviousBody.cursor, {
+        next: '11:0:2',
+        previous: '12:0:4',
+        current: '12:0:2',
+      });
+    });
+
+    test('should allow block-boundary cursors for anchored transactions', async () => {
+      await db.update(
+        new TestBlockBuilder({
+          block_height: 3,
+          block_hash: hex(3),
+          index_block_hash: hex(3),
+          parent_index_block_hash: hex(2),
+          parent_block_hash: hex(2),
+        })
+          .addTx({
+            tx_id: hex(0x3001),
+            block_hash: hex(3),
+            index_block_hash: hex(3),
+            block_time: 3000,
+            burn_block_height: 3,
+            burn_block_time: 3000,
+            tx_index: 0,
+            microblock_sequence: I32_MAX,
+            sender_address: emptyPrincipal,
+          })
+          .build()
+      );
+
+      const response = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/principals/${emptyPrincipal}/transactions`,
+        query: {
+          limit: '1',
+          cursor: '3:0:0',
+        },
+      });
+      assert.equal(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.equal(body.results.length, 1);
+      assert.equal(body.results[0].transaction.tx_id, hex(0x3001));
+      assert.deepEqual(body.cursor, {
+        next: null,
+        previous: null,
+        current: `3:${I32_MAX}:0`,
       });
     });
 

--- a/tests/api/v3/principals.test.ts
+++ b/tests/api/v3/principals.test.ts
@@ -378,6 +378,59 @@ describe('principals', () => {
       });
     });
 
+    test('should preserve exact height:0:0 transaction cursors', async () => {
+      await db.update(
+        new TestBlockBuilder({
+          block_height: 3,
+          block_hash: hex(3),
+          index_block_hash: hex(3),
+          parent_index_block_hash: hex(2),
+          parent_block_hash: hex(2),
+        })
+          .addTx({
+            tx_id: hex(0x3001),
+            block_hash: hex(3),
+            index_block_hash: hex(3),
+            block_time: 3000,
+            burn_block_height: 3,
+            burn_block_time: 3000,
+            tx_index: 0,
+            microblock_sequence: 0,
+            sender_address: emptyPrincipal,
+          })
+          .addTx({
+            tx_id: hex(0x3002),
+            block_hash: hex(3),
+            index_block_hash: hex(3),
+            block_time: 3000,
+            burn_block_height: 3,
+            burn_block_time: 3000,
+            tx_index: 1,
+            microblock_sequence: I32_MAX,
+            sender_address: emptyPrincipal,
+          })
+          .build()
+      );
+
+      const response = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/principals/${emptyPrincipal}/transactions`,
+        query: {
+          limit: '1',
+          cursor: '3:0:0',
+        },
+      });
+      assert.equal(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.equal(body.results.length, 1);
+      assert.equal(body.results[0].transaction.tx_id, hex(0x3001));
+      assert.deepEqual(body.cursor, {
+        next: null,
+        previous: `3:${I32_MAX}:1`,
+        current: '3:0:0',
+      });
+    });
+
     test('should return 304 when ETag matches and refresh ETag on new principal activity', async () => {
       // testAddr1 has confirmed activity from the setup, so the principal cache is populated.
       const first = await api.fastifyApp.inject({

--- a/tests/api/v3/transactions.test.ts
+++ b/tests/api/v3/transactions.test.ts
@@ -259,6 +259,46 @@ describe('transactions', () => {
       });
     });
 
+    test('should preserve exact height:0:0 transaction cursors', async () => {
+      await db.update(
+        new TestBlockBuilder({
+          block_height: 1,
+          index_block_hash: hex(1),
+          parent_index_block_hash: hex(0),
+          parent_block_hash: hex(0),
+        })
+          .addTx({
+            tx_id: hex(0x1001),
+            tx_index: 0,
+            microblock_sequence: 0,
+          })
+          .addTx({
+            tx_id: hex(0x1002),
+            tx_index: 1,
+            microblock_sequence: I32_MAX,
+          })
+          .build()
+      );
+
+      const response = await api.fastifyApp.inject({
+        method: 'GET',
+        url: '/extended/v3/transactions',
+        query: {
+          limit: '1',
+          cursor: '1:0:0',
+        },
+      });
+      assert.equal(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.equal(body.results.length, 1);
+      assert.equal(body.results[0].tx_id, hex(0x1001));
+      assert.deepEqual(body.cursor, {
+        next: null,
+        previous: `1:${I32_MAX}:1`,
+        current: '1:0:0',
+      });
+    });
+
     test('should return 304 when ETag matches and refresh ETag when chain tip changes', async () => {
       await db.update(
         new TestBlockBuilder({

--- a/tests/api/v3/transactions.test.ts
+++ b/tests/api/v3/transactions.test.ts
@@ -9,6 +9,7 @@ import { DbTxStatus, DbTxTypeId } from '../../../src/datastore/common.ts';
 import { stringAsciiCV, uintCV } from '@stacks/transactions';
 import { bufferToHex } from '@stacks/api-toolkit';
 import { hex } from '../test-helpers.ts';
+import { I32_MAX } from '../../../src/helpers.ts';
 
 describe('transactions', () => {
   let db: PgWriteStore;
@@ -221,6 +222,40 @@ describe('transactions', () => {
         next: '8:0:4',
         previous: '10:0:4',
         current: '9:0:4',
+      });
+    });
+
+    test('should allow block-boundary cursors for anchored transactions', async () => {
+      await db.update(
+        new TestBlockBuilder({
+          block_height: 1,
+          index_block_hash: hex(1),
+          parent_index_block_hash: hex(0),
+          parent_block_hash: hex(0),
+        })
+          .addTx({
+            tx_id: hex(0x1001),
+            microblock_sequence: I32_MAX,
+          })
+          .build()
+      );
+
+      const response = await api.fastifyApp.inject({
+        method: 'GET',
+        url: '/extended/v3/transactions',
+        query: {
+          limit: '1',
+          cursor: '1:0:0',
+        },
+      });
+      assert.equal(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.equal(body.results.length, 1);
+      assert.equal(body.results[0].tx_id, hex(0x1001));
+      assert.deepEqual(body.cursor, {
+        next: null,
+        previous: null,
+        current: `1:${I32_MAX}:0`,
       });
     });
 


### PR DESCRIPTION
* Fix v3 transaction cursor handling for `height:0:0` cursors so anchored transactions with microblock_sequence = 2147483647 are included when the cursor represents a block boundary.
* Preserve exact `height:0:0` cursor behavior when an actual transaction exists at that cursor.
* Fix previous cursor generation for partial previous pages, and share transaction cursor parsing/encoding logic through datastore helpers.