### PR TITLE
fix: make bond early_unlock_admin nullable

### DIFF
--- a/migrations/1779487960678_bonds.ts
+++ b/migrations/1779487960678_bonds.ts
@@ -86,7 +86,6 @@ export const up = (pgm: MigrationBuilder) => {
     },
     early_unlock_admin: {
       type: 'text',
-      notNull: true,
     },
     first_reward_cycle: {
       type: 'integer',

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -1655,7 +1655,6 @@ export interface DbBondInsertValues extends DbTxLocation {
   unlock_cycle: number;
   unlock_burn_height: number;
   early_unlock_bytes: string;
-  early_unlock_admin: string;
 }
 
 /** How the BTC backing a bond registration was locked. */

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -617,7 +617,6 @@ export class PgWriteStore extends PgStore {
       stx_value_ratio: parseInt(event.data.stx_value_ratio),
       min_ustx_ratio: parseInt(event.data.min_ustx_ratio),
       early_unlock_bytes: event.data.early_unlock_bytes,
-      early_unlock_admin: '', // TODO: Make nullable
       first_reward_cycle: parseInt(event.data.first_reward_cycle),
       bond_start_height: parseInt(event.data.bond_start_height),
       unlock_cycle: parseInt(event.data.unlock_cycle),

--- a/src/datastore/v3/types.ts
+++ b/src/datastore/v3/types.ts
@@ -156,7 +156,7 @@ export interface DbBondSummary {
 
 export interface DbBond extends DbBondSummary, DbTxLocation {
   early_unlock_bytes: string;
-  early_unlock_admin: string;
+  early_unlock_admin: string | null;
 }
 
 export interface DbBondAllowlistEntry {

--- a/tests/api/pox5/bonds.test.ts
+++ b/tests/api/pox5/bonds.test.ts
@@ -52,7 +52,6 @@ const SETUP_BOND_DATA = {
   stx_value_ratio: String(STX_VALUE_RATIO),
   min_ustx_ratio: String(MIN_USTX_RATIO),
   early_unlock_bytes: '',
-  early_unlock_admin: ADMIN,
   first_reward_cycle: String(FIRST_REWARD_CYCLE),
   bond_start_height: String(BOND_START_HEIGHT),
   unlock_cycle: String(UNLOCK_CYCLE),


### PR DESCRIPTION
## Description

The `setup-bond` pox-5 event no longer carries an `early_unlock_admin` field, but the `bonds` table still defined the `early_unlock_admin` column as `NOT NULL`, forcing ingestion to write an empty-string placeholder. This makes the column nullable so bond creation can simply skip it.

1. **Motivation for change:** keep the schema in sync with the updated `setup-bond` event and stop persisting a meaningless placeholder value.
2. **What was changed:**
   - `bonds` migration: `early_unlock_admin` is now nullable (dropped `NOT NULL`).
   - Ingestion (`updateBond`): no longer sets `early_unlock_admin` (removed the `''` placeholder + its `TODO`); the column defaults to `NULL`.
   - `DbBondInsertValues`: dropped the `early_unlock_admin` field (no longer written).
   - `DbBond`: `early_unlock_admin` read type is now `string | null`.
3. **How does this impact application developers:** no API-visible change — `early_unlock_admin` is not exposed in any response/serializer; it remains an internal column (now nullable).
4. **Link to relevant issues and documentation:** follow-up to the pox-5 `setup-bond` event change (#2579).

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No. Targets the unreleased `pox5` line; the column is internal and not serialized in any API response.

## Are documentation updates required?
- [ ] Link to documentation updates:

## Testing information

1. Testing is covered by the existing simulated `tests/api/pox5/bonds.test.ts` suite — the `SETUP_BOND_DATA` fixture no longer includes `early_unlock_admin`, matching the new event shape.
2. Not a reproduction-style bug.
3. Affected code paths: pox-5 `setup-bond` ingestion (`pg-write-store` → `updateBond`), `bonds` migration, and the bond DB types.
4. No other affected projects.
5. Watch out for: nothing reads `early_unlock_admin` on the read path; `BOND_COLUMNS` still selects it (now returns `null`). Verified with `npm run test:api:pox5` (bonds suite: 17/17 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
