### PR TITLE
feat: materialized locked-STX table and v3 principal balance endpoints

### DIFF
--- a/migrations/1779800000000_stx-locked-balances.ts
+++ b/migrations/1779800000000_stx-locked-balances.ts
@@ -1,0 +1,110 @@
+import type { ColumnDefinitions, MigrationBuilder } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+/**
+ * Materialized current STX lock state, one row per principal — so a principal's
+ * locked balance is a single-row lookup instead of recomputing it from the
+ * latest applicable lock event across pox versions on every read.
+ *
+ * Locked STX is NOT additive: every lock/stake event carries an absolute
+ * `locked_amount` + `unlock_burn_height`, a principal has at most one active
+ * lock at a time, and a lock auto-expires once the burn height reaches
+ * `unlock_burn_height` (no event fires at expiry). So this table is a
+ * "latest lock state per principal" (SET/replace), read with a height
+ * comparison:
+ *   locked = (current_burn_height < unlock_burn_height
+ *             AND force-unlock for `pox_version` not yet reached) ? locked_amount : 0
+ *
+ * Maintained on write from pox-4 lock events and pox-5 stake/stake-update/
+ * unstake events; recomputed for affected principals on reorg.
+ */
+export function up(pgm: MigrationBuilder): void {
+  pgm.createTable('stx_locked_balances', {
+    // One active lock per principal.
+    principal: {
+      type: 'text',
+      notNull: true,
+      primaryKey: true,
+    },
+    // Locked µSTX from the latest lock event.
+    locked_amount: {
+      type: 'numeric',
+      notNull: true,
+    },
+    // Burn height at which the lock expires (locked is 0 once reached).
+    unlock_burn_height: {
+      type: 'bigint',
+      notNull: true,
+    },
+    // Which pox contract set this lock (e.g. 4, 5) — needed to apply the
+    // per-version force-unlock heights (e.g. `pox_v4_unlock_height`).
+    pox_version: {
+      type: 'smallint',
+      notNull: true,
+    },
+    // Lock provenance, materialized so the balance response needs no extra query.
+    lock_tx_id: {
+      type: 'bytea',
+      notNull: true,
+    },
+    // Stacks block height where the lock was created.
+    lock_block_height: {
+      type: 'integer',
+      notNull: true,
+    },
+    // Burn height where the lock was created.
+    burnchain_lock_height: {
+      type: 'bigint',
+      notNull: true,
+    },
+  });
+
+  // Supports "who is still locked at burn height H" style scans.
+  pgm.createIndex('stx_locked_balances', 'unlock_burn_height');
+
+  // Backfill the table from existing pox-1..4 lock events (pox-5 locks are
+  // materialized by the synthetic stake/unstake handlers, so they're excluded
+  // here). For each principal, take their latest canonical lock event and keep
+  // it only if the lock is still active (positive amount, unlock height beyond
+  // the current canonical burn tip). This is a no-op on a fresh database.
+  pgm.sql(`
+    INSERT INTO stx_locked_balances (
+      principal, locked_amount, unlock_burn_height, pox_version,
+      lock_tx_id, lock_block_height, burnchain_lock_height
+    )
+    SELECT DISTINCT ON (e.locked_address)
+      e.locked_address,
+      e.locked_amount,
+      e.unlock_height,
+      CASE e.contract_name
+        WHEN 'pox' THEN 1
+        WHEN 'pox-2' THEN 2
+        WHEN 'pox-3' THEN 3
+        WHEN 'pox-4' THEN 4
+        ELSE 0
+      END AS pox_version,
+      e.tx_id,
+      e.block_height,
+      b.burn_block_height
+    FROM stx_lock_events e
+    JOIN blocks b ON b.index_block_hash = e.index_block_hash
+    WHERE e.canonical = true
+      AND e.microblock_canonical = true
+      AND e.contract_name <> 'pox-5'
+      AND e.locked_amount > 0
+      AND e.unlock_height > (
+        SELECT COALESCE(MAX(burn_block_height), 0) FROM blocks WHERE canonical = true
+      )
+    ORDER BY
+      e.locked_address,
+      e.block_height DESC,
+      e.microblock_sequence DESC,
+      e.tx_index DESC,
+      e.event_index DESC
+  `);
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropTable('stx_locked_balances');
+}

--- a/migrations/1779800000001_ft-balances-address-balance-index.ts
+++ b/migrations/1779800000001_ft-balances-address-balance-index.ts
@@ -1,0 +1,25 @@
+import type { ColumnDefinitions, MigrationBuilder } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+/**
+ * Supports the principal FT balances endpoint, which lists a principal's tokens
+ * sorted by balance descending and keyset-paginates by `(balance, token)`. This
+ * composite index lets the `WHERE address = $1 ORDER BY balance DESC, token ASC`
+ * scan be served directly from the index.
+ */
+export function up(pgm: MigrationBuilder): void {
+  pgm.createIndex('ft_balances', [
+    { name: 'address' },
+    { name: 'balance', sort: 'DESC' },
+    { name: 'token', sort: 'ASC' },
+  ]);
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropIndex('ft_balances', [
+    { name: 'address' },
+    { name: 'balance', sort: 'DESC' },
+    { name: 'token', sort: 'ASC' },
+  ]);
+}

--- a/migrations/1779800000002_nft-custody-recipient-asset-value-index.ts
+++ b/migrations/1779800000002_nft-custody-recipient-asset-value-index.ts
@@ -1,0 +1,27 @@
+import type { ColumnDefinitions, MigrationBuilder } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+/**
+ * Supports the principal NFT balances endpoint, which lists a principal's owned
+ * NFT instances keyset-paginated by `(asset_identifier, value)`. The existing
+ * `(recipient, asset_identifier)` index does not include `value`, so this adds
+ * it as the trailing key, letting the
+ * `WHERE recipient = $1 ... ORDER BY asset_identifier, value` scan be served
+ * directly from the index.
+ */
+export function up(pgm: MigrationBuilder): void {
+  pgm.createIndex('nft_custody', [
+    { name: 'recipient' },
+    { name: 'asset_identifier' },
+    { name: 'value' },
+  ]);
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropIndex('nft_custody', [
+    { name: 'recipient' },
+    { name: 'asset_identifier' },
+    { name: 'value' },
+  ]);
+}

--- a/src/api/pagination.ts
+++ b/src/api/pagination.ts
@@ -42,6 +42,7 @@ export enum ResourceType {
   TokenHolders,
   BlockSignerSignature,
   FtBalance,
+  NftBalance,
 }
 
 export const pagingQueryLimits: Record<ResourceType, { defaultLimit: number; maxLimit: number }> = {
@@ -102,6 +103,10 @@ export const pagingQueryLimits: Record<ResourceType, { defaultLimit: number; max
     maxLimit: 1000,
   },
   [ResourceType.FtBalance]: {
+    defaultLimit: 100,
+    maxLimit: 200,
+  },
+  [ResourceType.NftBalance]: {
     defaultLimit: 100,
     maxLimit: 200,
   },

--- a/src/api/routes/v2/addresses.ts
+++ b/src/api/routes/v2/addresses.ts
@@ -195,7 +195,6 @@ export const AddressRoutesV2: FastifyPluginAsync<
         const stxPoxLockedResult = await fastify.db.v2.getStxPoxLockedAtBlock({
           sql,
           stxAddress,
-          blockHeight: chainTip.block_height,
           burnBlockHeight: chainTip.burn_block_height,
         });
 

--- a/src/api/routes/v3/principals.ts
+++ b/src/api/routes/v3/principals.ts
@@ -1,4 +1,7 @@
-import { handlePrincipalCache } from '../../controllers/cache-controller.js';
+import {
+  handlePrincipalCache,
+  handlePrincipalMempoolCache,
+} from '../../controllers/cache-controller.js';
 import { FastifyPluginAsync } from 'fastify';
 import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Server } from 'node:http';
@@ -14,6 +17,10 @@ import { serializePrincipalTransactionSummary } from '../../serializers/v3/trans
 import { PrincipalBondPositionSchema } from '../../schemas/v3/entities/principal-bond-positions.js';
 import { serializeDbPrincipalBondPosition } from '../../serializers/v3/bonds.js';
 import { handleChainTipCache } from '../../controllers/cache-controller.js';
+import {
+  PrincipalStxBalance,
+  PrincipalStxBalanceSchema,
+} from '../../schemas/v3/entities/principal-balances.js';
 
 export const PrincipalsRoutes: FastifyPluginAsync<
   Record<never, never>,
@@ -80,6 +87,65 @@ export const PrincipalsRoutes: FastifyPluginAsync<
         principal: req.params.principal,
       });
       await reply.send(positions.map(serializeDbPrincipalBondPosition));
+    }
+  );
+
+  fastify.get(
+    '/principals/:principal/balances/stx',
+    {
+      preHandler: handlePrincipalMempoolCache,
+      schema: {
+        operationId: 'get_principal_stx_balance',
+        summary: 'Get principal STX balance',
+        description:
+          "Get a principal's STX balance: its total and spendable (available) balance, any locked STX, and the projected balance from pending mempool transactions.",
+        tags: ['Accounts'],
+        params: Type.Object({ principal: PrincipalSchema }),
+        response: {
+          200: PrincipalStxBalanceSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const stxAddress = req.params.principal;
+      const result = await fastify.db.sqlTransaction(async sql => {
+        const chainTip = await fastify.db.getChainTip(sql);
+        const holder = await fastify.db.v2.getStxHolderBalance({ sql, stxAddress });
+        const balance = holder.found ? holder.result.balance : 0n;
+        const lock = await fastify.db.v2.getStxPoxLockedAtBlock({
+          sql,
+          stxAddress,
+          burnBlockHeight: chainTip.burn_block_height,
+        });
+        const mempool = await fastify.db.getPrincipalMempoolStxBalanceDelta(sql, stxAddress);
+
+        const available = balance - lock.locked;
+        const response: PrincipalStxBalance = {
+          balance: balance.toString(),
+          available: available.toString(),
+          locked:
+            lock.locked > 0n
+              ? {
+                  amount: lock.locked.toString(),
+                  pox_version: lock.poxVersion,
+                  lock_tx_id: lock.lockTxId,
+                  stacks_lock_height: lock.lockHeight,
+                  burn_lock_height: lock.burnchainLockHeight,
+                  burn_unlock_height: lock.burnchainUnlockHeight,
+                }
+              : null,
+          mempool:
+            mempool.inbound > 0n || mempool.outbound > 0n
+              ? {
+                  estimated_balance: (available + mempool.delta).toString(),
+                  inbound: mempool.inbound.toString(),
+                  outbound: mempool.outbound.toString(),
+                }
+              : null,
+        };
+        return response;
+      });
+      await reply.send(result);
     }
   );
 

--- a/src/api/routes/v3/principals.ts
+++ b/src/api/routes/v3/principals.ts
@@ -11,8 +11,10 @@ import {
   CursorPaginationQuerystring,
   CursorPaginatedResponse,
   FtBalanceCursorSchema,
+  NftBalanceCursorSchema,
   TransactionCursorSchema,
 } from '../../schemas/v3/cursors.js';
+import { decodeClarityValueToRepr } from '@stacks/codec';
 import { PrincipalTransactionSummarySchema } from '../../schemas/v3/entities/principal-transactions.js';
 import { serializePrincipalTransactionSummary } from '../../serializers/v3/transactions.js';
 import { PrincipalBondPositionSchema } from '../../schemas/v3/entities/principal-bond-positions.js';
@@ -20,6 +22,7 @@ import { serializeDbPrincipalBondPosition } from '../../serializers/v3/bonds.js'
 import { handleChainTipCache } from '../../controllers/cache-controller.js';
 import {
   PrincipalFtPositionSchema,
+  PrincipalNftPositionSchema,
   PrincipalStxBalance,
   PrincipalStxBalanceSchema,
 } from '../../schemas/v3/entities/principal-balances.js';
@@ -188,6 +191,52 @@ export const PrincipalsRoutes: FastifyPluginAsync<
         results: results.results.map(r => ({
           asset_identifier: r.token,
           balance: r.balance,
+        })),
+      });
+    }
+  );
+
+  fastify.get(
+    '/principals/:principal/balances/nft',
+    {
+      preHandler: handlePrincipalCache,
+      schema: {
+        operationId: 'get_principal_nft_balances',
+        summary: 'Get principal NFT balances',
+        description:
+          'Get the non-fungible token instances currently owned by a principal, ordered by asset identifier and value.',
+        tags: ['Accounts'],
+        params: Type.Object({ principal: PrincipalSchema }),
+        querystring: CursorPaginationQuerystring(NftBalanceCursorSchema, ResourceType.NftBalance),
+        response: {
+          200: CursorPaginatedResponse(
+            PrincipalNftPositionSchema,
+            NftBalanceCursorSchema,
+            ResourceType.NftBalance
+          ),
+        },
+      },
+    },
+    async (req, reply) => {
+      const results = await fastify.db.v3.getPrincipalNftBalances({
+        principal: req.params.principal,
+        limit: req.query.limit ?? getPagingQueryLimit(ResourceType.NftBalance),
+        cursor: req.query.cursor,
+      });
+      await reply.send({
+        limit: results.limit,
+        total: results.total,
+        cursor: {
+          next: results.next_cursor,
+          previous: results.prev_cursor,
+          current: results.current_cursor,
+        },
+        results: results.results.map(r => ({
+          asset_identifier: r.asset_identifier,
+          value: {
+            hex: r.value,
+            repr: decodeClarityValueToRepr(r.value),
+          },
         })),
       });
     }

--- a/src/api/routes/v3/principals.ts
+++ b/src/api/routes/v3/principals.ts
@@ -10,6 +10,7 @@ import { PrincipalSchema } from '../../schemas/v3/entities/common.js';
 import {
   CursorPaginationQuerystring,
   CursorPaginatedResponse,
+  FtBalanceCursorSchema,
   TransactionCursorSchema,
 } from '../../schemas/v3/cursors.js';
 import { PrincipalTransactionSummarySchema } from '../../schemas/v3/entities/principal-transactions.js';
@@ -18,6 +19,7 @@ import { PrincipalBondPositionSchema } from '../../schemas/v3/entities/principal
 import { serializeDbPrincipalBondPosition } from '../../serializers/v3/bonds.js';
 import { handleChainTipCache } from '../../controllers/cache-controller.js';
 import {
+  PrincipalFtPositionSchema,
   PrincipalStxBalance,
   PrincipalStxBalanceSchema,
 } from '../../schemas/v3/entities/principal-balances.js';
@@ -146,6 +148,48 @@ export const PrincipalsRoutes: FastifyPluginAsync<
         return response;
       });
       await reply.send(result);
+    }
+  );
+
+  fastify.get(
+    '/principals/:principal/balances/ft',
+    {
+      preHandler: handlePrincipalCache,
+      schema: {
+        operationId: 'get_principal_ft_balances',
+        summary: 'Get principal FT balances',
+        description: "Get a principal's fungible-token balances, sorted by balance descending.",
+        tags: ['Accounts'],
+        params: Type.Object({ principal: PrincipalSchema }),
+        querystring: CursorPaginationQuerystring(FtBalanceCursorSchema, ResourceType.FtBalance),
+        response: {
+          200: CursorPaginatedResponse(
+            PrincipalFtPositionSchema,
+            FtBalanceCursorSchema,
+            ResourceType.FtBalance
+          ),
+        },
+      },
+    },
+    async (req, reply) => {
+      const results = await fastify.db.v3.getPrincipalFtBalances({
+        principal: req.params.principal,
+        limit: req.query.limit ?? getPagingQueryLimit(ResourceType.FtBalance),
+        cursor: req.query.cursor,
+      });
+      await reply.send({
+        limit: results.limit,
+        total: results.total,
+        cursor: {
+          next: results.next_cursor,
+          previous: results.prev_cursor,
+          current: results.current_cursor,
+        },
+        results: results.results.map(r => ({
+          asset_identifier: r.token,
+          balance: r.balance,
+        })),
+      });
     }
   );
 

--- a/src/api/schemas/v3/cursors.ts
+++ b/src/api/schemas/v3/cursors.ts
@@ -77,3 +77,10 @@ export const BondCursorSchema = Type.String({
   description: 'Cursor for paginating bonds. Format: bond_index',
 });
 export type BondCursor = Static<typeof BondCursorSchema>;
+
+export const FtBalanceCursorSchema = Type.String({
+  pattern: '^\\d+:.+$',
+  description:
+    'Cursor for paginating FT balances (sorted by balance, descending). Format: balance:asset_identifier',
+});
+export type FtBalanceCursor = Static<typeof FtBalanceCursorSchema>;

--- a/src/api/schemas/v3/cursors.ts
+++ b/src/api/schemas/v3/cursors.ts
@@ -84,3 +84,10 @@ export const FtBalanceCursorSchema = Type.String({
     'Cursor for paginating FT balances (sorted by balance, descending). Format: balance:asset_identifier',
 });
 export type FtBalanceCursor = Static<typeof FtBalanceCursorSchema>;
+
+export const NftBalanceCursorSchema = Type.String({
+  pattern: '^0x[0-9a-fA-F]*:.+$',
+  description:
+    'Cursor for paginating NFT balances (sorted by asset identifier then value). Format: value:asset_identifier',
+});
+export type NftBalanceCursor = Static<typeof NftBalanceCursorSchema>;

--- a/src/api/schemas/v3/entities/principal-balances.ts
+++ b/src/api/schemas/v3/entities/principal-balances.ts
@@ -49,3 +49,18 @@ export const PrincipalStxBalanceSchema = Type.Object(
   { title: 'PrincipalStxBalance' }
 );
 export type PrincipalStxBalance = Static<typeof PrincipalStxBalanceSchema>;
+
+export const PrincipalFtPositionSchema = Type.Object(
+  {
+    asset_identifier: Type.String({
+      description: 'Fungible token asset identifier',
+      examples: ['SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token'],
+    }),
+    balance: Type.String({
+      description:
+        "The principal's balance of this token, as a string-quoted integer in base units",
+    }),
+  },
+  { title: 'PrincipalFtPosition' }
+);
+export type PrincipalFtPosition = Static<typeof PrincipalFtPositionSchema>;

--- a/src/api/schemas/v3/entities/principal-balances.ts
+++ b/src/api/schemas/v3/entities/principal-balances.ts
@@ -64,3 +64,21 @@ export const PrincipalFtPositionSchema = Type.Object(
   { title: 'PrincipalFtPosition' }
 );
 export type PrincipalFtPosition = Static<typeof PrincipalFtPositionSchema>;
+
+export const PrincipalNftPositionSchema = Type.Object(
+  {
+    asset_identifier: Type.String({
+      description: 'Non-fungible token asset identifier',
+      examples: ['SP2X0TZ59D5SZ8ACQ6YMCHHNR2ZN51Z32E2CJ173.the-explorer-guild::The-Explorer-Guild'],
+    }),
+    value: Type.Object(
+      {
+        hex: Type.String(),
+        repr: Type.String(),
+      },
+      { description: 'The NFT instance identifier, as a Clarity value' }
+    ),
+  },
+  { title: 'PrincipalNftPosition' }
+);
+export type PrincipalNftPosition = Static<typeof PrincipalNftPositionSchema>;

--- a/src/api/schemas/v3/entities/principal-balances.ts
+++ b/src/api/schemas/v3/entities/principal-balances.ts
@@ -1,0 +1,51 @@
+import { Static, Type } from '@sinclair/typebox';
+import { Nullable } from '../../v1/util.js';
+import { TransactionIdSchema } from './common.js';
+
+export const StxLockSchema = Type.Object(
+  {
+    amount: Type.String({ description: 'The amount of locked micro-STX' }),
+    pox_version: Type.Integer({
+      description: 'The PoX contract version that created the lock (e.g. 4, 5)',
+    }),
+    lock_tx_id: TransactionIdSchema,
+    stacks_lock_height: Type.Integer({
+      description: 'The Stacks block height at which the lock was created',
+    }),
+    burn_lock_height: Type.Integer({
+      description: 'The burnchain block height at which the lock was created',
+    }),
+    burn_unlock_height: Type.Integer({
+      description: 'The burnchain block height at which the locked STX unlocks',
+    }),
+  },
+  { title: 'StxLock' }
+);
+export type StxLock = Static<typeof StxLockSchema>;
+
+export const StxMempoolBalanceSchema = Type.Object(
+  {
+    estimated_balance: Type.String({
+      description: 'Estimated spendable micro-STX balance once pending mempool txs confirm',
+    }),
+    inbound: Type.String({ description: 'Pending inbound micro-STX from the mempool' }),
+    outbound: Type.String({
+      description: 'Pending outbound micro-STX from the mempool (transfers plus fees)',
+    }),
+  },
+  { title: 'StxMempoolBalance' }
+);
+export type StxMempoolBalance = Static<typeof StxMempoolBalanceSchema>;
+
+export const PrincipalStxBalanceSchema = Type.Object(
+  {
+    balance: Type.String({ description: 'Total micro-STX balance (available plus locked)' }),
+    available: Type.String({
+      description: 'Spendable micro-STX balance (balance minus locked)',
+    }),
+    locked: Nullable(StxLockSchema),
+    mempool: Nullable(StxMempoolBalanceSchema),
+  },
+  { title: 'PrincipalStxBalance' }
+);
+export type PrincipalStxBalance = Static<typeof PrincipalStxBalanceSchema>;

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -275,6 +275,97 @@ export function prefixedCols(columns: string[], prefix: string): string[] {
   return columns.map(c => `${prefix}.${c}`);
 }
 
+/** A materialized current-lock row from the `stx_locked_balances` table. */
+export interface MaterializedStxLockRow {
+  locked_amount: string;
+  unlock_burn_height: string;
+  pox_version: number;
+  lock_tx_id: string;
+  lock_block_height: number;
+  burnchain_lock_height: string;
+}
+
+/** The locked-STX portion of a principal's balance response. */
+export interface ResolvedStxLock {
+  lockTxId: string;
+  locked: bigint;
+  lockHeight: number;
+  burnchainLockHeight: number;
+  burnchainUnlockHeight: number;
+}
+
+const EMPTY_STX_LOCK: ResolvedStxLock = {
+  lockTxId: '',
+  locked: 0n,
+  lockHeight: 0,
+  burnchainLockHeight: 0,
+  burnchainUnlockHeight: 0,
+};
+
+/**
+ * Resolve a materialized `stx_locked_balances` row into the locked-STX portion
+ * of a balance response, applying lock expiry. The lock is considered unlocked
+ * (zeroed out) when either:
+ *  - the burn chain has reached the lock's `unlock_burn_height`, or
+ *  - the pox version's force-unlock height (e.g. `pox_v4_unlock_height`) has
+ *    been surpassed (pox-5 has no force-unlock height).
+ *
+ * `stx_locked_balances` only reflects the current canonical tip, so this is only
+ * valid for current-tip reads; historical (`until_block`) reads must derive the
+ * lock from the per-version event tables instead.
+ */
+export function resolveMaterializedStxLock(
+  row: MaterializedStxLockRow | undefined,
+  burnBlockHeight: number,
+  forceUnlockHeights: {
+    pox1UnlockHeight: number | null;
+    pox2UnlockHeight: number | null;
+    pox3UnlockHeight: number | null;
+    pox4UnlockHeight: number | null;
+  } | null
+): ResolvedStxLock {
+  if (!row) {
+    return { ...EMPTY_STX_LOCK };
+  }
+  const burnchainUnlockHeight = Number(row.unlock_burn_height);
+  // Lock has naturally expired (mirrors the `unlock_height >= burnBlockHeight`
+  // filter used by the per-version event scan).
+  if (burnchainUnlockHeight < burnBlockHeight) {
+    return { ...EMPTY_STX_LOCK };
+  }
+  // Apply the per-version force-unlock height, if one is set.
+  let forcedUnlockHeight: number | null = null;
+  if (forceUnlockHeights) {
+    switch (row.pox_version) {
+      case 1:
+        forcedUnlockHeight = forceUnlockHeights.pox1UnlockHeight;
+        break;
+      case 2:
+        forcedUnlockHeight = forceUnlockHeights.pox2UnlockHeight;
+        break;
+      case 3:
+        forcedUnlockHeight = forceUnlockHeights.pox3UnlockHeight;
+        break;
+      case 4:
+        forcedUnlockHeight = forceUnlockHeights.pox4UnlockHeight;
+        break;
+      default:
+        // pox-5 (and anything newer) has no force-unlock height.
+        forcedUnlockHeight = null;
+    }
+  }
+  if (forcedUnlockHeight && burnBlockHeight > forcedUnlockHeight) {
+    return { ...EMPTY_STX_LOCK };
+  }
+  return {
+    lockTxId: row.lock_tx_id,
+    locked: BigInt(row.locked_amount),
+    lockHeight: row.lock_block_height,
+    burnchainLockHeight: Number(row.burnchain_lock_height),
+    burnchainUnlockHeight,
+  };
+}
+
 /**
  * Shorthand function that returns a column query to retrieve the smart contract abi when querying transactions
  * that may be of type `contract_call`. Usually used alongside `TX_COLUMNS` or `MEMPOOL_TX_COLUMNS`.

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -1370,6 +1370,30 @@ export function removeNullBytes(str: string): string {
 }
 
 /**
+ * Maps the `contract_name` of a node-emitted `stx_lock` event to the pox
+ * version that produced it. Returns `undefined` for unrecognized contracts.
+ * Note: pox-5 locks are materialized by the synthetic stake/unstake handlers,
+ * not from `stx_lock` events, so callers feeding `stx_locked_balances` should
+ * skip version 5.
+ */
+export function poxVersionFromContractName(contractName: string): number | undefined {
+  switch (contractName) {
+    case 'pox':
+      return 1;
+    case 'pox-2':
+      return 2;
+    case 'pox-3':
+      return 3;
+    case 'pox-4':
+      return 4;
+    case 'pox-5':
+      return 5;
+    default:
+      return undefined;
+  }
+}
+
+/**
  * Priority queue for parallel Postgres write query execution. This helps performance because it
  * parallelizes the work postgres.js has to do when serializing JS types to PG types.
  */

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -292,6 +292,8 @@ export interface ResolvedStxLock {
   lockHeight: number;
   burnchainLockHeight: number;
   burnchainUnlockHeight: number;
+  /** PoX contract version that created the lock (e.g. 4, 5); 0 when nothing is locked. */
+  poxVersion: number;
 }
 
 const EMPTY_STX_LOCK: ResolvedStxLock = {
@@ -300,6 +302,7 @@ const EMPTY_STX_LOCK: ResolvedStxLock = {
   lockHeight: 0,
   burnchainLockHeight: 0,
   burnchainUnlockHeight: 0,
+  poxVersion: 0,
 };
 
 /**
@@ -363,6 +366,7 @@ export function resolveMaterializedStxLock(
     lockHeight: row.lock_block_height,
     burnchainLockHeight: Number(row.burnchain_lock_height),
     burnchainUnlockHeight,
+    poxVersion: row.pox_version,
   };
 }
 

--- a/src/datastore/pg-store-v2.ts
+++ b/src/datastore/pg-store-v2.ts
@@ -34,7 +34,6 @@ import {
   DbPoxCycleSigner,
   DbPoxCycleSignerStacker,
   DbCursorPaginatedResult,
-  PoxSyntheticEventQueryResult,
   DbBurnBlockPoxTx,
   DbSmartContractEvent,
 } from './common.js';
@@ -44,11 +43,10 @@ import {
   TX_COLUMNS,
   parseTxQueryResult,
   parseAccountTransferSummaryTxQueryResult,
-  POX4_SYNTHETIC_EVENT_COLUMNS,
-  parseDbPoxSyntheticEvent,
   prefixedCols,
+  resolveMaterializedStxLock,
+  MaterializedStxLockRow,
 } from './helpers.js';
-import { Pox4EventName } from '@stacks/codec';
 
 async function assertTxIdExists(sql: PgSqlClient, tx_id: string) {
   const txCheck = await sql`SELECT tx_id FROM txs WHERE tx_id = ${tx_id} LIMIT 1`;
@@ -1169,69 +1167,45 @@ export class PgStoreV2 extends BasePgStoreModule {
   async getStxPoxLockedAtBlock({
     sql,
     stxAddress,
-    blockHeight,
     burnBlockHeight,
   }: {
     sql: PgSqlClient;
     stxAddress: string;
-    blockHeight: number;
     burnBlockHeight: number;
   }) {
-    let lockTxId: string = '';
-    let locked: bigint = 0n;
-    let lockHeight = 0;
-    let burnchainLockHeight = 0;
-    let burnchainUnlockHeight = 0;
-
-    const [poxState] = await sql<{ pox_v4_unlock_height: string }[]>`
-      SELECT pox_v4_unlock_height
+    // This endpoint is always queried at the current canonical tip, so the
+    // locked balance is read straight from the materialized `stx_locked_balances`
+    // table (covering all pox versions, including pox-5) rather than re-derived
+    // from the per-version event tables.
+    const [poxState] = await sql<
+      {
+        pox_v1_unlock_height: string;
+        pox_v2_unlock_height: string;
+        pox_v3_unlock_height: string;
+        pox_v4_unlock_height: string;
+      }[]
+    >`
+      SELECT pox_v1_unlock_height, pox_v2_unlock_height, pox_v3_unlock_height, pox_v4_unlock_height
       FROM pox_state
       LIMIT 1
     `;
-    const pox4UnlockHeight = parseInt(poxState?.pox_v4_unlock_height ?? '0') || null;
-    const includePox4State = !pox4UnlockHeight || burnBlockHeight <= pox4UnlockHeight;
-
-    // Query for the latest lock event that still applies to the current burn block height.
-    // Special case for `handle-unlock` which should be returned if it is the last received event.
-    if (includePox4State) {
-      const pox4EventQuery = await sql<PoxSyntheticEventQueryResult[]>`
-        SELECT ${sql(POX4_SYNTHETIC_EVENT_COLUMNS)}
-        FROM pox4_events
-        WHERE canonical = true AND microblock_canonical = true AND stacker = ${stxAddress}
-        AND block_height <= ${blockHeight}
-        AND (
-          (name != ${Pox4EventName.HandleUnlock} AND burnchain_unlock_height >= ${burnBlockHeight})
-          OR
-          (name = ${Pox4EventName.HandleUnlock} AND burnchain_unlock_height < ${burnBlockHeight})
-        )
-        ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
-        LIMIT 1
-      `;
-      if (pox4EventQuery.length > 0) {
-        const pox4Event = parseDbPoxSyntheticEvent(pox4EventQuery[0]);
-        if (pox4Event.name !== Pox4EventName.HandleUnlock) {
-          lockTxId = pox4Event.tx_id;
-          locked = BigInt(pox4Event.locked);
-          burnchainUnlockHeight = Number(pox4Event.burnchain_unlock_height);
-          lockHeight = pox4Event.block_height;
-
-          const [burnBlockQuery] = await sql<{ burn_block_height: string }[]>`
-            SELECT burn_block_height FROM blocks
-            WHERE block_height = ${blockHeight} AND canonical = true
-            LIMIT 1
-          `;
-          burnchainLockHeight = parseInt(burnBlockQuery?.burn_block_height ?? '0');
+    const forceUnlockHeights = poxState
+      ? {
+          pox1UnlockHeight: parseInt(poxState.pox_v1_unlock_height) || null,
+          pox2UnlockHeight: parseInt(poxState.pox_v2_unlock_height) || null,
+          pox3UnlockHeight: parseInt(poxState.pox_v3_unlock_height) || null,
+          pox4UnlockHeight: parseInt(poxState.pox_v4_unlock_height) || null,
         }
-      }
-    }
+      : null;
 
-    return {
-      lockTxId,
-      locked,
-      lockHeight,
-      burnchainLockHeight,
-      burnchainUnlockHeight,
-    };
+    const [lockRow] = await sql<MaterializedStxLockRow[]>`
+      SELECT locked_amount, unlock_burn_height, pox_version, lock_tx_id,
+        lock_block_height, burnchain_lock_height
+      FROM stx_locked_balances
+      WHERE principal = ${stxAddress}
+      LIMIT 1
+    `;
+    return resolveMaterializedStxLock(lockRow, burnBlockHeight, forceUnlockHeights);
   }
 
   async getSmartContractEvents(args: {

--- a/src/datastore/pg-store.ts
+++ b/src/datastore/pg-store.ts
@@ -82,6 +82,8 @@ import {
   POX4_SYNTHETIC_EVENT_COLUMNS,
   POX_SYNTHETIC_EVENT_COLUMNS,
   prefixedCols,
+  resolveMaterializedStxLock,
+  MaterializedStxLockRow,
   TX_COLUMNS,
   validateZonefileHash,
 } from './helpers.js';
@@ -2281,151 +2283,104 @@ export class PgStore extends BasePgStore {
     let burnchainLockHeight = 0;
     let burnchainUnlockHeight = 0;
 
-    let includePox1State = true;
-    let includePox2State = true;
-    let includePox3State = true;
-    let includePox4State = true;
     const poxForceUnlockHeights = await this.getPoxForcedUnlockHeightsInternal(sql);
-    if (poxForceUnlockHeights.found) {
-      if (
-        poxForceUnlockHeights.result.pox1UnlockHeight &&
-        burnBlockHeight > poxForceUnlockHeights.result.pox1UnlockHeight
-      ) {
-        includePox1State = false;
-      }
-      if (
-        poxForceUnlockHeights.result.pox2UnlockHeight &&
-        burnBlockHeight > poxForceUnlockHeights.result.pox2UnlockHeight
-      ) {
-        includePox2State = false;
-      }
-      if (
-        poxForceUnlockHeights.result.pox3UnlockHeight &&
-        burnBlockHeight > poxForceUnlockHeights.result.pox3UnlockHeight
-      ) {
-        includePox3State = false;
-      }
-      if (
-        poxForceUnlockHeights.result.pox4UnlockHeight &&
-        burnBlockHeight > poxForceUnlockHeights.result.pox4UnlockHeight
-      ) {
-        includePox4State = false;
-      }
-    }
 
-    // Once the pox_v1_unlock_height is reached, stop using `stx_lock_events` to determinel locked state,
-    // because it includes pox-v1 entries. We only care about pox-v2, so only need to query `pox2_events`.
-    if (includePox1State) {
-      const lockQuery = await sql<
-        {
-          locked_amount: string;
-          unlock_height: string;
-          block_height: string;
-          tx_id: string;
-        }[]
-      >`
-        SELECT locked_amount, unlock_height, block_height, tx_id
-        FROM stx_lock_events
-        WHERE canonical = true AND microblock_canonical = true AND locked_address = ${stxAddress}
-        AND block_height <= ${blockHeight} AND unlock_height >= ${burnBlockHeight}
-        ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+    // The materialized `stx_locked_balances` table only reflects the current
+    // canonical tip, so it can only answer current-tip reads. Historical
+    // (`until_block`) reads must still derive the lock from the per-version
+    // event tables below.
+    const lockChainTip = await this.getChainTip(sql);
+    const isCurrentTip = blockHeight >= lockChainTip.block_height;
+
+    if (isCurrentTip) {
+      const [lockRow] = await sql<MaterializedStxLockRow[]>`
+        SELECT locked_amount, unlock_burn_height, pox_version, lock_tx_id,
+          lock_block_height, burnchain_lock_height
+        FROM stx_locked_balances
+        WHERE principal = ${stxAddress}
         LIMIT 1
       `;
-      if (lockQuery.length > 1) {
-        throw new Error(
-          `stx_lock_events event query for ${stxAddress} should return zero or one rows but returned ${lockQuery.length}`
-        );
-      } else if (lockQuery.length === 1) {
-        lockTxId = lockQuery[0].tx_id;
-        locked = BigInt(lockQuery[0].locked_amount);
-        burnchainUnlockHeight = parseInt(lockQuery[0].unlock_height);
-        lockHeight = parseInt(lockQuery[0].block_height);
-        const blockQuery = await this.getBlockByHeightInternal(sql, lockHeight);
-        burnchainLockHeight = blockQuery.found ? blockQuery.result.burn_block_height : 0;
+      const resolved = resolveMaterializedStxLock(
+        lockRow,
+        burnBlockHeight,
+        poxForceUnlockHeights.found ? poxForceUnlockHeights.result : null
+      );
+      lockTxId = resolved.lockTxId;
+      locked = resolved.locked;
+      lockHeight = resolved.lockHeight;
+      burnchainLockHeight = resolved.burnchainLockHeight;
+      burnchainUnlockHeight = resolved.burnchainUnlockHeight;
+    } else {
+      let includePox1State = true;
+      let includePox2State = true;
+      let includePox3State = true;
+      let includePox4State = true;
+      if (poxForceUnlockHeights.found) {
+        if (
+          poxForceUnlockHeights.result.pox1UnlockHeight &&
+          burnBlockHeight > poxForceUnlockHeights.result.pox1UnlockHeight
+        ) {
+          includePox1State = false;
+        }
+        if (
+          poxForceUnlockHeights.result.pox2UnlockHeight &&
+          burnBlockHeight > poxForceUnlockHeights.result.pox2UnlockHeight
+        ) {
+          includePox2State = false;
+        }
+        if (
+          poxForceUnlockHeights.result.pox3UnlockHeight &&
+          burnBlockHeight > poxForceUnlockHeights.result.pox3UnlockHeight
+        ) {
+          includePox3State = false;
+        }
+        if (
+          poxForceUnlockHeights.result.pox4UnlockHeight &&
+          burnBlockHeight > poxForceUnlockHeights.result.pox4UnlockHeight
+        ) {
+          includePox4State = false;
+        }
       }
-    }
 
-    // Once the pox_v2_unlock_height is reached, stop using `pox2_events` to determinel locked state.
-    if (includePox2State) {
-      // Query for the latest lock event that still applies to the current burn block height.
-      // Special case for `handle-unlock` which should be returned if it is the last received event.
-      const pox2EventQuery = await sql<PoxSyntheticEventQueryResult[]>`
-        SELECT ${sql(POX_SYNTHETIC_EVENT_COLUMNS)}
-        FROM pox2_events
-        WHERE canonical = true AND microblock_canonical = true AND stacker = ${stxAddress}
-        AND block_height <= ${blockHeight}
-        AND (
-          (name != ${Pox4EventName.HandleUnlock} AND burnchain_unlock_height >= ${burnBlockHeight})
-          OR
-          (name = ${Pox4EventName.HandleUnlock} AND burnchain_unlock_height < ${burnBlockHeight})
-        )
-        ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
-        LIMIT 1
-      `;
-      if (pox2EventQuery.length > 0) {
-        const pox2Event = parseDbPoxSyntheticEvent(pox2EventQuery[0]);
-        if (pox2Event.name === Pox4EventName.HandleUnlock) {
-          // on a handle-unlock, set all of the locked stx related property to empty/default
-          lockTxId = '';
-          locked = 0n;
-          burnchainUnlockHeight = 0;
-          lockHeight = 0;
-          burnchainLockHeight = 0;
-        } else {
-          lockTxId = pox2Event.tx_id;
-          locked = BigInt(pox2Event.locked);
-          burnchainUnlockHeight = Number(pox2Event.burnchain_unlock_height);
-          lockHeight = pox2Event.block_height;
+      // Once the pox_v1_unlock_height is reached, stop using `stx_lock_events` to determinel locked state,
+      // because it includes pox-v1 entries. We only care about pox-v2, so only need to query `pox2_events`.
+      if (includePox1State) {
+        const lockQuery = await sql<
+          {
+            locked_amount: string;
+            unlock_height: string;
+            block_height: string;
+            tx_id: string;
+          }[]
+        >`
+          SELECT locked_amount, unlock_height, block_height, tx_id
+          FROM stx_lock_events
+          WHERE canonical = true AND microblock_canonical = true AND locked_address = ${stxAddress}
+          AND block_height <= ${blockHeight} AND unlock_height >= ${burnBlockHeight}
+          ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+          LIMIT 1
+        `;
+        if (lockQuery.length > 1) {
+          throw new Error(
+            `stx_lock_events event query for ${stxAddress} should return zero or one rows but returned ${lockQuery.length}`
+          );
+        } else if (lockQuery.length === 1) {
+          lockTxId = lockQuery[0].tx_id;
+          locked = BigInt(lockQuery[0].locked_amount);
+          burnchainUnlockHeight = parseInt(lockQuery[0].unlock_height);
+          lockHeight = parseInt(lockQuery[0].block_height);
           const blockQuery = await this.getBlockByHeightInternal(sql, lockHeight);
           burnchainLockHeight = blockQuery.found ? blockQuery.result.burn_block_height : 0;
         }
       }
-    }
 
-    // Once the pox_v3_unlock_height is reached, stop using `pox3_events` to determine locked state.
-    if (includePox3State) {
-      // Query for the latest lock event that still applies to the current burn block height.
-      // Special case for `handle-unlock` which should be returned if it is the last received event.
-      const pox3EventQuery = await sql<PoxSyntheticEventQueryResult[]>`
-        SELECT ${sql(POX_SYNTHETIC_EVENT_COLUMNS)}
-        FROM pox3_events
-        WHERE canonical = true AND microblock_canonical = true AND stacker = ${stxAddress}
-        AND block_height <= ${blockHeight}
-        AND (
-          (name != ${Pox4EventName.HandleUnlock} AND burnchain_unlock_height >= ${burnBlockHeight})
-          OR
-          (name = ${Pox4EventName.HandleUnlock} AND burnchain_unlock_height < ${burnBlockHeight})
-        )
-        ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
-        LIMIT 1
-      `;
-      if (pox3EventQuery.length > 0) {
-        const pox3Event = parseDbPoxSyntheticEvent(pox3EventQuery[0]);
-        if (pox3Event.name === Pox4EventName.HandleUnlock) {
-          // on a handle-unlock, set all of the locked stx related property to empty/default
-          lockTxId = '';
-          locked = 0n;
-          burnchainUnlockHeight = 0;
-          lockHeight = 0;
-          burnchainLockHeight = 0;
-        } else {
-          lockTxId = pox3Event.tx_id;
-          locked = BigInt(pox3Event.locked);
-          burnchainUnlockHeight = Number(pox3Event.burnchain_unlock_height);
-          lockHeight = pox3Event.block_height;
-          const blockQuery = await this.getBlockByHeightInternal(sql, lockHeight);
-          burnchainLockHeight = blockQuery.found ? blockQuery.result.burn_block_height : 0;
-        }
-      }
-    }
-
-    // Once the pox_v4_unlock_height is reached, stop using `pox4_events` to determine locked state.
-    if (includePox4State) {
-      // Query for the latest lock event that still applies to the current burn block height.
-      // Special case for `handle-unlock` which should be returned if it is the last received event.
-      const pox4EventQuery = await sql<PoxSyntheticEventQueryResult[]>`
-          SELECT ${sql(POX4_SYNTHETIC_EVENT_COLUMNS)}
-          FROM pox4_events
+      // Once the pox_v2_unlock_height is reached, stop using `pox2_events` to determinel locked state.
+      if (includePox2State) {
+        // Query for the latest lock event that still applies to the current burn block height.
+        // Special case for `handle-unlock` which should be returned if it is the last received event.
+        const pox2EventQuery = await sql<PoxSyntheticEventQueryResult[]>`
+          SELECT ${sql(POX_SYNTHETIC_EVENT_COLUMNS)}
+          FROM pox2_events
           WHERE canonical = true AND microblock_canonical = true AND stacker = ${stxAddress}
           AND block_height <= ${blockHeight}
           AND (
@@ -2436,22 +2391,97 @@ export class PgStore extends BasePgStore {
           ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
           LIMIT 1
         `;
-      if (pox4EventQuery.length > 0) {
-        const pox4Event = parseDbPoxSyntheticEvent(pox4EventQuery[0]);
-        if (pox4Event.name === Pox4EventName.HandleUnlock) {
-          // on a handle-unlock, set all of the locked stx related property to empty/default
-          lockTxId = '';
-          locked = 0n;
-          burnchainUnlockHeight = 0;
-          lockHeight = 0;
-          burnchainLockHeight = 0;
-        } else {
-          lockTxId = pox4Event.tx_id;
-          locked = BigInt(pox4Event.locked);
-          burnchainUnlockHeight = Number(pox4Event.burnchain_unlock_height);
-          lockHeight = pox4Event.block_height;
-          const blockQuery = await this.getBlockByHeightInternal(sql, lockHeight);
-          burnchainLockHeight = blockQuery.found ? blockQuery.result.burn_block_height : 0;
+        if (pox2EventQuery.length > 0) {
+          const pox2Event = parseDbPoxSyntheticEvent(pox2EventQuery[0]);
+          if (pox2Event.name === Pox4EventName.HandleUnlock) {
+            // on a handle-unlock, set all of the locked stx related property to empty/default
+            lockTxId = '';
+            locked = 0n;
+            burnchainUnlockHeight = 0;
+            lockHeight = 0;
+            burnchainLockHeight = 0;
+          } else {
+            lockTxId = pox2Event.tx_id;
+            locked = BigInt(pox2Event.locked);
+            burnchainUnlockHeight = Number(pox2Event.burnchain_unlock_height);
+            lockHeight = pox2Event.block_height;
+            const blockQuery = await this.getBlockByHeightInternal(sql, lockHeight);
+            burnchainLockHeight = blockQuery.found ? blockQuery.result.burn_block_height : 0;
+          }
+        }
+      }
+
+      // Once the pox_v3_unlock_height is reached, stop using `pox3_events` to determine locked state.
+      if (includePox3State) {
+        // Query for the latest lock event that still applies to the current burn block height.
+        // Special case for `handle-unlock` which should be returned if it is the last received event.
+        const pox3EventQuery = await sql<PoxSyntheticEventQueryResult[]>`
+          SELECT ${sql(POX_SYNTHETIC_EVENT_COLUMNS)}
+          FROM pox3_events
+          WHERE canonical = true AND microblock_canonical = true AND stacker = ${stxAddress}
+          AND block_height <= ${blockHeight}
+          AND (
+            (name != ${Pox4EventName.HandleUnlock} AND burnchain_unlock_height >= ${burnBlockHeight})
+            OR
+            (name = ${Pox4EventName.HandleUnlock} AND burnchain_unlock_height < ${burnBlockHeight})
+          )
+          ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+          LIMIT 1
+        `;
+        if (pox3EventQuery.length > 0) {
+          const pox3Event = parseDbPoxSyntheticEvent(pox3EventQuery[0]);
+          if (pox3Event.name === Pox4EventName.HandleUnlock) {
+            // on a handle-unlock, set all of the locked stx related property to empty/default
+            lockTxId = '';
+            locked = 0n;
+            burnchainUnlockHeight = 0;
+            lockHeight = 0;
+            burnchainLockHeight = 0;
+          } else {
+            lockTxId = pox3Event.tx_id;
+            locked = BigInt(pox3Event.locked);
+            burnchainUnlockHeight = Number(pox3Event.burnchain_unlock_height);
+            lockHeight = pox3Event.block_height;
+            const blockQuery = await this.getBlockByHeightInternal(sql, lockHeight);
+            burnchainLockHeight = blockQuery.found ? blockQuery.result.burn_block_height : 0;
+          }
+        }
+      }
+
+      // Once the pox_v4_unlock_height is reached, stop using `pox4_events` to determine locked state.
+      if (includePox4State) {
+        // Query for the latest lock event that still applies to the current burn block height.
+        // Special case for `handle-unlock` which should be returned if it is the last received event.
+        const pox4EventQuery = await sql<PoxSyntheticEventQueryResult[]>`
+            SELECT ${sql(POX4_SYNTHETIC_EVENT_COLUMNS)}
+            FROM pox4_events
+            WHERE canonical = true AND microblock_canonical = true AND stacker = ${stxAddress}
+            AND block_height <= ${blockHeight}
+            AND (
+              (name != ${Pox4EventName.HandleUnlock} AND burnchain_unlock_height >= ${burnBlockHeight})
+              OR
+              (name = ${Pox4EventName.HandleUnlock} AND burnchain_unlock_height < ${burnBlockHeight})
+            )
+            ORDER BY block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+            LIMIT 1
+          `;
+        if (pox4EventQuery.length > 0) {
+          const pox4Event = parseDbPoxSyntheticEvent(pox4EventQuery[0]);
+          if (pox4Event.name === Pox4EventName.HandleUnlock) {
+            // on a handle-unlock, set all of the locked stx related property to empty/default
+            lockTxId = '';
+            locked = 0n;
+            burnchainUnlockHeight = 0;
+            lockHeight = 0;
+            burnchainLockHeight = 0;
+          } else {
+            lockTxId = pox4Event.tx_id;
+            locked = BigInt(pox4Event.locked);
+            burnchainUnlockHeight = Number(pox4Event.burnchain_unlock_height);
+            lockHeight = pox4Event.block_height;
+            const blockQuery = await this.getBlockByHeightInternal(sql, lockHeight);
+            burnchainLockHeight = blockQuery.found ? blockQuery.result.burn_block_height : 0;
+          }
         }
       }
     }

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -89,6 +89,7 @@ import {
   newReOrgUpdatedEntities,
   PgWriteQueue,
   removeNullBytes,
+  poxVersionFromContractName,
 } from './helpers.js';
 import { PgNotifier } from './pg-notifier.js';
 import { MIGRATIONS_DIR, PgStore } from './pg-store.js';
@@ -116,6 +117,8 @@ import {
   Pox5EventName,
   Pox5EventRegisterForBond,
   Pox5EventSetupBond,
+  Pox5EventStake,
+  Pox5EventStakeUpdate,
   Pox5EventUnstakeSbtc,
   Pox5EventUpdateBondRegistration,
 } from '@stacks/codec';
@@ -583,10 +586,10 @@ export class PgWriteStore extends PgStore {
             break;
           case Pox5EventName.Stake:
           case Pox5EventName.StakeUpdate:
-            // TODO: Implement
+            await this.upsertStxLockedBalance(sql, txLocation, poxEvent);
             break;
           case Pox5EventName.Unstake:
-            // TODO: Implement
+            await this.clearStxLockedBalance(sql, poxEvent.data.staker);
             break;
           case Pox5EventName.RegisterSigner:
             // TODO: Implement
@@ -912,6 +915,178 @@ export class PgWriteStore extends PgStore {
     await sql`
       INSERT INTO bond_reward_calculations ${sql(rewardCalculation)}
     `;
+  }
+
+  /**
+   * Materialize a principal's current STX lock state (latest lock wins). Called
+   * for pox-5 `stake`/`stake-update` events, which carry the absolute locked
+   * amount and unlock height.
+   */
+  /** Low-level upsert of a principal's materialized STX lock (latest lock wins). */
+  private async setStxLockedBalance(
+    sql: PgSqlClient,
+    values: {
+      principal: string;
+      lockedAmount: string;
+      unlockBurnHeight: string | number;
+      poxVersion: number;
+      lockTxId: string;
+      lockBlockHeight: number;
+      burnchainLockHeight: string | number;
+    }
+  ) {
+    const insertValues = {
+      principal: values.principal,
+      locked_amount: values.lockedAmount,
+      unlock_burn_height: values.unlockBurnHeight,
+      pox_version: values.poxVersion,
+      lock_tx_id: values.lockTxId,
+      lock_block_height: values.lockBlockHeight,
+      burnchain_lock_height: values.burnchainLockHeight,
+    };
+    await sql`
+      INSERT INTO stx_locked_balances ${sql(insertValues)}
+      ON CONFLICT (principal) DO UPDATE SET
+        locked_amount = EXCLUDED.locked_amount,
+        unlock_burn_height = EXCLUDED.unlock_burn_height,
+        pox_version = EXCLUDED.pox_version,
+        lock_tx_id = EXCLUDED.lock_tx_id,
+        lock_block_height = EXCLUDED.lock_block_height,
+        burnchain_lock_height = EXCLUDED.burnchain_lock_height
+    `;
+  }
+
+  private async upsertStxLockedBalance(
+    sql: PgSqlClient,
+    txLocation: DbTxLocation,
+    event: Pox5EventStake | Pox5EventStakeUpdate
+  ) {
+    await this.setStxLockedBalance(sql, {
+      principal: event.data.staker,
+      lockedAmount: event.data.amount_ustx,
+      unlockBurnHeight: event.data.unlock_burn_height,
+      poxVersion: 5,
+      lockTxId: txLocation.tx_id,
+      lockBlockHeight: txLocation.block_height,
+      burnchainLockHeight: txLocation.burn_block_height,
+    });
+  }
+
+  /** Clear a principal's materialized STX lock (e.g. on pox-5 `unstake`). */
+  private async clearStxLockedBalance(sql: PgSqlClient, principal: string) {
+    await sql`DELETE FROM stx_locked_balances WHERE principal = ${principal}`;
+  }
+
+  /**
+   * Recompute the materialized `stx_locked_balances` rows for every principal
+   * touched by a block whose canonical flag just flipped during a reorg.
+   *
+   * Locked STX is a SET/latest-wins value (not additive like ft_balances), so a
+   * reorg can't be handled with signed deltas — instead we re-derive each
+   * affected principal's current lock from the latest applicable canonical
+   * lock-changing event across all blocks: pox-1..4 `stx_lock_events` and the
+   * synthetic pox-5 `stake`/`stake-update` (lock) and `unstake` (clear) events.
+   *
+   * Must run AFTER the `stx_lock_events` and `pox5_events` canonical flips for
+   * this block have completed (i.e. after the reorg queue drains), so the
+   * "latest canonical event" reflects the post-flip state. Because the recompute
+   * reads global canonical state, the last-flipped block touching a principal
+   * always produces that principal's final, correct value.
+   */
+  private async recomputeStxLockedBalances(sql: PgSqlClient, indexBlockHash: string) {
+    // Principals whose lock state may have changed in this block.
+    const affectedRows = await sql<{ principal: string }[]>`
+      SELECT locked_address AS principal
+      FROM stx_lock_events
+      WHERE index_block_hash = ${indexBlockHash} AND contract_name <> 'pox-5'
+      UNION
+      SELECT data->>'staker' AS principal
+      FROM pox5_events
+      WHERE index_block_hash = ${indexBlockHash}
+        AND name IN ('stake', 'stake-update', 'unstake')
+    `;
+    const principals = affectedRows.map(r => r.principal);
+    if (principals.length === 0) {
+      return;
+    }
+    // Process affected principals in chunks (same approach as other batched
+    // write paths). For each chunk: drop their current materialized rows, then
+    // re-insert the correct rows (if any) derived from the latest canonical
+    // lock-changing event.
+    for (const batch of batchIterate(principals, INSERT_BATCH_SIZE)) {
+      await sql`
+        DELETE FROM stx_locked_balances
+        WHERE principal IN ${sql(batch)}
+      `;
+      await sql`
+        INSERT INTO stx_locked_balances (
+          principal, locked_amount, unlock_burn_height, pox_version,
+          lock_tx_id, lock_block_height, burnchain_lock_height
+        )
+        SELECT principal, locked_amount, unlock_burn_height, pox_version,
+          lock_tx_id, lock_block_height, burnchain_lock_height
+        FROM (
+          SELECT DISTINCT ON (principal)
+            principal, is_set, locked_amount, unlock_burn_height, pox_version,
+            lock_tx_id, lock_block_height, burnchain_lock_height
+          FROM (
+            -- pox-1..4 lock events (locked_amount = 0 means the lock was cleared)
+            SELECT
+              e.locked_address AS principal,
+              e.block_height, e.microblock_sequence, e.tx_index, e.event_index,
+              (e.locked_amount > 0) AS is_set,
+              e.locked_amount,
+              e.unlock_height AS unlock_burn_height,
+              CASE e.contract_name
+                WHEN 'pox' THEN 1 WHEN 'pox-2' THEN 2 WHEN 'pox-3' THEN 3 WHEN 'pox-4' THEN 4 ELSE 0
+              END AS pox_version,
+              e.tx_id AS lock_tx_id,
+              e.block_height AS lock_block_height,
+              b.burn_block_height AS burnchain_lock_height
+            FROM stx_lock_events e
+            JOIN blocks b ON b.index_block_hash = e.index_block_hash
+            WHERE e.canonical = true AND e.microblock_canonical = true
+              AND e.contract_name <> 'pox-5'
+              AND e.locked_address IN ${sql(batch)}
+            UNION ALL
+            -- pox-5 stake / stake-update (sets the lock)
+            SELECT
+              p.data->>'staker' AS principal,
+              p.block_height, p.microblock_sequence, p.tx_index, p.event_index,
+              true AS is_set,
+              (p.data->>'amount_ustx')::numeric AS locked_amount,
+              (p.data->>'unlock_burn_height')::bigint AS unlock_burn_height,
+              5 AS pox_version,
+              p.tx_id AS lock_tx_id,
+              p.block_height AS lock_block_height,
+              p.burn_block_height AS burnchain_lock_height
+            FROM pox5_events p
+            WHERE p.canonical = true AND p.microblock_canonical = true
+              AND p.name IN ('stake', 'stake-update')
+              AND p.data->>'staker' IN ${sql(batch)}
+            UNION ALL
+            -- pox-5 unstake (clears the lock)
+            SELECT
+              p.data->>'staker' AS principal,
+              p.block_height, p.microblock_sequence, p.tx_index, p.event_index,
+              false AS is_set,
+              0::numeric AS locked_amount,
+              0::bigint AS unlock_burn_height,
+              5 AS pox_version,
+              p.tx_id AS lock_tx_id,
+              p.block_height AS lock_block_height,
+              p.burn_block_height AS burnchain_lock_height
+            FROM pox5_events p
+            WHERE p.canonical = true AND p.microblock_canonical = true
+              AND p.name = 'unstake'
+              AND p.data->>'staker' IN ${sql(batch)}
+          ) candidates
+          ORDER BY principal,
+            block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+        ) latest
+        WHERE latest.is_set
+      `;
+    }
   }
 
   private async updateBondAllowlistEntry(
@@ -1601,6 +1776,29 @@ export class PgWriteStore extends PgStore {
         INSERT INTO stx_lock_events ${sql(batch)}
       `;
       assert(res.count === batch.length, `Expecting ${batch.length} inserts, got ${res.count}`);
+    }
+
+    // Materialize the locked balance from these lock events. pox-5 locks are
+    // owned by the synthetic stake/stake-update/unstake handlers, so skip them
+    // here to avoid double-writes; pox-1..4 (and any future versions emitting
+    // stx_lock events) are inherited here. Applied in block order so the latest
+    // lock per principal wins.
+    for (const { tx, stxLockEvents } of entries) {
+      for (const event of stxLockEvents) {
+        const poxVersion = poxVersionFromContractName(event.contract_name);
+        if (poxVersion === undefined || poxVersion === 5) {
+          continue;
+        }
+        await this.setStxLockedBalance(sql, {
+          principal: event.locked_address,
+          lockedAmount: event.locked_amount.toString(),
+          unlockBurnHeight: event.unlock_height,
+          poxVersion,
+          lockTxId: event.tx_id,
+          lockBlockHeight: event.block_height,
+          burnchainLockHeight: tx.burn_block_height,
+        });
+      }
     }
   }
 
@@ -4353,6 +4551,11 @@ export class PgWriteStore extends PgStore {
     });
 
     await q.done();
+
+    // Recompute the materialized locked-STX balances for principals touched by
+    // this block. Must run after the queue drains so the `stx_lock_events` and
+    // `pox5_events` canonical flips above are visible to the recompute.
+    await this.recomputeStxLockedBalances(sql, indexBlockHash);
 
     return result;
   }

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -592,7 +592,7 @@ export class PgWriteStore extends PgStore {
             await this.clearStxLockedBalance(sql, poxEvent.data.staker);
             break;
           case Pox5EventName.RegisterSigner:
-            // TODO: Implement
+            // No-op.
             break;
         }
       }

--- a/src/datastore/v3/helpers.ts
+++ b/src/datastore/v3/helpers.ts
@@ -1,4 +1,8 @@
-import { FtBalanceCursor, TransactionCursor } from '../../api/schemas/v3/cursors.js';
+import {
+  FtBalanceCursor,
+  NftBalanceCursor,
+  TransactionCursor,
+} from '../../api/schemas/v3/cursors.js';
 import { I32_MAX } from '../../helpers.js';
 
 const MAX_TX_INDEX = 0x7fff;
@@ -61,3 +65,25 @@ export const parseFtBalanceCursor = (cursor: FtBalanceCursor): FtBalanceCursorRo
 
 export const encodeFtBalanceCursor = (row: FtBalanceCursorRow): FtBalanceCursor =>
   `${row.balance}:${row.token}`;
+
+export type NftBalanceCursorRow = {
+  /** The NFT instance value as a `0x`-prefixed hex string. */
+  value: string;
+  asset_identifier: string;
+};
+
+/**
+ * Parses an NFT balance cursor (`value:asset_identifier`). The value is a
+ * `0x`-prefixed hex string and contains no colon, so the cursor is split on the
+ * first colon; the remainder is the asset identifier (which may contain `::`).
+ */
+export const parseNftBalanceCursor = (cursor: NftBalanceCursor): NftBalanceCursorRow => {
+  const separatorIndex = cursor.indexOf(':');
+  return {
+    value: cursor.slice(0, separatorIndex),
+    asset_identifier: cursor.slice(separatorIndex + 1),
+  };
+};
+
+export const encodeNftBalanceCursor = (row: NftBalanceCursorRow): NftBalanceCursor =>
+  `${row.value}:${row.asset_identifier}`;

--- a/src/datastore/v3/helpers.ts
+++ b/src/datastore/v3/helpers.ts
@@ -1,4 +1,4 @@
-import { TransactionCursor } from '../../api/schemas/v3/cursors.js';
+import { FtBalanceCursor, TransactionCursor } from '../../api/schemas/v3/cursors.js';
 import { I32_MAX } from '../../helpers.js';
 
 const MAX_TX_INDEX = 0x7fff;
@@ -40,3 +40,24 @@ export const resolveTransactionCursor = async (
 
 export const encodeTransactionCursor = (tx: TransactionCursorRow): TransactionCursor =>
   `${tx.block_height}:${tx.microblock_sequence}:${tx.tx_index}`;
+
+export type FtBalanceCursorRow = {
+  balance: string;
+  token: string;
+};
+
+/**
+ * Parses an FT balance cursor (`balance:asset_identifier`). The balance is
+ * digits-only and contains no colon, so the cursor is split on the first colon;
+ * the remainder is the asset identifier (which may itself contain `::`).
+ */
+export const parseFtBalanceCursor = (cursor: FtBalanceCursor): FtBalanceCursorRow => {
+  const separatorIndex = cursor.indexOf(':');
+  return {
+    balance: cursor.slice(0, separatorIndex),
+    token: cursor.slice(separatorIndex + 1),
+  };
+};
+
+export const encodeFtBalanceCursor = (row: FtBalanceCursorRow): FtBalanceCursor =>
+  `${row.balance}:${row.token}`;

--- a/src/datastore/v3/pg-store-v3.ts
+++ b/src/datastore/v3/pg-store-v3.ts
@@ -8,6 +8,7 @@ import {
   DbMempoolTransaction,
   DbMempoolTransactionSummary,
   DbPrincipalBondPosition,
+  DbPrincipalFtBalance,
   DbPrincipalTransactionSummary,
   DbTransaction,
   DbTransactionCursor,
@@ -33,10 +34,16 @@ import { InvalidRequestError, InvalidRequestErrorType } from '../../errors.js';
 import { TransactionIncludeField } from '../../api/schemas/v3/entities/transactions.js';
 import type {
   BondCursor,
+  FtBalanceCursor,
   TransactionCursor,
   TransactionEventCursor,
 } from '../../api/schemas/v3/cursors.js';
-import { encodeTransactionCursor, resolveTransactionCursor } from './helpers.js';
+import {
+  encodeFtBalanceCursor,
+  encodeTransactionCursor,
+  parseFtBalanceCursor,
+  resolveTransactionCursor,
+} from './helpers.js';
 import { DbEventTypeId } from '../common.js';
 
 export class PgStoreV3 extends BasePgStoreModule {
@@ -249,6 +256,86 @@ export class PgStoreV3 extends BasePgStoreModule {
         current_cursor: currentCursor,
         total,
         results,
+      };
+    });
+  }
+
+  /**
+   * Gets a principal's fungible-token balances, sorted by balance descending,
+   * keyset-paginated by `(balance, asset_identifier)`.
+   * @param args - The arguments for the query.
+   * @returns The principal's FT positions.
+   */
+  async getPrincipalFtBalances(args: {
+    principal: Principal;
+    limit: number;
+    cursor?: FtBalanceCursor;
+  }): Promise<DbCursorPaginatedResult<DbPrincipalFtBalance>> {
+    return await this.sqlTransaction(async sql => {
+      // Position the page at or after the cursor in `(balance DESC, token ASC)`
+      // order: a smaller balance comes later, or the same balance with a token
+      // at-or-after the cursor's token.
+      let cursorFilter = sql``;
+      if (args.cursor) {
+        const cursor = parseFtBalanceCursor(args.cursor);
+        cursorFilter = sql`
+          AND (
+            balance < ${cursor.balance}::numeric
+            OR (balance = ${cursor.balance}::numeric AND token >= ${cursor.token})
+          )
+        `;
+      }
+      const baseFilter = sql`
+        address = ${args.principal} AND token != 'stx' AND balance > 0
+      `;
+      const resultQuery = await sql<(DbPrincipalFtBalance & { total: number })[]>`
+        SELECT
+          token,
+          balance::text AS balance,
+          (SELECT COUNT(*)::int FROM ft_balances WHERE ${baseFilter}) AS total
+        FROM ft_balances
+        WHERE ${baseFilter} ${cursorFilter}
+        ORDER BY balance DESC, token ASC
+        LIMIT ${args.limit + 1}
+      `;
+
+      const hasNextPage = resultQuery.count > args.limit;
+      const results = hasNextPage ? resultQuery.slice(0, args.limit) : resultQuery;
+      const total = resultQuery.count > 0 ? resultQuery[0].total : 0;
+
+      const nextResult = resultQuery[resultQuery.length - 1];
+      const nextCursor = hasNextPage && nextResult ? encodeFtBalanceCursor(nextResult) : null;
+
+      const firstResult = results[0];
+      const currentCursor = firstResult ? encodeFtBalanceCursor(firstResult) : null;
+
+      // The previous page is the rows strictly before the first result in sort
+      // order: a larger balance, or the same balance with an earlier token.
+      let prevCursor: string | null = null;
+      if (firstResult) {
+        const prevPageQuery = await sql<{ balance: string; token: string }[]>`
+          SELECT token, balance::text AS balance
+          FROM ft_balances
+          WHERE ${baseFilter}
+            AND (
+              balance > ${firstResult.balance}::numeric
+              OR (balance = ${firstResult.balance}::numeric AND token < ${firstResult.token})
+            )
+          ORDER BY balance ASC, token DESC
+          LIMIT ${args.limit}
+        `;
+        if (prevPageQuery.length > 0) {
+          prevCursor = encodeFtBalanceCursor(prevPageQuery[prevPageQuery.length - 1]);
+        }
+      }
+
+      return {
+        limit: args.limit,
+        next_cursor: nextCursor,
+        prev_cursor: prevCursor,
+        current_cursor: currentCursor,
+        total,
+        results: results.map(r => ({ token: r.token, balance: r.balance })),
       };
     });
   }

--- a/src/datastore/v3/pg-store-v3.ts
+++ b/src/datastore/v3/pg-store-v3.ts
@@ -9,6 +9,7 @@ import {
   DbMempoolTransactionSummary,
   DbPrincipalBondPosition,
   DbPrincipalFtBalance,
+  DbPrincipalNftBalance,
   DbPrincipalTransactionSummary,
   DbTransaction,
   DbTransactionCursor,
@@ -35,13 +36,16 @@ import { TransactionIncludeField } from '../../api/schemas/v3/entities/transacti
 import type {
   BondCursor,
   FtBalanceCursor,
+  NftBalanceCursor,
   TransactionCursor,
   TransactionEventCursor,
 } from '../../api/schemas/v3/cursors.js';
 import {
   encodeFtBalanceCursor,
+  encodeNftBalanceCursor,
   encodeTransactionCursor,
   parseFtBalanceCursor,
+  parseNftBalanceCursor,
   resolveTransactionCursor,
 } from './helpers.js';
 import { DbEventTypeId } from '../common.js';
@@ -336,6 +340,85 @@ export class PgStoreV3 extends BasePgStoreModule {
         current_cursor: currentCursor,
         total,
         results: results.map(r => ({ token: r.token, balance: r.balance })),
+      };
+    });
+  }
+
+  /**
+   * Gets a principal's individually-owned NFT instances, keyset-paginated by
+   * `(asset_identifier, value)` (the unique key for an NFT instance), sorted
+   * ascending. Backed by the `nft_custody` index on
+   * `(recipient, asset_identifier, value)`.
+   * @param args - The arguments for the query.
+   * @returns The principal's NFT positions.
+   */
+  async getPrincipalNftBalances(args: {
+    principal: Principal;
+    limit: number;
+    cursor?: NftBalanceCursor;
+  }): Promise<DbCursorPaginatedResult<DbPrincipalNftBalance>> {
+    return await this.sqlTransaction(async sql => {
+      // Position the page strictly after the cursor in `(asset_identifier, value)`
+      // ascending order.
+      let cursorFilter = sql``;
+      if (args.cursor) {
+        const cursor = parseNftBalanceCursor(args.cursor);
+        // Inclusive on the cursor row: `next_cursor` points at the first row of
+        // the next page, which is re-included here as that page's first result.
+        cursorFilter = sql`
+          AND (
+            asset_identifier > ${cursor.asset_identifier}
+            OR (asset_identifier = ${cursor.asset_identifier} AND value >= ${cursor.value})
+          )
+        `;
+      }
+      const resultQuery = await sql<(DbPrincipalNftBalance & { total: number })[]>`
+        SELECT
+          asset_identifier,
+          value,
+          (SELECT COUNT(*)::int FROM nft_custody WHERE recipient = ${args.principal}) AS total
+        FROM nft_custody
+        WHERE recipient = ${args.principal} ${cursorFilter}
+        ORDER BY asset_identifier ASC, value ASC
+        LIMIT ${args.limit + 1}
+      `;
+
+      const hasNextPage = resultQuery.count > args.limit;
+      const results = hasNextPage ? resultQuery.slice(0, args.limit) : resultQuery;
+      const total = resultQuery.count > 0 ? resultQuery[0].total : 0;
+
+      const nextResult = resultQuery[resultQuery.length - 1];
+      const nextCursor = hasNextPage && nextResult ? encodeNftBalanceCursor(nextResult) : null;
+
+      const firstResult = results[0];
+      const currentCursor = firstResult ? encodeNftBalanceCursor(firstResult) : null;
+
+      // The previous page is the rows strictly before the first result in sort order.
+      let prevCursor: string | null = null;
+      if (firstResult) {
+        const prevPageQuery = await sql<{ asset_identifier: string; value: string }[]>`
+          SELECT asset_identifier, value
+          FROM nft_custody
+          WHERE recipient = ${args.principal}
+            AND (
+              asset_identifier < ${firstResult.asset_identifier}
+              OR (asset_identifier = ${firstResult.asset_identifier} AND value < ${firstResult.value})
+            )
+          ORDER BY asset_identifier DESC, value DESC
+          LIMIT ${args.limit}
+        `;
+        if (prevPageQuery.length > 0) {
+          prevCursor = encodeNftBalanceCursor(prevPageQuery[prevPageQuery.length - 1]);
+        }
+      }
+
+      return {
+        limit: args.limit,
+        next_cursor: nextCursor,
+        prev_cursor: prevCursor,
+        current_cursor: currentCursor,
+        total,
+        results: results.map(r => ({ asset_identifier: r.asset_identifier, value: r.value })),
       };
     });
   }

--- a/src/datastore/v3/types.ts
+++ b/src/datastore/v3/types.ts
@@ -187,3 +187,9 @@ export interface DbTransactionCursor {
   microblock_sequence: number;
   tx_index: number;
 }
+
+export interface DbPrincipalFtBalance {
+  /** The fungible token asset identifier (the `ft_balances.token` column). */
+  token: string;
+  balance: string;
+}

--- a/src/datastore/v3/types.ts
+++ b/src/datastore/v3/types.ts
@@ -193,3 +193,9 @@ export interface DbPrincipalFtBalance {
   token: string;
   balance: string;
 }
+
+export interface DbPrincipalNftBalance {
+  asset_identifier: string;
+  /** The NFT instance value (Clarity value) as a `0x`-prefixed hex string. */
+  value: string;
+}

--- a/tests/api/datastore/datastore.test.ts
+++ b/tests/api/datastore/datastore.test.ts
@@ -110,7 +110,7 @@ describe('postgres datastore', () => {
       block_hash: '0x9876',
       block_height: 1,
       block_time: 2837565,
-      burn_block_height: 1,
+      burn_block_height: 123,
       burn_block_time: 2837565,
       parent_burn_block_time: 1626122935,
       type_id: DbTxTypeId.Coinbase,
@@ -196,8 +196,11 @@ describe('postgres datastore', () => {
       return stxEvent;
     };
     const stxLockEvents = [
-      createStxLockEvent('addrA', 400n),
+      // addrA: an earlier lock superseded by a later, still-active lock. The
+      // latest lock (400n, unlock = block_height + 200 = 201) is authoritative.
       createStxLockEvent('addrA', 222n, 1),
+      createStxLockEvent('addrA', 400n),
+      // addrB: a single lock that has already expired (unlock height 1) → not locked.
       createStxLockEvent('addrB', 333n, 1),
     ];
     await db.updateStxLockEvents(client, [{ tx, stxLockEvents }]);

--- a/tests/api/pox5/stx-lock.test.ts
+++ b/tests/api/pox5/stx-lock.test.ts
@@ -1,3 +1,4 @@
+import supertest from 'supertest';
 import { afterEach, beforeEach, describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { STACKS_TESTNET } from '@stacks/network';
@@ -205,6 +206,55 @@ describe('pox-5 locked STX in balance read path', () => {
     assert.equal(balance.locked, 0n);
     assert.equal(balance.lockTxId, '');
     assert.equal(balance.burnchainUnlockHeight, 0);
+  });
+
+  test('the v3 /balances/stx endpoint reports the active pox-5 lock', async () => {
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        block_hash: '0x01',
+        index_block_hash: '0x01',
+        burn_block_height: TIP_BURN_HEIGHT,
+      })
+        .addTx({ tx_id: '0x' + 'a1'.repeat(32) })
+        // Credit alice so she actually holds the STX she locks.
+        .addTxStxEvent({ recipient: ALICE, amount: STAKE_AMOUNT })
+        .addTxPox5Event({ name: Pox5EventName.Stake, data: stakeData(STAKE_AMOUNT, ACTIVE_UNLOCK) })
+        .build()
+    );
+    const res = await supertest(api.server).get(`/extended/v3/principals/${ALICE}/balances/stx`);
+    assert.equal(res.status, 200, res.text);
+    const body = JSON.parse(res.text);
+    assert.ok(body.locked, 'locked object present');
+    assert.equal(body.locked.amount, STAKE_AMOUNT.toString());
+    assert.equal(body.locked.pox_version, 5);
+    assert.equal(body.locked.burn_unlock_height, ACTIVE_UNLOCK);
+    assert.notEqual(body.locked.lock_tx_id, '');
+    // No STX credits in this block, so total balance is just the locked amount and
+    // available is balance − locked = 0. Mempool is empty → null.
+    assert.equal(body.balance, STAKE_AMOUNT.toString());
+    assert.equal(body.available, '0');
+    assert.equal(body.mempool, null);
+  });
+
+  test('the v3 /balances/stx endpoint returns null locked when nothing is locked', async () => {
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        block_hash: '0x01',
+        index_block_hash: '0x01',
+        burn_block_height: TIP_BURN_HEIGHT,
+      })
+        .addTx({ tx_id: '0x' + 'a1'.repeat(32) })
+        .build()
+    );
+    const res = await supertest(api.server).get(`/extended/v3/principals/${ALICE}/balances/stx`);
+    assert.equal(res.status, 200, res.text);
+    const body = JSON.parse(res.text);
+    assert.equal(body.locked, null);
+    assert.equal(body.mempool, null);
+    assert.equal(body.balance, '0');
+    assert.equal(body.available, '0');
   });
 });
 

--- a/tests/api/pox5/stx-lock.test.ts
+++ b/tests/api/pox5/stx-lock.test.ts
@@ -131,6 +131,84 @@ describe('pox-5 stake locked balances', () => {
 });
 
 /**
+ * The STX balance read path resolves the `locked` amount from the materialized
+ * `stx_locked_balances` table for current-tip reads, so a pox-5 stake must now
+ * surface as locked STX in the balance response (it previously did not).
+ */
+describe('pox-5 locked STX in balance read path', () => {
+  let db: PgWriteStore;
+  let api: ApiServer;
+
+  const ALICE = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
+  const SIGNER = 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP.signer-manager';
+  const STAKE_AMOUNT = 50_000_000n;
+  const TIP_BURN_HEIGHT = 100;
+  const ACTIVE_UNLOCK = 500;
+  const EXPIRED_UNLOCK = 50;
+
+  function stakeData(amount: bigint, unlock: number) {
+    return {
+      signer: SIGNER,
+      staker: ALICE,
+      amount_ustx: amount.toString(),
+      num_cycles: '2',
+      first_reward_cycle: '8',
+      unlock_burn_height: String(unlock),
+      unlock_cycle: '20',
+    };
+  }
+
+  beforeEach(async () => {
+    await migrate('up');
+    db = await PgWriteStore.connect({ usageName: 'tests', withNotifier: false, skipMigrations: true });
+    api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
+  });
+
+  afterEach(async () => {
+    await api.terminate();
+    await db?.close();
+    await migrate('down');
+  });
+
+  test('an active pox-5 stake is reported as locked STX', async () => {
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        block_hash: '0x01',
+        index_block_hash: '0x01',
+        burn_block_height: TIP_BURN_HEIGHT,
+      })
+        .addTx({ tx_id: '0x' + 'a1'.repeat(32) })
+        .addTxPox5Event({ name: Pox5EventName.Stake, data: stakeData(STAKE_AMOUNT, ACTIVE_UNLOCK) })
+        .build()
+    );
+    const balance = await db.getStxBalance({ stxAddress: ALICE, includeUnanchored: false });
+    assert.equal(balance.locked, STAKE_AMOUNT);
+    assert.equal(balance.burnchainUnlockHeight, ACTIVE_UNLOCK);
+    assert.equal(balance.lockHeight, 1);
+    assert.notEqual(balance.lockTxId, '');
+  });
+
+  test('a pox-5 stake whose unlock height has passed reports zero locked STX', async () => {
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        block_hash: '0x01',
+        index_block_hash: '0x01',
+        burn_block_height: TIP_BURN_HEIGHT,
+      })
+        .addTx({ tx_id: '0x' + 'a1'.repeat(32) })
+        .addTxPox5Event({ name: Pox5EventName.Stake, data: stakeData(STAKE_AMOUNT, EXPIRED_UNLOCK) })
+        .build()
+    );
+    const balance = await db.getStxBalance({ stxAddress: ALICE, includeUnanchored: false });
+    assert.equal(balance.locked, 0n);
+    assert.equal(balance.lockTxId, '');
+    assert.equal(balance.burnchainUnlockHeight, 0);
+  });
+});
+
+/**
  * pox-4 (and earlier) `stx_lock` events emitted by transactions are inherited
  * into the same materialized `stx_locked_balances` table, with the pox version
  * derived from the lock event's `contract_name`.

--- a/tests/api/pox5/stx-lock.test.ts
+++ b/tests/api/pox5/stx-lock.test.ts
@@ -1,0 +1,428 @@
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { STACKS_TESTNET } from '@stacks/network';
+import { Pox5EventName } from '@stacks/codec';
+import { ApiServer, startApiServer } from '../../../src/api/init.ts';
+import { PgWriteStore } from '../../../src/datastore/pg-write-store.ts';
+import { migrate } from '../../test-helpers.ts';
+import { TestBlockBuilder } from '../test-builders.ts';
+
+/**
+ * pox-5 stake / stake-update / unstake → materialized `stx_locked_balances`.
+ * (Asserted directly against the table; the read endpoint is wired up later.)
+ */
+
+const ADMIN = 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP';
+const ALICE = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
+const SIGNER = `${ADMIN}.signer-manager`;
+const FIRST_REWARD_CYCLE = 8;
+const UNLOCK_CYCLE = 20;
+
+describe('pox-5 stake locked balances', () => {
+  let db: PgWriteStore;
+  let api: ApiServer;
+
+  const STAKE_AMOUNT = 50_000_000n;
+  const STAKE_UNLOCK = 500;
+  const UPDATED_AMOUNT = 80_000_000n;
+  const UPDATED_UNLOCK = 600;
+
+  async function lockedRow(principal: string) {
+    const rows = await db.sql<
+      { locked_amount: string; unlock_burn_height: string; pox_version: number; lock_block_height: number }[]
+    >`
+      SELECT locked_amount, unlock_burn_height, pox_version, lock_block_height
+      FROM stx_locked_balances WHERE principal = ${principal}
+    `;
+    return rows[0];
+  }
+
+  const stakeData = {
+    signer: SIGNER,
+    staker: ALICE,
+    amount_ustx: STAKE_AMOUNT.toString(),
+    num_cycles: '2',
+    first_reward_cycle: String(FIRST_REWARD_CYCLE),
+    unlock_burn_height: String(STAKE_UNLOCK),
+    unlock_cycle: String(UNLOCK_CYCLE),
+  };
+  const stakeUpdateData = {
+    staker: ALICE,
+    signer: SIGNER,
+    old_signer: SIGNER,
+    prev_unlock_height: String(STAKE_UNLOCK),
+    unlock_burn_height: String(UPDATED_UNLOCK),
+    unlock_cycle: '25',
+    num_cycles: '3',
+    amount_ustx: UPDATED_AMOUNT.toString(),
+    amount_increase: (UPDATED_AMOUNT - STAKE_AMOUNT).toString(),
+    cycles_to_extend: '1',
+  };
+  const unstakeData = {
+    staker: ALICE,
+    signer: SIGNER,
+    amount_ustx: STAKE_AMOUNT.toString(),
+    first_reward_cycle: String(FIRST_REWARD_CYCLE),
+    unlock_cycle: String(UNLOCK_CYCLE),
+    unlock_burn_height: String(STAKE_UNLOCK),
+  };
+
+  beforeEach(async () => {
+    await migrate('up');
+    db = await PgWriteStore.connect({ usageName: 'tests', withNotifier: false, skipMigrations: true });
+    api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
+    // Block 1: alice stakes.
+    await db.update(
+      new TestBlockBuilder({ block_height: 1, block_hash: '0x01', index_block_hash: '0x01' })
+        .addTx({ tx_id: '0x' + 'a1'.repeat(32) })
+        .addTxPox5Event({ name: Pox5EventName.Stake, data: stakeData })
+        .build()
+    );
+  });
+
+  afterEach(async () => {
+    await api.terminate();
+    await db?.close();
+    await migrate('down');
+  });
+
+  test('stake materializes the locked balance', async () => {
+    const row = await lockedRow(ALICE);
+    assert.ok(row, 'locked balance row created');
+    assert.equal(BigInt(row.locked_amount), STAKE_AMOUNT);
+    assert.equal(BigInt(row.unlock_burn_height), BigInt(STAKE_UNLOCK));
+    assert.equal(row.pox_version, 5);
+    assert.equal(row.lock_block_height, 1);
+  });
+
+  test('stake-update replaces the locked balance with the new total + unlock', async () => {
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        block_hash: '0x02',
+        index_block_hash: '0x02',
+        parent_block_hash: '0x01',
+        parent_index_block_hash: '0x01',
+      })
+        .addTx({ tx_id: '0x' + 'a2'.repeat(32) })
+        .addTxPox5Event({ name: Pox5EventName.StakeUpdate, data: stakeUpdateData })
+        .build()
+    );
+    const row = await lockedRow(ALICE);
+    assert.equal(BigInt(row.locked_amount), UPDATED_AMOUNT);
+    assert.equal(BigInt(row.unlock_burn_height), BigInt(UPDATED_UNLOCK));
+  });
+
+  test('unstake clears the locked balance', async () => {
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        block_hash: '0x02',
+        index_block_hash: '0x02',
+        parent_block_hash: '0x01',
+        parent_index_block_hash: '0x01',
+      })
+        .addTx({ tx_id: '0x' + 'a2'.repeat(32) })
+        .addTxPox5Event({ name: Pox5EventName.Unstake, data: unstakeData })
+        .build()
+    );
+    assert.equal(await lockedRow(ALICE), undefined, 'locked balance row removed');
+  });
+});
+
+/**
+ * pox-4 (and earlier) `stx_lock` events emitted by transactions are inherited
+ * into the same materialized `stx_locked_balances` table, with the pox version
+ * derived from the lock event's `contract_name`.
+ */
+describe('pox-4 stx_lock inheritance', () => {
+  let db: PgWriteStore;
+  let api: ApiServer;
+
+  const BOB = 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5';
+  const POX4_LOCKED = 75_000_000;
+  const POX4_UNLOCK = 4200;
+
+  async function lockedRow(principal: string) {
+    const rows = await db.sql<
+      {
+        locked_amount: string;
+        unlock_burn_height: string;
+        pox_version: number;
+        lock_block_height: number;
+        burnchain_lock_height: string;
+      }[]
+    >`
+      SELECT locked_amount, unlock_burn_height, pox_version, lock_block_height, burnchain_lock_height
+      FROM stx_locked_balances WHERE principal = ${principal}
+    `;
+    return rows[0];
+  }
+
+  beforeEach(async () => {
+    await migrate('up');
+    db = await PgWriteStore.connect({ usageName: 'tests', withNotifier: false, skipMigrations: true });
+    api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
+  });
+
+  afterEach(async () => {
+    await api.terminate();
+    await db?.close();
+    await migrate('down');
+  });
+
+  test('a pox-4 stx_lock event materializes the locked balance', async () => {
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        block_hash: '0x01',
+        index_block_hash: '0x01',
+        burn_block_height: 100,
+      })
+        .addTx({ tx_id: '0x' + 'b1'.repeat(32) })
+        .addTxStxLockEvent({
+          locked_address: BOB,
+          locked_amount: POX4_LOCKED,
+          unlock_height: POX4_UNLOCK,
+          contract_name: 'pox-4',
+        })
+        .build()
+    );
+    const row = await lockedRow(BOB);
+    assert.ok(row, 'locked balance row created from pox-4 lock event');
+    assert.equal(BigInt(row.locked_amount), BigInt(POX4_LOCKED));
+    assert.equal(BigInt(row.unlock_burn_height), BigInt(POX4_UNLOCK));
+    assert.equal(row.pox_version, 4);
+    assert.equal(row.lock_block_height, 1);
+  });
+
+  test('a later pox-4 lock event replaces the prior lock state', async () => {
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        block_hash: '0x01',
+        index_block_hash: '0x01',
+        burn_block_height: 100,
+      })
+        .addTx({ tx_id: '0x' + 'b1'.repeat(32) })
+        .addTxStxLockEvent({
+          locked_address: BOB,
+          locked_amount: POX4_LOCKED,
+          unlock_height: POX4_UNLOCK,
+          contract_name: 'pox-4',
+        })
+        .build()
+    );
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        block_hash: '0x02',
+        index_block_hash: '0x02',
+        parent_block_hash: '0x01',
+        parent_index_block_hash: '0x01',
+        burn_block_height: 101,
+      })
+        .addTx({ tx_id: '0x' + 'b2'.repeat(32) })
+        .addTxStxLockEvent({
+          locked_address: BOB,
+          locked_amount: 90_000_000,
+          unlock_height: 5000,
+          contract_name: 'pox-4',
+        })
+        .build()
+    );
+    const row = await lockedRow(BOB);
+    assert.equal(BigInt(row.locked_amount), 90_000_000n);
+    assert.equal(BigInt(row.unlock_burn_height), 5000n);
+    assert.equal(row.lock_block_height, 2);
+  });
+});
+
+/**
+ * Reorg handling for the materialized `stx_locked_balances` table. Because the
+ * locked balance is a SET/latest-wins value (not additive), reorgs are handled
+ * by recomputing each affected principal's latest canonical lock — not by
+ * applying deltas. A lock on an orphaned fork must disappear (reverting to the
+ * prior canonical lock, if any), and reappear if its fork is restored.
+ */
+describe('stx_locked_balances reorg handling', () => {
+  let db: PgWriteStore;
+  let api: ApiServer;
+
+  const ALICE = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6';
+  const SIGNER = 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP.signer-manager';
+
+  function stakeData(amount: bigint, unlock: number) {
+    return {
+      signer: SIGNER,
+      staker: ALICE,
+      amount_ustx: amount.toString(),
+      num_cycles: '2',
+      first_reward_cycle: '8',
+      unlock_burn_height: String(unlock),
+      unlock_cycle: '20',
+    };
+  }
+
+  async function lockedRow(principal: string) {
+    const rows = await db.sql<
+      { locked_amount: string; unlock_burn_height: string; pox_version: number; lock_block_height: number }[]
+    >`
+      SELECT locked_amount, unlock_burn_height, pox_version, lock_block_height
+      FROM stx_locked_balances WHERE principal = ${principal}
+    `;
+    return rows[0];
+  }
+
+  beforeEach(async () => {
+    await migrate('up');
+    db = await PgWriteStore.connect({ usageName: 'tests', withNotifier: false, skipMigrations: true });
+    api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
+    // Genesis.
+    await db.update(
+      new TestBlockBuilder({ block_height: 1, block_hash: '0x01', index_block_hash: '0x01' }).build()
+    );
+  });
+
+  afterEach(async () => {
+    await api.terminate();
+    await db?.close();
+    await migrate('down');
+  });
+
+  test('a pox-5 stake on an orphaned fork disappears and is restored when its fork wins again', async () => {
+    // Fork A, block 2: alice stakes.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        block_hash: '0xa2',
+        index_block_hash: '0xa2',
+        parent_block_hash: '0x01',
+        parent_index_block_hash: '0x01',
+      })
+        .addTx({ tx_id: '0x' + 'a2'.repeat(32) })
+        .addTxPox5Event({ name: Pox5EventName.Stake, data: stakeData(50_000_000n, 500) })
+        .build()
+    );
+    assert.ok(await lockedRow(ALICE), 'lock present on fork A');
+
+    // Fork B (blocks 2 + 3, no stake) overtakes fork A.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        block_hash: '0xb2',
+        index_block_hash: '0xb2',
+        parent_block_hash: '0x01',
+        parent_index_block_hash: '0x01',
+      })
+        .addTx({ tx_id: '0x' + 'b2'.repeat(32) })
+        .build()
+    );
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 3,
+        block_hash: '0xb3',
+        index_block_hash: '0xb3',
+        parent_block_hash: '0xb2',
+        parent_index_block_hash: '0xb2',
+      })
+        .addTx({ tx_id: '0x' + 'b3'.repeat(32) })
+        .build()
+    );
+    assert.equal(await lockedRow(ALICE), undefined, 'lock gone after fork A orphaned');
+
+    // Fork A (blocks 3 + 4) wins again.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 3,
+        block_hash: '0xa3',
+        index_block_hash: '0xa3',
+        parent_block_hash: '0xa2',
+        parent_index_block_hash: '0xa2',
+      })
+        .addTx({ tx_id: '0x' + 'a3'.repeat(32) })
+        .build()
+    );
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 4,
+        block_hash: '0xa4',
+        index_block_hash: '0xa4',
+        parent_block_hash: '0xa3',
+        parent_index_block_hash: '0xa3',
+      })
+        .addTx({ tx_id: '0x' + 'a4'.repeat(32) })
+        .build()
+    );
+    const restored = await lockedRow(ALICE);
+    assert.ok(restored, 'lock restored when fork A wins again');
+    assert.equal(BigInt(restored.locked_amount), 50_000_000n);
+    assert.equal(restored.pox_version, 5);
+  });
+
+  test('orphaning a pox-5 stake reverts to the principal prior pox-4 lock', async () => {
+    // Block 2 (canonical chain): a pox-4 lock for alice.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        block_hash: '0x02',
+        index_block_hash: '0x02',
+        parent_block_hash: '0x01',
+        parent_index_block_hash: '0x01',
+        burn_block_height: 200,
+      })
+        .addTx({ tx_id: '0x' + 'c2'.repeat(32) })
+        .addTxStxLockEvent({
+          locked_address: ALICE,
+          locked_amount: 30_000_000,
+          unlock_height: 9000,
+          contract_name: 'pox-4',
+        })
+        .build()
+    );
+    // Fork A, block 3: a pox-5 stake supersedes the pox-4 lock.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 3,
+        block_hash: '0xa3',
+        index_block_hash: '0xa3',
+        parent_block_hash: '0x02',
+        parent_index_block_hash: '0x02',
+      })
+        .addTx({ tx_id: '0x' + 'a3'.repeat(32) })
+        .addTxPox5Event({ name: Pox5EventName.Stake, data: stakeData(50_000_000n, 500) })
+        .build()
+    );
+    let row = await lockedRow(ALICE);
+    assert.equal(row.pox_version, 5, 'pox-5 stake is the latest lock');
+    assert.equal(BigInt(row.locked_amount), 50_000_000n);
+
+    // Fork B (blocks 3 + 4, no stake) overtakes fork A, orphaning the pox-5 stake.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 3,
+        block_hash: '0xb3',
+        index_block_hash: '0xb3',
+        parent_block_hash: '0x02',
+        parent_index_block_hash: '0x02',
+      })
+        .addTx({ tx_id: '0x' + 'd3'.repeat(32) })
+        .build()
+    );
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 4,
+        block_hash: '0xb4',
+        index_block_hash: '0xb4',
+        parent_block_hash: '0xb3',
+        parent_index_block_hash: '0xb3',
+      })
+        .addTx({ tx_id: '0x' + 'd4'.repeat(32) })
+        .build()
+    );
+    row = await lockedRow(ALICE);
+    assert.ok(row, 'lock still present (reverted to pox-4)');
+    assert.equal(row.pox_version, 4, 'reverted to the pox-4 lock');
+    assert.equal(BigInt(row.locked_amount), 30_000_000n);
+  });
+});

--- a/tests/api/test-builders.ts
+++ b/tests/api/test-builders.ts
@@ -527,6 +527,7 @@ interface TestStxEventLockArgs {
   locked_amount?: number;
   unlock_height?: number;
   locked_address?: string;
+  contract_name?: string;
 }
 
 /**
@@ -545,7 +546,7 @@ function testStxLockEvent(args?: TestStxEventLockArgs): DbStxLockEvent {
     locked_amount: BigInt(args?.locked_amount ?? 500),
     unlock_height: args?.unlock_height ?? 1,
     locked_address: args?.locked_address ?? 'lock-addr',
-    contract_name: 'pox',
+    contract_name: args?.contract_name ?? 'pox',
   };
 }
 

--- a/tests/api/v3/principals.test.ts
+++ b/tests/api/v3/principals.test.ts
@@ -4,7 +4,7 @@ import { ApiServer, startApiServer } from '../../../src/api/init.ts';
 import { migrate } from '../../test-helpers.ts';
 import { STACKS_TESTNET } from '@stacks/network';
 import * as assert from 'node:assert/strict';
-import { TestBlockBuilder } from '../test-builders.ts';
+import { TestBlockBuilder, testMempoolTx } from '../test-builders.ts';
 import { DbTxStatus, DbTxTypeId } from '../../../src/datastore/common.ts';
 import { hex } from '../test-helpers.ts';
 import { I32_MAX } from '../../../src/helpers.ts';
@@ -516,6 +516,162 @@ describe('principals', () => {
         headers: { 'if-none-match': newEtag as string },
       });
       assert.equal(refreshed.statusCode, 304);
+    });
+  });
+
+  describe('/v3/principals/:principal/balances/stx', () => {
+    // Fresh principals not touched by the shared block setup.
+    const balAddr = 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5';
+    const lockAddr = 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP';
+
+    const getStxBalance = async (principal: string) => {
+      const res = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/principals/${principal}/balances/stx`,
+      });
+      assert.equal(res.statusCode, 200, res.body);
+      return JSON.parse(res.body);
+    };
+
+    // Block 3: credits `balAddr` 1,000,000 µSTX, and credits + locks 400,000 of
+    // `lockAddr`'s STX via a pox-4 lock that unlocks far in the future.
+    const buildBlock3 = () =>
+      new TestBlockBuilder({
+        block_height: 3,
+        block_hash: hex(3),
+        index_block_hash: hex(3),
+        parent_index_block_hash: hex(2),
+        parent_block_hash: hex(2),
+        burn_block_height: 3,
+      })
+        .addTx({
+          tx_id: hex(301),
+          block_hash: hex(3),
+          index_block_hash: hex(3),
+          burn_block_height: 3,
+          sender_address: testAddr4,
+        })
+        .addTxStxEvent({ recipient: balAddr, sender: testAddr4, amount: 1_000_000n })
+        .addTx({
+          tx_id: hex(302),
+          block_hash: hex(3),
+          index_block_hash: hex(3),
+          burn_block_height: 3,
+          tx_index: 1,
+          sender_address: testAddr4,
+        })
+        .addTxStxEvent({ recipient: lockAddr, sender: testAddr4, amount: 1_000_000n })
+        .addTxStxLockEvent({
+          locked_address: lockAddr,
+          locked_amount: 400_000,
+          unlock_height: 1000,
+          contract_name: 'pox-4',
+        })
+        .build();
+
+    test('returns zeroed balance for a principal with no activity', async () => {
+      const body = await getStxBalance(emptyPrincipal);
+      assert.deepEqual(body, {
+        balance: '0',
+        available: '0',
+        locked: null,
+        mempool: null,
+      });
+    });
+
+    test('returns the confirmed STX balance with no lock or mempool activity', async () => {
+      await db.update(buildBlock3());
+      const body = await getStxBalance(balAddr);
+      assert.deepEqual(body, {
+        balance: '1000000',
+        available: '1000000',
+        locked: null,
+        mempool: null,
+      });
+    });
+
+    test('reports locked STX with available = balance − locked', async () => {
+      await db.update(buildBlock3());
+      const body = await getStxBalance(lockAddr);
+      assert.equal(body.balance, '1000000');
+      assert.equal(body.available, '600000');
+      assert.equal(body.mempool, null);
+      assert.deepEqual(body.locked, {
+        amount: '400000',
+        pox_version: 4,
+        lock_tx_id: hex(302),
+        stacks_lock_height: 3,
+        burn_lock_height: 3,
+        burn_unlock_height: 1000,
+      });
+    });
+
+    test('includes pending mempool balance and projects the estimated balance', async () => {
+      await db.update(buildBlock3());
+      // A pending outbound transfer of 50,000 µSTX + 1,234 fee from balAddr.
+      await db.updateMempoolTxs({
+        mempoolTxs: [
+          testMempoolTx({
+            tx_id: hex(401),
+            sender_address: balAddr,
+            token_transfer_amount: 50_000n,
+            fee_rate: 1_234n,
+          }),
+        ],
+      });
+      const body = await getStxBalance(balAddr);
+      assert.equal(body.balance, '1000000');
+      assert.equal(body.available, '1000000');
+      assert.equal(body.locked, null);
+      assert.deepEqual(body.mempool, {
+        // available (1,000,000) − outbound (50,000 + 1,234)
+        estimated_balance: '948766',
+        inbound: '0',
+        outbound: '51234',
+      });
+    });
+
+    test('ETag tracks mempool changes (handlePrincipalMempoolCache)', async () => {
+      await db.update(buildBlock3());
+
+      const first = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/principals/${balAddr}/balances/stx`,
+      });
+      assert.equal(first.statusCode, 200);
+      const etag = first.headers['etag'];
+      assert.ok(etag, 'expected ETag header to be set');
+
+      // Same ETag returns 304.
+      const cached = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/principals/${balAddr}/balances/stx`,
+        headers: { 'if-none-match': etag as string },
+      });
+      assert.equal(cached.statusCode, 304);
+      assert.equal(cached.body, '');
+
+      // A new pending mempool tx for the principal invalidates the ETag.
+      await db.updateMempoolTxs({
+        mempoolTxs: [
+          testMempoolTx({
+            tx_id: hex(402),
+            sender_address: balAddr,
+            token_transfer_amount: 10_000n,
+            fee_rate: 500n,
+          }),
+        ],
+      });
+
+      const afterMempool = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/principals/${balAddr}/balances/stx`,
+        headers: { 'if-none-match': etag as string },
+      });
+      assert.equal(afterMempool.statusCode, 200);
+      const newEtag = afterMempool.headers['etag'];
+      assert.ok(newEtag);
+      assert.notEqual(newEtag, etag);
     });
   });
 });

--- a/tests/api/v3/principals.test.ts
+++ b/tests/api/v3/principals.test.ts
@@ -674,4 +674,103 @@ describe('principals', () => {
       assert.notEqual(newEtag, etag);
     });
   });
+
+  describe('/v3/principals/:principal/balances/ft', () => {
+    const ftAddr = 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5';
+    const tokenBig = 'SP000000000000000000002Q6VF78.token-big::big';
+    const tokenMid = 'SP000000000000000000002Q6VF78.token-mid::mid';
+    const tokenSmall = 'SP000000000000000000002Q6VF78.token-small::small';
+    const tokenZero = 'SP000000000000000000002Q6VF78.token-zero::zero';
+
+    const getFtBalances = async (principal: string, query: Record<string, string> = {}) => {
+      const res = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/principals/${principal}/balances/ft`,
+        query,
+      });
+      assert.equal(res.statusCode, 200, res.body);
+      return JSON.parse(res.body);
+    };
+
+    // Block 3: credits `ftAddr` three tokens of distinct balances, an STX
+    // balance (must be excluded), and a token that nets to zero (must be excluded).
+    const buildFtBlock = () =>
+      new TestBlockBuilder({
+        block_height: 3,
+        block_hash: hex(3),
+        index_block_hash: hex(3),
+        parent_index_block_hash: hex(2),
+        parent_block_hash: hex(2),
+        burn_block_height: 3,
+      })
+        .addTx({
+          tx_id: hex(310),
+          block_hash: hex(3),
+          index_block_hash: hex(3),
+          burn_block_height: 3,
+          sender_address: testAddr4,
+        })
+        .addTxStxEvent({ recipient: ftAddr, sender: testAddr4, amount: 9_999n })
+        .addTxFtEvent({ recipient: ftAddr, sender: testAddr4, asset_identifier: tokenBig, amount: 3_000_000n })
+        .addTxFtEvent({ recipient: ftAddr, sender: testAddr4, asset_identifier: tokenMid, amount: 2_000_000n })
+        .addTxFtEvent({ recipient: ftAddr, sender: testAddr4, asset_identifier: tokenSmall, amount: 1_000_000n })
+        .addTxFtEvent({ recipient: ftAddr, sender: testAddr4, asset_identifier: tokenZero, amount: 500_000n })
+        .addTxFtEvent({ sender: ftAddr, recipient: testAddr4, asset_identifier: tokenZero, amount: 500_000n })
+        .build();
+
+    test('returns an empty page for a principal with no FT balances', async () => {
+      const body = await getFtBalances(emptyPrincipal);
+      assert.deepEqual(body, {
+        total: 0,
+        limit: 100,
+        cursor: { next: null, previous: null, current: null },
+        results: [],
+      });
+    });
+
+    test('lists FT positions sorted by balance descending, excluding stx and zero balances', async () => {
+      await db.update(buildFtBlock());
+      const body = await getFtBalances(ftAddr);
+      assert.equal(body.total, 3);
+      assert.deepEqual(body.results, [
+        { asset_identifier: tokenBig, balance: '3000000' },
+        { asset_identifier: tokenMid, balance: '2000000' },
+        { asset_identifier: tokenSmall, balance: '1000000' },
+      ]);
+      assert.deepEqual(body.cursor, { next: null, previous: null, current: `3000000:${tokenBig}` });
+    });
+
+    test('paginates with cursors across pages', async () => {
+      await db.update(buildFtBlock());
+
+      // Page 1.
+      const page1 = await getFtBalances(ftAddr, { limit: '1' });
+      assert.equal(page1.total, 3);
+      assert.equal(page1.limit, 1);
+      assert.deepEqual(page1.results, [{ asset_identifier: tokenBig, balance: '3000000' }]);
+      assert.deepEqual(page1.cursor, {
+        next: `2000000:${tokenMid}`,
+        previous: null,
+        current: `3000000:${tokenBig}`,
+      });
+
+      // Page 2.
+      const page2 = await getFtBalances(ftAddr, { limit: '1', cursor: page1.cursor.next });
+      assert.deepEqual(page2.results, [{ asset_identifier: tokenMid, balance: '2000000' }]);
+      assert.deepEqual(page2.cursor, {
+        next: `1000000:${tokenSmall}`,
+        previous: `3000000:${tokenBig}`,
+        current: `2000000:${tokenMid}`,
+      });
+
+      // Page 3 (last).
+      const page3 = await getFtBalances(ftAddr, { limit: '1', cursor: page2.cursor.next });
+      assert.deepEqual(page3.results, [{ asset_identifier: tokenSmall, balance: '1000000' }]);
+      assert.deepEqual(page3.cursor, {
+        next: null,
+        previous: `2000000:${tokenMid}`,
+        current: `1000000:${tokenSmall}`,
+      });
+    });
+  });
 });

--- a/tests/api/v3/principals.test.ts
+++ b/tests/api/v3/principals.test.ts
@@ -5,6 +5,7 @@ import { migrate } from '../../test-helpers.ts';
 import { STACKS_TESTNET } from '@stacks/network';
 import * as assert from 'node:assert/strict';
 import { TestBlockBuilder, testMempoolTx } from '../test-builders.ts';
+import { serializeCV, uintCV } from '@stacks/transactions';
 import { DbTxStatus, DbTxTypeId } from '../../../src/datastore/common.ts';
 import { hex } from '../test-helpers.ts';
 import { I32_MAX } from '../../../src/helpers.ts';
@@ -770,6 +771,113 @@ describe('principals', () => {
         next: null,
         previous: `2000000:${tokenMid}`,
         current: `1000000:${tokenSmall}`,
+      });
+    });
+  });
+
+  describe('/v3/principals/:principal/balances/nft', () => {
+    const nftAddr = 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP';
+    const collectionA = 'SP000000000000000000002Q6VF78.collection-a::A';
+    const collectionB = 'SP000000000000000000002Q6VF78.collection-b::B';
+    const cvHex = (n: number) => '0x' + serializeCV(uintCV(n));
+    const vA1 = cvHex(1);
+    const vA2 = cvHex(2);
+    const vB1 = cvHex(1);
+
+    const getNftBalances = async (principal: string, query: Record<string, string> = {}) => {
+      const res = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/principals/${principal}/balances/nft`,
+        query,
+      });
+      assert.equal(res.statusCode, 200, res.body);
+      return JSON.parse(res.body);
+    };
+
+    // Block 3: transfers three NFT instances to `nftAddr` — two of collection A
+    // (token ids 1, 2) and one of collection B (token id 1).
+    const buildNftBlock = () =>
+      new TestBlockBuilder({
+        block_height: 3,
+        block_hash: hex(3),
+        index_block_hash: hex(3),
+        parent_index_block_hash: hex(2),
+        parent_block_hash: hex(2),
+        burn_block_height: 3,
+      })
+        .addTx({
+          tx_id: hex(320),
+          block_hash: hex(3),
+          index_block_hash: hex(3),
+          burn_block_height: 3,
+          sender_address: testAddr4,
+        })
+        .addTxNftEvent({ recipient: nftAddr, sender: testAddr4, asset_identifier: collectionA, value: vA1 })
+        .addTxNftEvent({ recipient: nftAddr, sender: testAddr4, asset_identifier: collectionA, value: vA2 })
+        .addTxNftEvent({ recipient: nftAddr, sender: testAddr4, asset_identifier: collectionB, value: vB1 })
+        .build();
+
+    test('returns an empty page for a principal with no NFTs', async () => {
+      const body = await getNftBalances(emptyPrincipal);
+      assert.deepEqual(body, {
+        total: 0,
+        limit: 100,
+        cursor: { next: null, previous: null, current: null },
+        results: [],
+      });
+    });
+
+    test('lists owned NFT instances sorted by asset identifier then value', async () => {
+      await db.update(buildNftBlock());
+      const body = await getNftBalances(nftAddr);
+      assert.equal(body.total, 3);
+      assert.deepEqual(body.results, [
+        { asset_identifier: collectionA, value: { hex: vA1, repr: 'u1' } },
+        { asset_identifier: collectionA, value: { hex: vA2, repr: 'u2' } },
+        { asset_identifier: collectionB, value: { hex: vB1, repr: 'u1' } },
+      ]);
+      assert.deepEqual(body.cursor, {
+        next: null,
+        previous: null,
+        current: `${vA1}:${collectionA}`,
+      });
+    });
+
+    test('paginates with cursors across pages', async () => {
+      await db.update(buildNftBlock());
+
+      // Page 1.
+      const page1 = await getNftBalances(nftAddr, { limit: '1' });
+      assert.equal(page1.total, 3);
+      assert.deepEqual(page1.results, [
+        { asset_identifier: collectionA, value: { hex: vA1, repr: 'u1' } },
+      ]);
+      assert.deepEqual(page1.cursor, {
+        next: `${vA2}:${collectionA}`,
+        previous: null,
+        current: `${vA1}:${collectionA}`,
+      });
+
+      // Page 2.
+      const page2 = await getNftBalances(nftAddr, { limit: '1', cursor: page1.cursor.next });
+      assert.deepEqual(page2.results, [
+        { asset_identifier: collectionA, value: { hex: vA2, repr: 'u2' } },
+      ]);
+      assert.deepEqual(page2.cursor, {
+        next: `${vB1}:${collectionB}`,
+        previous: `${vA1}:${collectionA}`,
+        current: `${vA2}:${collectionA}`,
+      });
+
+      // Page 3 (last).
+      const page3 = await getNftBalances(nftAddr, { limit: '1', cursor: page2.cursor.next });
+      assert.deepEqual(page3.results, [
+        { asset_identifier: collectionB, value: { hex: vB1, repr: 'u1' } },
+      ]);
+      assert.deepEqual(page3.cursor, {
+        next: null,
+        previous: `${vA2}:${collectionA}`,
+        current: `${vB1}:${collectionB}`,
       });
     });
   });


### PR DESCRIPTION
## Summary

This branch introduces a materialized current-state table for **locked STX** (modeled on `ft_balances`) and three new v3 principal **balance endpoints**, all backed by materialized tables so balances are single-row / index-served lookups rather than multi-version event scans.

### Locked STX (`stx_locked_balances`)
- New `stx_locked_balances` table: one row per principal holding the current lock state (amount, unlock burn height, pox version, lock provenance), so a principal's locked STX is a single-row lookup.
- Maintained on write from pox-5 `stake` / `stake-update` / `unstake` events and inherited pox-1..4 `stx_lock` events; backfilled in the migration from existing canonical lock events.
- Reorg-safe: affected principals are recomputed from their latest canonical lock-changing event (locked STX is a set/latest-wins value, so it can't be delta-applied like `ft_balances`).
- **Read-path switch:** `getStxBalance` (current tip) and the v2 `/addresses/:principal/balances/stx` endpoint now read locked STX from this table — which also surfaces **pox-5** locks in balance responses for the first time. Historical (`until_block`) reads keep the per-version event scan.

### New v3 endpoints
- `GET /extended/v3/principals/:principal/balances/stx` — total + spendable (`available`) balance, a nested `locked` object, and projected `mempool` balance (mempool-aware ETag cache).
- `GET /extended/v3/principals/:principal/balances/ft` — fungible-token positions, sorted by balance descending, cursor-paginated.
- `GET /extended/v3/principals/:principal/balances/nft` — owned NFT instances, cursor-paginated by `(asset_identifier, value)`.

### Supporting indexes
- `ft_balances (address, balance DESC, token)` and `nft_custody (recipient, asset_identifier, value)` so the keyset-paginated scans are served directly from an index.

## Testing
- New `tests/api/pox5/stx-lock.test.ts`: stake/unstake materialization, pox-4 `stx_lock` inheritance, reorg recompute, and balance read-path coverage.
- Extended `tests/api/v3/principals.test.ts`: the stx/ft/nft balance endpoints incl. cursor pagination and ETag behavior.
