### PR TITLE
fix: keep unstaked pox-5 STX locked until the cycle-end unlock height

### DIFF
--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -1207,8 +1207,8 @@ export class PgWriteStore extends PgStore {
    * Locked STX is a SET/latest-wins value (not additive like ft_balances), so a reorg can't be
    * handled with signed deltas — instead we re-derive each affected principal's current lock from
    * the latest applicable canonical lock-changing event across all blocks: pox-1..4
-   * `stx_lock_events` and the synthetic pox-5 `stake`/`stake-update` (lock) and `unstake` (clear)
-   * events.
+   * `stx_lock_events` and the synthetic pox-5 `stake`/`stake-update`/`unstake` events (which all set
+   * the lock with an absolute amount and `unlock_burn_height`).
    *
    * Must run AFTER the `stx_lock_events` and `pox5_events` canonical flips for this block have
    * completed (i.e. after the reorg queue drains), so the "latest canonical event" reflects the

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -128,6 +128,7 @@ import {
   Pox5EventSetupBond,
   Pox5EventStake,
   Pox5EventStakeUpdate,
+  Pox5EventUnstake,
   Pox5EventUnstakeSbtc,
   Pox5EventUpdateBondRegistration,
 } from '@stacks/codec';
@@ -599,10 +600,8 @@ export class PgWriteStore extends PgStore {
             break;
           case Pox5EventName.Stake:
           case Pox5EventName.StakeUpdate:
-            await this.upsertStxLockedBalance(sql, txLocation, poxEvent);
-            break;
           case Pox5EventName.Unstake:
-            await this.clearStxLockedBalance(sql, poxEvent.data.staker);
+            await this.upsertStxLockedBalance(sql, txLocation, poxEvent);
             break;
           case Pox5EventName.RegisterSigner:
             await this.upsertStakingSigner(sql, txLocation, poxEvent);
@@ -612,7 +611,7 @@ export class PgWriteStore extends PgStore {
           case Pox5EventName.GrantSignerKey:
           case Pox5EventName.RevokeSignerGrant:
           case Pox5EventName.SetBondAdmin:
-            // TODO: Implement
+            // No-op
             break;
         }
       }
@@ -1080,11 +1079,6 @@ export class PgWriteStore extends PgStore {
     }
   }
 
-  /**
-   * Materialize a principal's current STX lock state (latest lock wins). Called
-   * for pox-5 `stake`/`stake-update` events, which carry the absolute locked
-   * amount and unlock height.
-   */
   /** Low-level upsert of a principal's materialized STX lock (latest lock wins). */
   private async setStxLockedBalance(
     sql: PgSqlClient,
@@ -1119,10 +1113,17 @@ export class PgWriteStore extends PgStore {
     `;
   }
 
+  /**
+   * Materialize a principal's current STX lock state (latest lock wins). Called for pox-5 `stake` /
+   * `stake-update` / `unstake` events, which all carry the absolute locked amount and the
+   * `unlock_burn_height`. `unstake` is included deliberately: it doesn't unlock instantly — it sets
+   * the lock's unlock height to the end of the current cycle, and the materialized lock stays
+   * locked until that burn height is reached (zeroed out on read by lock expiry).
+   */
   private async upsertStxLockedBalance(
     sql: PgSqlClient,
     txLocation: DbTxLocation,
-    event: Pox5EventStake | Pox5EventStakeUpdate
+    event: Pox5EventStake | Pox5EventStakeUpdate | Pox5EventUnstake
   ) {
     await this.setStxLockedBalance(sql, {
       principal: event.data.staker,
@@ -1133,11 +1134,6 @@ export class PgWriteStore extends PgStore {
       lockBlockHeight: txLocation.block_height,
       burnchainLockHeight: txLocation.burn_block_height,
     });
-  }
-
-  /** Clear a principal's materialized STX lock (e.g. on pox-5 `unstake`). */
-  private async clearStxLockedBalance(sql: PgSqlClient, principal: string) {
-    await sql`DELETE FROM stx_locked_balances WHERE principal = ${principal}`;
   }
 
   /**
@@ -1205,20 +1201,19 @@ export class PgWriteStore extends PgStore {
   }
 
   /**
-   * Recompute the materialized `stx_locked_balances` rows for every principal
-   * touched by a block whose canonical flag just flipped during a reorg.
+   * Recompute the materialized `stx_locked_balances` rows for every principal touched by a block
+   * whose canonical flag just flipped during a reorg.
    *
-   * Locked STX is a SET/latest-wins value (not additive like ft_balances), so a
-   * reorg can't be handled with signed deltas — instead we re-derive each
-   * affected principal's current lock from the latest applicable canonical
-   * lock-changing event across all blocks: pox-1..4 `stx_lock_events` and the
-   * synthetic pox-5 `stake`/`stake-update` (lock) and `unstake` (clear) events.
+   * Locked STX is a SET/latest-wins value (not additive like ft_balances), so a reorg can't be
+   * handled with signed deltas — instead we re-derive each affected principal's current lock from
+   * the latest applicable canonical lock-changing event across all blocks: pox-1..4
+   * `stx_lock_events` and the synthetic pox-5 `stake`/`stake-update` (lock) and `unstake` (clear)
+   * events.
    *
-   * Must run AFTER the `stx_lock_events` and `pox5_events` canonical flips for
-   * this block have completed (i.e. after the reorg queue drains), so the
-   * "latest canonical event" reflects the post-flip state. Because the recompute
-   * reads global canonical state, the last-flipped block touching a principal
-   * always produces that principal's final, correct value.
+   * Must run AFTER the `stx_lock_events` and `pox5_events` canonical flips for this block have
+   * completed (i.e. after the reorg queue drains), so the "latest canonical event" reflects the
+   * post-flip state. Because the recompute reads global canonical state, the last-flipped block
+   * touching a principal always produces that principal's final, correct value.
    */
   private async recomputeStxLockedBalances(sql: PgSqlClient, indexBlockHash: string) {
     // Principals whose lock state may have changed in this block.
@@ -1236,10 +1231,9 @@ export class PgWriteStore extends PgStore {
     if (principals.length === 0) {
       return;
     }
-    // Process affected principals in chunks (same approach as other batched
-    // write paths). For each chunk: drop their current materialized rows, then
-    // re-insert the correct rows (if any) derived from the latest canonical
-    // lock-changing event.
+    // Process affected principals in chunks (same approach as other batched write paths). For each
+    // chunk: drop their current materialized rows, then re-insert the correct rows (if any) derived
+    // from the latest canonical lock-changing event.
     for (const batch of batchIterate(principals, INSERT_BATCH_SIZE)) {
       await sql`
         DELETE FROM stx_locked_balances
@@ -1276,7 +1270,10 @@ export class PgWriteStore extends PgStore {
               AND e.contract_name <> 'pox-5'
               AND e.locked_address IN ${sql(batch)}
             UNION ALL
-            -- pox-5 stake / stake-update (sets the lock)
+            -- pox-5 stake / stake-update / unstake all set the lock with an
+            -- absolute amount + unlock_burn_height. unstake moves the unlock
+            -- height to the end of the current cycle (it does NOT clear the
+            -- lock); the lock then expires on read once that height is reached.
             SELECT
               p.data->>'staker' AS principal,
               p.block_height, p.microblock_sequence, p.tx_index, p.event_index,
@@ -1289,23 +1286,7 @@ export class PgWriteStore extends PgStore {
               p.burn_block_height AS burnchain_lock_height
             FROM pox5_events p
             WHERE p.canonical = true AND p.microblock_canonical = true
-              AND p.name IN ('stake', 'stake-update')
-              AND p.data->>'staker' IN ${sql(batch)}
-            UNION ALL
-            -- pox-5 unstake (clears the lock)
-            SELECT
-              p.data->>'staker' AS principal,
-              p.block_height, p.microblock_sequence, p.tx_index, p.event_index,
-              false AS is_set,
-              0::numeric AS locked_amount,
-              0::bigint AS unlock_burn_height,
-              5 AS pox_version,
-              p.tx_id AS lock_tx_id,
-              p.block_height AS lock_block_height,
-              p.burn_block_height AS burnchain_lock_height
-            FROM pox5_events p
-            WHERE p.canonical = true AND p.microblock_canonical = true
-              AND p.name = 'unstake'
+              AND p.name IN ('stake', 'stake-update', 'unstake')
               AND p.data->>'staker' IN ${sql(batch)}
           ) candidates
           ORDER BY principal,

--- a/tests/api/pox5/stx-lock.test.ts
+++ b/tests/api/pox5/stx-lock.test.ts
@@ -59,13 +59,17 @@ describe('pox-5 stake locked balances', () => {
     amount_increase: (UPDATED_AMOUNT - STAKE_AMOUNT).toString(),
     cycles_to_extend: '1',
   };
+  // Unstaking moves the unlock to the end of the current cycle — an earlier
+  // height than the (extended) stake unlock, but still in the future. The STX
+  // stays locked until then; it does NOT unlock immediately.
+  const UNSTAKE_UNLOCK = 450;
   const unstakeData = {
     staker: ALICE,
     signer: SIGNER,
     amount_ustx: STAKE_AMOUNT.toString(),
     first_reward_cycle: String(FIRST_REWARD_CYCLE),
     unlock_cycle: String(UNLOCK_CYCLE),
-    unlock_burn_height: String(STAKE_UNLOCK),
+    unlock_burn_height: String(UNSTAKE_UNLOCK),
   };
 
   beforeEach(async () => {
@@ -114,7 +118,7 @@ describe('pox-5 stake locked balances', () => {
     assert.equal(BigInt(row.unlock_burn_height), BigInt(UPDATED_UNLOCK));
   });
 
-  test('unstake clears the locked balance', async () => {
+  test('unstake defers the unlock to the end of the cycle (keeps the lock until then)', async () => {
     await db.update(
       new TestBlockBuilder({
         block_height: 2,
@@ -127,7 +131,13 @@ describe('pox-5 stake locked balances', () => {
         .addTxPox5Event({ name: Pox5EventName.Unstake, data: unstakeData })
         .build()
     );
-    assert.equal(await lockedRow(ALICE), undefined, 'locked balance row removed');
+    // The lock is NOT removed — it persists with the unstake's (end-of-cycle)
+    // unlock height. The STX stays locked until that burn height; lock expiry
+    // is applied on read, not by deleting the row here.
+    const row = await lockedRow(ALICE);
+    assert.ok(row, 'locked balance row still present after unstake');
+    assert.equal(BigInt(row.locked_amount), STAKE_AMOUNT);
+    assert.equal(BigInt(row.unlock_burn_height), BigInt(UNSTAKE_UNLOCK));
   });
 });
 
@@ -206,6 +216,86 @@ describe('pox-5 locked STX in balance read path', () => {
     assert.equal(balance.locked, 0n);
     assert.equal(balance.lockTxId, '');
     assert.equal(balance.burnchainUnlockHeight, 0);
+  });
+
+  function unstakeData(amount: bigint, unlock: number) {
+    return {
+      staker: ALICE,
+      signer: SIGNER,
+      amount_ustx: amount.toString(),
+      first_reward_cycle: '8',
+      unlock_cycle: '20',
+      unlock_burn_height: String(unlock),
+    };
+  }
+
+  test('unstaking does NOT immediately unlock — STX stays locked until the cycle-end unlock height', async () => {
+    // Block 1: stake (unlock far out, e.g. extended). Block 2: unstake, which
+    // moves the unlock to the end of the current cycle — still in the future
+    // relative to the burn tip (TIP_BURN_HEIGHT = 100).
+    const STILL_LOCKED_UNLOCK = 300;
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        block_hash: '0x01',
+        index_block_hash: '0x01',
+        burn_block_height: TIP_BURN_HEIGHT,
+      })
+        .addTx({ tx_id: '0x' + 'a1'.repeat(32) })
+        .addTxPox5Event({ name: Pox5EventName.Stake, data: stakeData(STAKE_AMOUNT, ACTIVE_UNLOCK) })
+        .build()
+    );
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        block_hash: '0x02',
+        index_block_hash: '0x02',
+        parent_block_hash: '0x01',
+        parent_index_block_hash: '0x01',
+        burn_block_height: TIP_BURN_HEIGHT,
+      })
+        .addTx({ tx_id: '0x' + 'a2'.repeat(32) })
+        .addTxPox5Event({
+          name: Pox5EventName.Unstake,
+          data: unstakeData(STAKE_AMOUNT, STILL_LOCKED_UNLOCK),
+        })
+        .build()
+    );
+    // The reported bug: after unstake the STX showed as unlocked immediately.
+    // It must stay locked until the (end-of-cycle) unlock height.
+    const balance = await db.getStxBalance({ stxAddress: ALICE, includeUnanchored: false });
+    assert.equal(balance.locked, STAKE_AMOUNT, 'STX still locked right after unstake');
+    assert.equal(balance.burnchainUnlockHeight, STILL_LOCKED_UNLOCK, 'unlock deferred to cycle end');
+  });
+
+  test('after the cycle-end unlock height passes, an unstaked position reports zero locked STX', async () => {
+    // Unstake with an unlock height already below the burn tip → unlocked.
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 1,
+        block_hash: '0x01',
+        index_block_hash: '0x01',
+        burn_block_height: TIP_BURN_HEIGHT,
+      })
+        .addTx({ tx_id: '0x' + 'a1'.repeat(32) })
+        .addTxPox5Event({ name: Pox5EventName.Stake, data: stakeData(STAKE_AMOUNT, ACTIVE_UNLOCK) })
+        .build()
+    );
+    await db.update(
+      new TestBlockBuilder({
+        block_height: 2,
+        block_hash: '0x02',
+        index_block_hash: '0x02',
+        parent_block_hash: '0x01',
+        parent_index_block_hash: '0x01',
+        burn_block_height: TIP_BURN_HEIGHT,
+      })
+        .addTx({ tx_id: '0x' + 'a2'.repeat(32) })
+        .addTxPox5Event({ name: Pox5EventName.Unstake, data: unstakeData(STAKE_AMOUNT, EXPIRED_UNLOCK) })
+        .build()
+    );
+    const balance = await db.getStxBalance({ stxAddress: ALICE, includeUnanchored: false });
+    assert.equal(balance.locked, 0n, 'unlocked once the cycle-end height has passed');
   });
 
   test('the v3 /balances/stx endpoint reports the active pox-5 lock', async () => {


### PR DESCRIPTION
## Description

As a Stacks API consumer tracking a staker's balance, I expect STX that was unstaked from pox-5 to remain locked until the end of the current reward cycle — not to show as unlocked the instant the unstake transaction is mined.

**Bug report:** "I staked STX, extended for 3 cycles, earned for 1 cycle, then unstaked for stx-only and immediately my STX is unlocked. My understanding is that it will unlock at the end of the cycle."

**Root cause.** On a pox-5 `unstake` event, ingestion called `clearStxLockedBalance`, which immediately `DELETE`d the principal's row from the materialized `stx_locked_balances` table. So the balance endpoints reported the STX as unlocked as soon as the unstake landed. But the `unstake` event carries an `unlock_burn_height` (the end of the current reward cycle), and pox keeps the STX locked until that burn height.

**Fix.** `unstake` is now treated like `stake` / `stake-update`: it carries the absolute `amount_ustx` + `unlock_burn_height`, so it *sets* the lock rather than clearing it. The materialized lock persists with the cycle-end `unlock_burn_height`, and `resolveMaterializedStxLock` zeroes out `locked` on read once the burn tip reaches that height (the same deferred-unlock-by-height model already used for natural lock expiry — no event fires at expiry). The reorg recompute now also treats `unstake` as a set-the-lock event (merged into the stake/stake-update branch); the genuine "orphaned stake with no remaining canonical lock" case is still handled by the recompute's delete-then-reinsert. The now-unused `clearStxLockedBalance` helper was removed.

### Affected endpoints

The locked-STX figure (current-tip reads, sourced from `stx_locked_balances`) is now correct for the window between the unstake tx and the cycle-end unlock height on:

- `GET /extended/v1/address/:principal/stx`, `GET /extended/v1/address/:principal/balances`, `GET /extended/v1/search/:id` (balance metadata), and WebSocket address STX-balance updates
- `GET /extended/v2/addresses/:principal/balances/stx`
- `GET /extended/v3/principals/:principal/balances/stx` (`locked`) and `GET /extended/v3/principals/:principal/staking` (`stx.locked`)

Spendable balances are unchanged. Historical (`until_block`) reads use the per-version event scan and are not affected by this change.

## Type of Change
- [x] Bug fix

## Does this introduce a breaking change?
No. Behavior is corrected for in-cycle unstaked positions; response shapes are unchanged.

## Are documentation updates required?
- [ ] No (no schema/endpoint shape changes).

## Testing information

`npm run test:api:pox5` passes (48 tests). New/updated cases in `tests/api/pox5/stx-lock.test.ts`:
- `unstake defers the unlock to the end of the cycle (keeps the lock until then)` — the materialized row persists with the unstake's amount + unlock height (was previously asserted as deleted).
- `unstaking does NOT immediately unlock — STX stays locked until the cycle-end unlock height` — reproduces the report via `getStxBalance`: after unstake with a still-future unlock height, `locked` == staked amount and `burnchainUnlockHeight` == cycle-end.
- `after the cycle-end unlock height passes, an unstaked position reports zero locked STX`.

Regression-checked the shared lock/balance read path: `test:api:datastore` (48 pass) and `test:api:principal` (17 pass) are green.

Affected code paths: pox-5 `unstake` ingestion and `markEntitiesCanonical` reorg recompute in `src/datastore/pg-write-store.ts`.
