### PR TITLE
fix: default STACKS_CORE_PROXY_HOST/PORT to the core RPC host/port

### DIFF
--- a/src/api/routes/v1/core-node-rpc-proxy.ts
+++ b/src/api/routes/v1/core-node-rpc-proxy.ts
@@ -10,8 +10,9 @@ import { logger } from '@stacks/api-toolkit';
 import { ENV } from '../../../env.js';
 
 function GetStacksNodeProxyEndpoint() {
-  const proxyHost = ENV.STACKS_CORE_PROXY_HOST;
-  const proxyPort = ENV.STACKS_CORE_PROXY_PORT;
+  // Proxy host/port are optional and fall back to the core node RPC host/port when unset.
+  const proxyHost = ENV.STACKS_CORE_PROXY_HOST ?? ENV.STACKS_CORE_RPC_HOST;
+  const proxyPort = ENV.STACKS_CORE_PROXY_PORT ?? ENV.STACKS_CORE_RPC_PORT;
   return `${proxyHost}:${proxyPort}`;
 }
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -128,8 +128,16 @@ const schema = Type.Object({
   STACKS_CORE_EVENT_BODY_LIMIT: Type.Integer({ default: 500000000, minimum: 0 }),
   STACKS_CORE_RPC_HOST: Type.String({ default: '127.0.0.1' }),
   STACKS_CORE_RPC_PORT: Type.Integer({ default: 20443, minimum: 0, maximum: 65535 }),
-  STACKS_CORE_PROXY_HOST: Type.String({ default: '127.0.0.1' }),
-  STACKS_CORE_PROXY_PORT: Type.Integer({ default: 20443, minimum: 0, maximum: 65535 }),
+  /**
+   * Host of the Stacks core node to proxy `/v2` RPC requests to. Defaults to
+   * `STACKS_CORE_RPC_HOST`.
+   */
+  STACKS_CORE_PROXY_HOST: Type.Optional(Type.String()),
+  /**
+   * Port of the Stacks core node to proxy `/v2` RPC requests to. Defaults to
+   * `STACKS_CORE_RPC_PORT`.
+   */
+  STACKS_CORE_PROXY_PORT: Type.Optional(Type.Integer({ minimum: 0, maximum: 65535 })),
   /**
    * Stacks core RPC proxy body size limit. Defaults to 10MB.
    */


### PR DESCRIPTION
## Description

Makes `STACKS_CORE_PROXY_HOST` and `STACKS_CORE_PROXY_PORT` optional. When they are not set, the `/v2` RPC proxy now falls back to `STACKS_CORE_RPC_HOST` / `STACKS_CORE_RPC_PORT` instead of the previous static `127.0.0.1:20443` defaults.

Most deployments point the proxy at the same core node they already configure via the RPC vars, so having to set the same host/port twice was redundant and easy to get wrong (e.g. customizing the RPC host but forgetting the proxy host, leaving the proxy silently talking to `127.0.0.1`).

**Behavior note:** previously both the RPC and proxy vars defaulted independently to `127.0.0.1:20443`. Now the proxy inherits the RPC values when unset. This only changes behavior for a deployment that sets a custom `STACKS_CORE_RPC_HOST`/`PORT` *without* also setting the proxy vars — such a deployment will now proxy to the configured RPC host instead of `127.0.0.1`. Deployments that set both explicitly, or neither, are unaffected.

Changes:
- `src/env.ts`: `STACKS_CORE_PROXY_HOST`/`PORT` are now `Type.Optional` (defaults removed).
- `src/api/routes/v1/core-node-rpc-proxy.ts`: `?? STACKS_CORE_RPC_HOST` / `?? STACKS_CORE_RPC_PORT` fallback at the use site.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Tests added/updated — existing `tests/api/v2-proxy` sets both proxy vars explicitly and is unaffected; no new test added for the fallback path.
- [x] Docs updated (if needed) — README already documents these as "falls back to RPC host/port"; now consistent with the code.
- [ ] Breaking change — not breaking; see the behavior note above for the one deployment shape whose effective proxy target changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)