### PR TITLE
feat: deprecate v1/v2 endpoints superseded by v3 and hide them from the OpenAPI spec

### DIFF
--- a/src/api/deprecation-plugin.ts
+++ b/src/api/deprecation-plugin.ts
@@ -7,10 +7,32 @@ declare module 'fastify' {
   }
 }
 
-const pluginCb: FastifyPluginAsync<{ defaultDeprecatedMessage: string }> = async (
-  fastify,
-  options
-) => {
+const pluginCb: FastifyPluginAsync<{
+  defaultDeprecatedMessage: string;
+  /**
+   * When `false`, every route whose schema is marked `deprecated` is disabled and responds with
+   * `410 Gone`. Defaults to enabled when omitted.
+   */
+  enableDeprecatedEndpoints?: boolean;
+}> = async (fastify, options) => {
+  // When deprecated endpoints are disabled (e.g. past a sunset date), short-circuit any route
+  // whose schema is marked `deprecated` with a `410 Gone` before its handler (and any DB work)
+  // runs. `onRequest` is the earliest hook with `routeOptions` populated.
+  if (options.enableDeprecatedEndpoints === false) {
+    fastify.addHook('onRequest', async (request, reply) => {
+      if (request.routeOptions.schema?.deprecated) {
+        const message =
+          request.routeOptions.schema.deprecatedMessage ??
+          options.defaultDeprecatedMessage ??
+          'Endpoint is deprecated';
+        return reply.code(410).send({
+          error: 'Gone',
+          message: `This endpoint has been disabled. ${message}`,
+        });
+      }
+    });
+  }
+
   fastify.addHook('onSend', async (request, reply) => {
     if (request.routeOptions.schema?.deprecated) {
       const warningMessage =
@@ -27,12 +49,15 @@ const pluginCb: FastifyPluginAsync<{ defaultDeprecatedMessage: string }> = async
 };
 
 /**
- * Fastify plugin that adds deprecation warnings to HTTP responses.
+ * Fastify plugin that handles deprecated API endpoints.
  *
  * If a route's schema has `deprecated: true`, a `Warning` header will be added to the response.
  * - If the schema includes a `deprecatedMessage`, it will be used in the warning.
  * - If not, the plugin uses the `defaultDeprecatedMessage` provided in the plugin options.
  * - If neither is available, a generic warning message `299 - "Deprecated"` is used.
+ *
+ * If `enableDeprecatedEndpoints` is `false`, all deprecated routes are disabled and respond with
+ * `410 Gone` instead of executing. This is the master kill-switch flipped at a sunset date.
  */
 const DeprecationPlugin = fp(pluginCb);
 

--- a/src/api/deprecation-plugin.ts
+++ b/src/api/deprecation-plugin.ts
@@ -54,7 +54,7 @@ const pluginCb: FastifyPluginAsync<{
  * If a route's schema has `deprecated: true`, a `Warning` header will be added to the response.
  * - If the schema includes a `deprecatedMessage`, it will be used in the warning.
  * - If not, the plugin uses the `defaultDeprecatedMessage` provided in the plugin options.
- * - If neither is available, a generic warning message `299 - "Deprecated"` is used.
+ * - If neither is available, a generic warning message like `299 - "Deprecated: Endpoint is deprecated"` is used.
  *
  * If `enableDeprecatedEndpoints` is `false`, all deprecated routes are disabled and respond with
  * `410 Gone` instead of executing. This is the master kill-switch flipped at a sunset date.

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -179,9 +179,11 @@ export async function startApiServer(opts: {
   // Setup direct proxy to core-node RPC endpoints (/v2)
   await fastify.register(CoreNodeRpcProxyRouter, { prefix: '/v2' });
 
-  // Middleware to annotate http responses with deprecation warnings
+  // Middleware to annotate http responses with deprecation warnings, and to disable deprecated
+  // endpoints entirely (410 Gone) once `ENABLE_DEPRECATED_ENDPOINTS` is flipped off at sunset.
   await fastify.register(DeprecationPlugin, {
     defaultDeprecatedMessage: 'See https://docs.hiro.so/stacks/api for more information',
+    enableDeprecatedEndpoints: ENV.ENABLE_DEPRECATED_ENDPOINTS,
   });
 
   const serverSockets = new Set<Socket>();

--- a/src/api/routes/v1/address.ts
+++ b/src/api/routes/v1/address.ts
@@ -102,7 +102,7 @@ export const AddressRoutes: FastifyPluginAsync<
         operationId: 'get_account_stx_balance',
         summary: 'Get account STX balance',
         description:
-          'Retrieves STX token balance for a given Address or Contract Identifier. **This endpoint is deprecated in favor of `get_principal_stx_balance`.**',
+          'Retrieves STX token balance for a given Address or Contract Identifier. **Deprecated:** use `GET /extended/v3/principals/{principal}/balances/stx` instead.',
         tags: ['Accounts'],
         params: Type.Object({
           principal: PrincipalSchema,
@@ -279,7 +279,7 @@ export const AddressRoutes: FastifyPluginAsync<
         operationId: 'get_account_transactions',
         summary: 'Get account transactions',
         description:
-          'Retrieves a list of all Transactions for a given Address or Contract Identifier. **This endpoint is deprecated in favor of `get_address_transactions`.**',
+          'Retrieves a list of all Transactions for a given Address or Contract Identifier. **Deprecated:** use `GET /extended/v3/principals/{principal}/transactions` instead.',
         tags: ['Accounts'],
         params: Type.Object({
           principal: PrincipalSchema,
@@ -352,7 +352,7 @@ export const AddressRoutes: FastifyPluginAsync<
         operationId: 'get_single_transaction_with_transfers',
         summary: 'Get account transaction information for specific transaction',
         description:
-          'Retrieves transaction details for a given Transaction Id, for a given account or contract Identifier. **This endpoint is deprecated in favor of `get_address_transaction_events`.**',
+          'Retrieves transaction details for a given Transaction Id, for a given account or contract Identifier. **Deprecated:** use `GET /extended/v3/principals/{principal}/transactions/{tx_id}/balance-changes` instead.',
         tags: ['Accounts'],
         params: Type.Object({
           principal: PrincipalSchema,
@@ -418,7 +418,7 @@ export const AddressRoutes: FastifyPluginAsync<
         operationId: 'get_account_transactions_with_transfers',
         summary: 'Get account transactions including STX transfers for each transaction.',
         description:
-          'Retrieve all transactions for an account or contract identifier including STX transfers for each transaction. **This endpoint is deprecated in favor of `get_address_transactions`.**',
+          'Retrieve all transactions for an account or contract identifier including STX transfers for each transaction. **Deprecated:** use `GET /extended/v3/principals/{principal}/transactions` instead.',
         tags: ['Accounts'],
         params: Type.Object({
           principal: PrincipalSchema,

--- a/src/api/routes/v1/tx.ts
+++ b/src/api/routes/v1/tx.ts
@@ -69,7 +69,7 @@ export const TxRoutes: FastifyPluginAsync<
         operationId: 'get_transaction_list',
         deprecated: true,
         summary: 'Get recent transactions',
-        description: `Retrieves all recently mined transactions`,
+        description: `Retrieves all recently mined transactions. **Deprecated:** use \`GET /extended/v3/transactions\` instead.`,
         tags: ['Transactions'],
         querystring: Type.Object({
           offset: OffsetParam(),
@@ -251,7 +251,9 @@ export const TxRoutes: FastifyPluginAsync<
         summary: 'Get mempool transactions',
         description: `Retrieves all transactions that have been recently broadcast to the mempool. These are pending transactions awaiting confirmation.
 
-        If you need to monitor new transactions, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.`,
+        If you need to monitor new transactions, we highly recommend subscribing to [WebSockets or Socket.io](https://github.com/hirosystems/stacks-blockchain-api/tree/master/client) for real-time updates.
+
+        **Deprecated:** use \`GET /extended/v3/mempool/transactions\` instead.`,
         tags: ['Transactions'],
         querystring: Type.Object({
           sender_address: Type.Optional(AddressParamSchema),
@@ -440,7 +442,7 @@ export const TxRoutes: FastifyPluginAsync<
         operationId: 'get_transaction_by_id',
         deprecated: true,
         summary: 'Get transaction',
-        description: `Retrieves transaction details for a given transaction ID`,
+        description: `Retrieves transaction details for a given transaction ID. **Deprecated:** use \`GET /extended/v3/transactions/{tx_id}\` instead.`,
         tags: ['Transactions'],
         params: Type.Object({
           tx_id: TransactionIdParamSchema,
@@ -535,7 +537,7 @@ export const TxRoutes: FastifyPluginAsync<
         operationId: 'get_transactions_by_block_hash',
         summary: 'Transactions by block hash',
         description:
-          'Retrieves a list of all transactions within a block for a given block hash. **This endpoint is deprecated in favor of `get_transactions_by_block`.**',
+          'Retrieves a list of all transactions within a block for a given block hash. **Deprecated:** use `GET /extended/v3/blocks/{height_or_hash}/transactions` instead.',
         tags: ['Transactions'],
         params: Type.Object({
           block_hash: Type.String(),
@@ -582,7 +584,7 @@ export const TxRoutes: FastifyPluginAsync<
         operationId: 'get_transactions_by_block_height',
         summary: 'Transactions by block height',
         description:
-          'Retrieves all transactions within a block at a given height. **This endpoint is deprecated in favor of `get_transactions_by_block`.**',
+          'Retrieves all transactions within a block at a given height. **Deprecated:** use `GET /extended/v3/blocks/{height_or_hash}/transactions` instead.',
         tags: ['Transactions'],
         params: Type.Object({
           height: BlockHeightSchema,

--- a/src/api/routes/v1/tx.ts
+++ b/src/api/routes/v1/tx.ts
@@ -67,6 +67,7 @@ export const TxRoutes: FastifyPluginAsync<
       },
       schema: {
         operationId: 'get_transaction_list',
+        deprecated: true,
         summary: 'Get recent transactions',
         description: `Retrieves all recently mined transactions`,
         tags: ['Transactions'],
@@ -246,6 +247,7 @@ export const TxRoutes: FastifyPluginAsync<
       preHandler: handleMempoolCache,
       schema: {
         operationId: 'get_mempool_transaction_list',
+        deprecated: true,
         summary: 'Get mempool transactions',
         description: `Retrieves all transactions that have been recently broadcast to the mempool. These are pending transactions awaiting confirmation.
 
@@ -436,6 +438,7 @@ export const TxRoutes: FastifyPluginAsync<
       preHandler: handleTransactionCache,
       schema: {
         operationId: 'get_transaction_by_id',
+        deprecated: true,
         summary: 'Get transaction',
         description: `Retrieves transaction details for a given transaction ID`,
         tags: ['Transactions'],

--- a/src/api/routes/v2/addresses.ts
+++ b/src/api/routes/v2/addresses.ts
@@ -47,6 +47,7 @@ export const AddressRoutesV2: FastifyPluginAsync<
       preHandler: handlePrincipalCache,
       schema: {
         operationId: 'get_address_transactions',
+        deprecated: true,
         summary: 'Get address transactions',
         description: `Retrieves a paginated list of confirmed transactions sent or received by a STX address or Smart Contract ID, alongside the total amount of STX sent or received and the number of STX, FT and NFT transfers contained within each transaction.
 
@@ -108,6 +109,7 @@ export const AddressRoutesV2: FastifyPluginAsync<
       preHandler: handleTransactionCache,
       schema: {
         operationId: 'get_address_transaction_events',
+        deprecated: true,
         summary: 'Get events for an address transaction',
         description: `Retrieves a paginated list of all STX, FT and NFT events concerning a STX address or Smart Contract ID within a specific transaction.`,
         tags: ['Transactions'],
@@ -158,6 +160,7 @@ export const AddressRoutesV2: FastifyPluginAsync<
       },
       schema: {
         operationId: 'get_principal_stx_balance',
+        deprecated: true,
         summary: 'Get principal STX balance',
         description: `Retrieves STX account balance information for a given Address or Contract Identifier.`,
         tags: ['Accounts'],
@@ -238,6 +241,7 @@ export const AddressRoutesV2: FastifyPluginAsync<
       preHandler: handlePrincipalCache,
       schema: {
         operationId: 'get_principal_ft_balances',
+        deprecated: true,
         summary: 'Get principal FT balances',
         description: `Retrieves Fungible-token account balance information for a given Address or Contract Identifier.`,
         tags: ['Accounts'],

--- a/src/api/routes/v2/addresses.ts
+++ b/src/api/routes/v2/addresses.ts
@@ -51,7 +51,9 @@ export const AddressRoutesV2: FastifyPluginAsync<
         summary: 'Get address transactions',
         description: `Retrieves a paginated list of confirmed transactions sent or received by a STX address or Smart Contract ID, alongside the total amount of STX sent or received and the number of STX, FT and NFT transfers contained within each transaction.
 
-        More information on Transaction types can be found [here](https://docs.stacks.co/transactions/how-transactions-work#types).`,
+        More information on Transaction types can be found [here](https://docs.stacks.co/transactions/how-transactions-work#types).
+
+        **Deprecated:** use \`GET /extended/v3/principals/{principal}/transactions\` instead.`,
         tags: ['Transactions'],
         params: AddressParamsSchema,
         querystring: Type.Object({
@@ -111,7 +113,7 @@ export const AddressRoutesV2: FastifyPluginAsync<
         operationId: 'get_address_transaction_events',
         deprecated: true,
         summary: 'Get events for an address transaction',
-        description: `Retrieves a paginated list of all STX, FT and NFT events concerning a STX address or Smart Contract ID within a specific transaction.`,
+        description: `Retrieves a paginated list of all STX, FT and NFT events concerning a STX address or Smart Contract ID within a specific transaction. **Deprecated:** use \`GET /extended/v3/principals/{principal}/transactions/{tx_id}/balance-changes\` instead.`,
         tags: ['Transactions'],
         params: AddressTransactionParamsSchema,
         querystring: Type.Object({
@@ -162,7 +164,7 @@ export const AddressRoutesV2: FastifyPluginAsync<
         operationId: 'get_principal_stx_balance',
         deprecated: true,
         summary: 'Get principal STX balance',
-        description: `Retrieves STX account balance information for a given Address or Contract Identifier.`,
+        description: `Retrieves STX account balance information for a given Address or Contract Identifier. **Deprecated:** use \`GET /extended/v3/principals/{principal}/balances/stx\` instead.`,
         tags: ['Accounts'],
         params: Type.Object({
           principal: PrincipalSchema,
@@ -243,7 +245,7 @@ export const AddressRoutesV2: FastifyPluginAsync<
         operationId: 'get_principal_ft_balances',
         deprecated: true,
         summary: 'Get principal FT balances',
-        description: `Retrieves Fungible-token account balance information for a given Address or Contract Identifier.`,
+        description: `Retrieves Fungible-token account balance information for a given Address or Contract Identifier. **Deprecated:** use \`GET /extended/v3/principals/{principal}/balances/ft\` instead.`,
         tags: ['Accounts'],
         params: Type.Object({
           principal: PrincipalSchema,

--- a/src/api/routes/v2/blocks.ts
+++ b/src/api/routes/v2/blocks.ts
@@ -176,7 +176,7 @@ export const BlockRoutesV2: FastifyPluginAsync<
         operationId: 'get_transactions_by_block',
         deprecated: true,
         summary: 'Get transactions by block',
-        description: `Retrieves transactions confirmed in a single block`,
+        description: `Retrieves transactions confirmed in a single block. **Deprecated:** use \`GET /extended/v3/blocks/{height_or_hash}/transactions\` instead.`,
         tags: ['Transactions'],
         params: BlockParamsSchema,
         querystring: Type.Object({

--- a/src/api/routes/v2/blocks.ts
+++ b/src/api/routes/v2/blocks.ts
@@ -174,6 +174,7 @@ export const BlockRoutesV2: FastifyPluginAsync<
       },
       schema: {
         operationId: 'get_transactions_by_block',
+        deprecated: true,
         summary: 'Get transactions by block',
         description: `Retrieves transactions confirmed in a single block`,
         tags: ['Transactions'],

--- a/src/env.ts
+++ b/src/env.ts
@@ -94,6 +94,12 @@ const schema = Type.Object({
    * the /v2 proxy to mutlicast. The file should be a newline-delimited list of URLs.
    */
   STACKS_API_EXTRA_TX_ENDPOINTS_FILE: Type.Optional(Type.String()),
+  /**
+   * Master switch for all deprecated API endpoints. Enabled by default. Set to `false` to disable
+   * every endpoint marked as deprecated at once; disabled endpoints respond with `410 Gone`.
+   * Intended to be flipped at a planned sunset date.
+   */
+  ENABLE_DEPRECATED_ENDPOINTS: Type.Boolean({ default: true }),
 
   /** Web Socket ping interval to determine client availability, in seconds */
   STACKS_API_WS_PING_INTERVAL: Type.Integer({ default: 5, minimum: 0 }),

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -18,7 +18,11 @@ async function generateOpenApiFiles() {
   fastify.addHook(
     'onRoute',
     (route: {
-      schema?: { response: Record<string | number, TSchema>; deprecated?: boolean; hide?: boolean };
+      schema?: {
+        response?: Record<string | number, TSchema>;
+        deprecated?: boolean;
+        hide?: boolean;
+      };
     }) => {
       // Exclude deprecated endpoints from the generated spec entirely
       // (`@fastify/swagger` omits any route whose schema is marked `hide`).

--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -15,10 +15,18 @@ async function generateOpenApiFiles() {
     logger: true,
   }).withTypeProvider<TypeBoxTypeProvider>();
 
-  // If a response schema is defined but lacks a '4xx' response, add it
   fastify.addHook(
     'onRoute',
-    (route: { schema?: { response: Record<string | number, TSchema> } }) => {
+    (route: {
+      schema?: { response: Record<string | number, TSchema>; deprecated?: boolean; hide?: boolean };
+    }) => {
+      // Exclude deprecated endpoints from the generated spec entirely
+      // (`@fastify/swagger` omits any route whose schema is marked `hide`).
+      if (route.schema?.deprecated) {
+        route.schema.hide = true;
+        return;
+      }
+      // If a response schema is defined but lacks a '4xx' response, add it
       if (route.schema?.response && !route.schema?.response['4xx']) {
         route.schema.response['4xx'] = ErrorResponseSchema;
       }


### PR DESCRIPTION
## What

Marks the v1/v2 endpoints that have direct v3 replacements as `deprecated`, points each one's description at its v3 successor, changes the OpenAPI generator so deprecated endpoints are omitted from the generated `openapi.yaml` (and therefore the generated client), and adds a master `ENABLE_DEPRECATED_ENDPOINTS` env switch to disable all deprecated endpoints at once at a planned sunset date.

## Why

The new `/extended/v3` surface (principal balances, transactions, balance-changes, block/mempool transactions) now fully supersedes a set of older v1/v2 endpoints. We want to steer consumers to v3, stop advertising the superseded routes in the public spec, and have a single switch to turn them off entirely when the sunset date arrives — all while keeping them working at runtime for existing clients until then.

## Changes

- **`src/openapi-generator.ts`** — extend the existing `onRoute` hook so any route whose schema is `deprecated: true` is marked `hide: true`, which `@fastify/swagger` honors by omitting it from the spec entirely.
- **Routes marked `deprecated: true`** (the "safe direct" supersessions), each with a `**Deprecated:** use \`GET /extended/v3/...\`` note repointed to the v3 successor:
  - `v1/tx.ts`: `get_transaction_list`, `get_mempool_transaction_list`, `get_transaction_by_id`, `get_transactions_by_block_hash`, `get_transactions_by_block_height`
  - `v1/address.ts`: `get_account_stx_balance`, `get_account_transactions`, `get_single_transaction_with_transfers`, `get_account_transactions_with_transfers`
  - `v2/addresses.ts`: `get_address_transactions`, `get_address_transaction_events`, `get_principal_stx_balance`, `get_principal_ft_balances`
  - `v2/blocks.ts`: `get_transactions_by_block`
- Four v1 notes previously pointed at v2 endpoints that are now themselves deprecated — repointed straight to v3.
- **`ENABLE_DEPRECATED_ENDPOINTS` env var (default `true`)** — master kill-switch for all deprecated endpoints:
  - `src/env.ts`: new boolean, defaults to `true`.
  - `src/api/deprecation-plugin.ts`: when the flag is `false`, an `onRequest` hook short-circuits any route whose schema is `deprecated` with `410 Gone` (`{ error, message }`) **before** the handler or any DB work runs. The existing `Warning`-header behavior is unchanged.
  - `src/api/init.ts`: passes `ENV.ENABLE_DEPRECATED_ENDPOINTS` into the plugin.
  - Keys off the same `schema.deprecated` flag, so any endpoint marked deprecated is automatically covered — no per-route wiring at sunset.

## Supersession map

| Old endpoint | v3 successor |
|---|---|
| `GET /extended/v1/tx` | `/extended/v3/transactions` |
| `GET /extended/v1/tx/:tx_id` | `/extended/v3/transactions/{tx_id}` |
| `GET /extended/v1/tx/mempool` | `/extended/v3/mempool/transactions` |
| `GET /extended/v1/tx/block/:block_hash` | `/extended/v3/blocks/{height_or_hash}/transactions` |
| `GET /extended/v1/tx/block_height/:height` | `/extended/v3/blocks/{height_or_hash}/transactions` |
| `GET /extended/v1/address/:principal/stx` | `/extended/v3/principals/{principal}/balances/stx` |
| `GET /extended/v1/address/:principal/transactions` | `/extended/v3/principals/{principal}/transactions` |
| `GET /extended/v1/address/:principal/:tx_id/with_transfers` | `/extended/v3/principals/{principal}/transactions/{tx_id}/balance-changes` |
| `GET /extended/v1/address/:principal/transactions_with_transfers` | `/extended/v3/principals/{principal}/transactions` |
| `GET /extended/v2/addresses/:address/transactions` | `/extended/v3/principals/{principal}/transactions` |
| `GET /extended/v2/addresses/:address/transactions/:tx_id/events` | `/extended/v3/principals/{principal}/transactions/{tx_id}/balance-changes` |
| `GET /extended/v2/addresses/:principal/balances/stx` | `/extended/v3/principals/{principal}/balances/stx` |
| `GET /extended/v2/addresses/:principal/balances/ft` | `/extended/v3/principals/{principal}/balances/ft` |
| `GET /extended/v2/blocks/:height_or_hash/transactions` | `/extended/v3/blocks/{height_or_hash}/transactions` |

## Reviewer notes

- **Hidden vs. visible-deprecated:** these routes are now omitted from `openapi.yaml`, so they also drop out of the generated TypeScript client — but they remain fully functional at runtime (until disabled via the flag below). This is a stronger choice than the usual OpenAPI convention (visible-with-strikethrough). If we'd rather keep them visible-but-marked, the generator hook is a one-line change.
- **Spec visibility vs. runtime availability are orthogonal:** hiding from the spec (generator change) is independent of actually serving the route. `ENABLE_DEPRECATED_ENDPOINTS=false` is what stops them serving (`410 Gone`); the flag defaults to `true` so behavior is unchanged until we flip it at sunset.
- **Not included** (no clean v3 successor, intentionally left active/visible): `address/:principal/{assets,stx_inbound,mempool,nonces}`, `tx/{multiple,:tx_id/raw,mempool/stats,events}`, `addresses/:burnchain_address/pox-transactions`, and the "deprecate with care" pair (`get_account_balance`, `get_principal_ft_balance`).
- `openapi.yaml` is intentionally **not** regenerated here — it's auto-generated at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)