### PR TITLE
feat: add env to toggle faucet rate limits

### DIFF
--- a/src/api/routes/v1/faucets.ts
+++ b/src/api/routes/v1/faucets.ts
@@ -26,7 +26,7 @@ import {
 import { DbFaucetRequestCurrency } from '../../../datastore/common.js';
 import { getChainIDNetwork, getStxFaucetNetwork, stxToMicroStx } from '../../../helpers.js';
 import { StacksCoreRpcClient } from '../../../core-rpc/client.js';
-import { isProdEnv, logger } from '@stacks/api-toolkit';
+import { logger } from '@stacks/api-toolkit';
 import { ENV } from '../../../env.js';
 import { FastifyPluginAsync, preHandlerHookHandler } from 'fastify';
 import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
@@ -476,7 +476,7 @@ export const FaucetRoutes: FastifyPluginAsync<
         const isStackingReq = req.query.stacking ?? false;
         const now = Date.now();
 
-        if (isProdEnv && ENV.TESTNET_FAUCETS_RATE_LIMIT_ENABLED) {
+        if (ENV.TESTNET_FAUCETS_RATE_LIMIT_ENABLED) {
           const lastRequests = await fastify.db.getSTXFaucetRequests(recipientAddress);
           const [window, triggerCount] = isStackingReq
             ? [FAUCET_STACKING_WINDOW, FAUCET_STACKING_TRIGGER_COUNT]
@@ -664,7 +664,7 @@ export const FaucetRoutes: FastifyPluginAsync<
           req.ip;
         const now = Date.now();
 
-        if (isProdEnv && ENV.TESTNET_FAUCETS_RATE_LIMIT_ENABLED) {
+        if (ENV.TESTNET_FAUCETS_RATE_LIMIT_ENABLED) {
           const lastRequests = await fastify.db.getSBTCFaucetRequests(recipientAddress);
           const requestsInWindow = lastRequests.results
             .map(r => now - r.occurred_at)

--- a/src/api/routes/v1/faucets.ts
+++ b/src/api/routes/v1/faucets.ts
@@ -242,22 +242,24 @@ export const FaucetRoutes: FastifyPluginAsync<
         const ip =
           (Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor?.split(',')[0])?.trim() ??
           req.ip;
+        const now = Date.now();
 
         // Guard condition: requests are limited to 5 times per 5 minutes.
         // Only based on address for now, but we're keeping the IP in case
         // we want to escalate and implement a per IP policy
-        const lastRequests = await fastify.db.getBTCFaucetRequests(address);
-        const now = Date.now();
-        const window = 5 * 60 * 1000; // 5 minutes
-        const requestsInWindow = lastRequests.results
-          .map(r => now - r.occurred_at)
-          .filter(r => r <= window);
-        if (requestsInWindow.length >= 5) {
-          logger.warn(`BTC faucet rate limit hit for address ${address}`);
-          return await reply.status(429).send({
-            error: 'Too many requests',
-            success: false,
-          });
+        if (ENV.TESTNET_FAUCETS_RATE_LIMIT_ENABLED) {
+          const lastRequests = await fastify.db.getBTCFaucetRequests(address);
+          const window = 5 * 60 * 1000; // 5 minutes
+          const requestsInWindow = lastRequests.results
+            .map(r => now - r.occurred_at)
+            .filter(r => r <= window);
+          if (requestsInWindow.length >= 5) {
+            logger.warn(`BTC faucet rate limit hit for address ${address}`);
+            return await reply.status(429).send({
+              error: 'Too many requests',
+              success: false,
+            });
+          }
         }
 
         const tx = await makeBtcFaucetPayment(btc.networks.regtest, address, btcAmount);
@@ -474,7 +476,7 @@ export const FaucetRoutes: FastifyPluginAsync<
         const isStackingReq = req.query.stacking ?? false;
         const now = Date.now();
 
-        if (isProdEnv) {
+        if (isProdEnv && ENV.TESTNET_FAUCETS_RATE_LIMIT_ENABLED) {
           const lastRequests = await fastify.db.getSTXFaucetRequests(recipientAddress);
           const [window, triggerCount] = isStackingReq
             ? [FAUCET_STACKING_WINDOW, FAUCET_STACKING_TRIGGER_COUNT]
@@ -662,7 +664,7 @@ export const FaucetRoutes: FastifyPluginAsync<
           req.ip;
         const now = Date.now();
 
-        if (isProdEnv) {
+        if (isProdEnv && ENV.TESTNET_FAUCETS_RATE_LIMIT_ENABLED) {
           const lastRequests = await fastify.db.getSBTCFaucetRequests(recipientAddress);
           const requestsInWindow = lastRequests.results
             .map(r => now - r.occurred_at)

--- a/src/env.ts
+++ b/src/env.ts
@@ -206,6 +206,11 @@ const schema = Type.Object({
   BTC_FAUCET_PK: Type.String({
     default: '29c028009a8331358adcc61bb6397377c995d327ac0343ed8e8f1d4d3ef85c27',
   }),
+  /**
+   * Enable faucet request rate limiting for all faucets (STX, BTC, sBTC). Set to `false` to disable
+   * rate limits in special testnet environments.
+   */
+  TESTNET_FAUCETS_RATE_LIMIT_ENABLED: Type.Boolean({ default: true }),
   /** Enable the BTC regtest faucet endpoints on Stacks testnet. */
   TESTNET_BTC_FAUCET_ENABLED: Type.Boolean({ default: true }),
   /** Enable the STX faucet endpoints on Stacks testnet. */


### PR DESCRIPTION
### Summary

Adds a `TESTNET_FAUCETS_RATE_LIMIT_ENABLED` environment variable (default `true`) so faucet rate limits can be toggled off in special testnet environments. The check is applied uniformly to all three faucets (STX, BTC, sBTC).

### Changes

- **`src/env.ts`** — new boolean env var `TESTNET_FAUCETS_RATE_LIMIT_ENABLED`, defaulting to `true`. It piggybacks on the existing `coerceBooleanEnvVars` helper, so it accepts `true`/`false` as well as legacy `1`/`0`.
- **`src/api/routes/v1/faucets.ts`**
  - All three faucets (STX, BTC, sBTC) now gate their rate-limit guard solely on `if (ENV.TESTNET_FAUCETS_RATE_LIMIT_ENABLED)`.
  - Dropped the previous `isProdEnv` condition from the STX and sBTC faucets. Previously those only rate-limited in production while BTC rate-limited in every environment — an inconsistency. Now all three behave identically. Removed the now-unused `isProdEnv` import.

### Behavior

- Default (`true`, unset): all faucets are rate-limited in every environment, including testnet.
- `TESTNET_FAUCETS_RATE_LIMIT_ENABLED=false`: rate limiting is disabled for all faucets.

### Notes for reviewers

- This changes existing behavior for STX/sBTC in non-production environments: they were previously **not** rate-limited outside prod (due to the `isProdEnv` gate), and now are by default. Set `TESTNET_FAUCETS_RATE_LIMIT_ENABLED=false` to restore the unlimited behavior in those environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
