### PR TITLE
feat: add v3 single fungible-token balance endpoint and deprecate the v2 equivalent

### DIFF
--- a/src/api/routes/v2/addresses.ts
+++ b/src/api/routes/v2/addresses.ts
@@ -296,8 +296,9 @@ export const AddressRoutesV2: FastifyPluginAsync<
       preHandler: handlePrincipalCache,
       schema: {
         operationId: 'get_principal_ft_balance',
+        deprecated: true,
         summary: 'Get principal FT balance',
-        description: `Retrieves a specific fungible-token balance for a given principal.`,
+        description: `Retrieves a specific fungible-token balance for a given principal. **Deprecated:** use \`GET /extended/v3/principals/{principal}/balances/ft/{asset_identifier}\` instead.`,
         tags: ['Accounts'],
         params: Type.Object({
           principal: PrincipalSchema,

--- a/src/api/routes/v3/principals.ts
+++ b/src/api/routes/v3/principals.ts
@@ -7,7 +7,11 @@ import { FastifyPluginAsync } from 'fastify';
 import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Server } from 'node:http';
 import { getPagingQueryLimit, ResourceType } from '../../pagination.js';
-import { PrincipalSchema, TransactionIdSchema } from '../../schemas/v3/entities/common.js';
+import {
+  AssetIdentifierSchema,
+  PrincipalSchema,
+  TransactionIdSchema,
+} from '../../schemas/v3/entities/common.js';
 import {
   BondCursorSchema,
   CursorPaginationQuerystring,
@@ -356,6 +360,37 @@ export const PrincipalsRoutes: FastifyPluginAsync<
           asset_identifier: r.token,
           balance: r.balance,
         })),
+      });
+    }
+  );
+
+  fastify.get(
+    '/principals/:principal/balances/ft/:asset_identifier',
+    {
+      preHandler: handlePrincipalCache,
+      schema: {
+        operationId: 'get_principal_balance_ft',
+        summary: 'Get principal FT balance',
+        description:
+          "Get a principal's balance of a single fungible token. Returns a zero balance if the principal does not currently hold the token.",
+        tags: ['Accounts'],
+        params: Type.Object({
+          principal: PrincipalSchema,
+          asset_identifier: AssetIdentifierSchema,
+        }),
+        response: {
+          200: PrincipalFtPositionSchema,
+        },
+      },
+    },
+    async (req, reply) => {
+      const result = await fastify.db.v3.getPrincipalFtBalance({
+        principal: req.params.principal,
+        token: req.params.asset_identifier,
+      });
+      await reply.send({
+        asset_identifier: result.token,
+        balance: result.balance,
       });
     }
   );

--- a/src/datastore/v3/pg-store-v3.ts
+++ b/src/datastore/v3/pg-store-v3.ts
@@ -355,6 +355,31 @@ export class PgStoreV3 extends BasePgStoreModule {
   }
 
   /**
+   * Gets a principal's balance of a single fungible token via a point lookup on
+   * the `ft_balances (address, token)` primary key. Returns a `"0"` balance when
+   * the principal does not hold the token.
+   * @param args - The arguments for the query.
+   * @returns The principal's balance of the given token.
+   */
+  async getPrincipalFtBalance(args: {
+    principal: Principal;
+    token: string;
+  }): Promise<DbPrincipalFtBalance> {
+    return await this.sqlTransaction(async sql => {
+      const result = await sql<{ balance: string }[]>`
+        SELECT balance::text AS balance
+        FROM ft_balances
+        WHERE address = ${args.principal} AND token = ${args.token}
+        LIMIT 1
+      `;
+      return {
+        token: args.token,
+        balance: result.count > 0 ? result[0].balance : '0',
+      };
+    });
+  }
+
+  /**
    * Gets a principal's individually-owned NFT instances, keyset-paginated by
    * `(asset_identifier, value)` (the unique key for an NFT instance), sorted
    * ascending. Backed by the `nft_custody` index on

--- a/tests/api/v3/principals.test.ts
+++ b/tests/api/v3/principals.test.ts
@@ -1187,6 +1187,50 @@ describe('principals', () => {
         current: `1000000:${tokenSmall}`,
       });
     });
+
+    describe('single token lookup', () => {
+      const getFtBalance = (principal: string, assetIdentifier: string) =>
+        api.fastifyApp.inject({
+          method: 'GET',
+          url: `/extended/v3/principals/${principal}/balances/ft/${assetIdentifier}`,
+        });
+
+      test('returns the balance for a single held token', async () => {
+        await db.update(buildFtBlock());
+        const res = await getFtBalance(ftAddr, tokenMid);
+        assert.equal(res.statusCode, 200, res.body);
+        assert.deepEqual(JSON.parse(res.body), {
+          asset_identifier: tokenMid,
+          balance: '2000000',
+        });
+      });
+
+      test('returns a zero balance for a token the principal does not hold', async () => {
+        await db.update(buildFtBlock());
+        const tokenNone = 'SP000000000000000000002Q6VF78.token-none::none';
+        const res = await getFtBalance(ftAddr, tokenNone);
+        assert.equal(res.statusCode, 200, res.body);
+        assert.deepEqual(JSON.parse(res.body), {
+          asset_identifier: tokenNone,
+          balance: '0',
+        });
+      });
+
+      test('returns a zero balance for a token that nets to zero', async () => {
+        await db.update(buildFtBlock());
+        const res = await getFtBalance(ftAddr, tokenZero);
+        assert.equal(res.statusCode, 200, res.body);
+        assert.deepEqual(JSON.parse(res.body), {
+          asset_identifier: tokenZero,
+          balance: '0',
+        });
+      });
+
+      test('rejects a malformed asset identifier with 400', async () => {
+        const res = await getFtBalance(ftAddr, 'not-a-valid-asset-id');
+        assert.equal(res.statusCode, 400, res.body);
+      });
+    });
   });
 
   describe('/v3/principals/:principal/balances/nft', () => {


### PR DESCRIPTION
## What

Adds a v3 point-lookup endpoint for a single fungible-token balance and deprecates the v2 endpoint it supersedes.

- **New:** `GET /extended/v3/principals/:principal/balances/ft/:asset_identifier`
- **Deprecated:** `GET /extended/v2/addresses/:principal/balances/ft/:token`

## Why

The v3 FT surface only had the paginated list (`/balances/ft`), so there was no clean successor for v2's single-token lookup — the one remaining "deprecate with care" gap from #2597. A path-param route (mirroring v2) is the right shape for a point read: it avoids forcing callers to page a list and infer "not held = balance 0" from an empty array.

## Changes

- **`src/datastore/v3/pg-store-v3.ts`** — `getPrincipalFtBalance(principal, token)`: a primary-key point lookup on `ft_balances (address, token)`, returning a `"0"` balance when the principal doesn't hold the token (matches v2's behavior; no 404).
- **`src/api/routes/v3/principals.ts`** — new route (operationId `get_principal_balance_ft`) with `handlePrincipalCache`; params validated by `PrincipalSchema` + the existing `AssetIdentifierSchema`; response is `PrincipalFtPositionSchema` (`{ asset_identifier, balance }`), the same item shape as the list endpoint.
- **`src/api/routes/v2/addresses.ts`** — marked `get_principal_ft_balance` `deprecated: true` with a `**Deprecated:** use \`GET /extended/v3/principals/{principal}/balances/ft/{asset_identifier}\`` note. Per the deprecation handling from #2597 this means it is now hidden from the OpenAPI spec and disabled (`410 Gone`) when `ENABLE_DEPRECATED_ENDPOINTS=false`.
- **`tests/api/v3/principals.test.ts`** — 4 tests under a `single token lookup` sub-describe: held token returns its balance, unheld token → `"0"`, net-zero token → `"0"`, malformed asset identifier → `400`.

## Reviewer notes

- **Param name** is `:asset_identifier` (consistent with the list endpoint's response field) rather than v2's `:token`. Asset identifiers contain no `/`, so they fit in a single path segment — v2 already relies on this.
- **Zero vs. 404:** an unheld (or net-zero) token returns `200 { asset_identifier, balance: "0" }`, intentionally matching v2 rather than 404-ing.
- `openapi.yaml` is intentionally **not** regenerated here — it's auto-generated at release.

## Testing

`npm run test:api:v3` — 30 passed, 0 failed (includes the 4 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)