### PR TITLE
fix: v3 transaction events 500 for asset identifiers containing digits

### DIFF
--- a/src/api/schemas/v3/entities/common.ts
+++ b/src/api/schemas/v3/entities/common.ts
@@ -21,7 +21,7 @@ export type Principal = Static<typeof PrincipalSchema>;
 
 export const AssetIdentifierSchema = Type.String({
   pattern:
-    '^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z-]+$',
+    '^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*]){0,127}$',
   title: 'Asset Identifier',
   description: 'Asset Identifier',
   examples: ['SP000000000000000000002Q6VF78.pox-3::stx-token'],

--- a/tests/api/v3/transactions.test.ts
+++ b/tests/api/v3/transactions.test.ts
@@ -609,6 +609,40 @@ describe('transactions', () => {
       );
     });
 
+    test('should serialize NFT and FT events whose asset name contains a digit', async () => {
+      // Regression for #2612: `AssetIdentifierSchema` rejected asset names with digits (e.g.
+      // `BNS-V2`), causing response serialization to fail with HTTP 500.
+      const txId = hex(0x7005);
+      const nftAssetId = 'SP2QEZ06AGJ3RKJPBV14SY1V5BBFNAW33D96YPGZF.BNS-V2::BNS-V2';
+      const ftAssetId = 'SP2QEZ06AGJ3RKJPBV14SY1V5BBFNAW33D96YPGZF.token-v2::wrapped-btc-2';
+      await db.update(
+        new TestBlockBuilder({
+          block_height: 1,
+          index_block_hash: hex(1),
+          parent_index_block_hash: hex(0),
+          parent_block_hash: hex(0),
+        })
+          .addTx({ tx_id: txId, tx_index: 0, event_count: 2 })
+          .addTxNftEvent({ sender, recipient, asset_identifier: nftAssetId })
+          .addTxFtEvent({ amount: 202n, sender, recipient, asset_identifier: ftAssetId })
+          .build()
+      );
+
+      const response = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/transactions/${txId}/events`,
+      });
+      assert.equal(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.equal(body.total, 2);
+      assert.deepEqual(
+        body.results.map((event: { type: string }) => event.type),
+        ['nft_asset', 'ft_asset']
+      );
+      assert.equal(body.results[0].nft_asset.asset_identifier, nftAssetId);
+      assert.equal(body.results[1].ft_asset.asset_identifier, ftAssetId);
+    });
+
     test('should cursor paginate transaction events by event_index', async () => {
       const txId = hex(0x7002);
       await db.update(


### PR DESCRIPTION
## Description

Closes #2612.

`GET /extended/v3/transactions/{tx_id}/events` (and other v3 responses using `AssetIdentifierSchema`) returned HTTP 500 for valid NFT/FT asset identifiers whose asset name contains a digit, e.g. `SP2QEZ06AGJ3RKJPBV14SY1V5BBFNAW33D96YPGZF.BNS-V2::BNS-V2`.

**Root cause:** `AssetIdentifierSchema` validated the asset-name component (after `::`) with `[a-zA-Z-]+`, which rejects digits. This schema is used only in **response** bodies, so a valid asset id failed Fastify's response serialization and surfaced as a 500. The pattern could only ever reject valid data — it validated nothing on the request side.

**Fix:** the asset-name component now uses the canonical Clarity-name charset (leading letter, then alphanumerics plus the Clarity-name symbols, up to 128 chars):

```
::[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*]){0,127}$
```

The contract-name component before `::` is unchanged — it already matches Clarity `ContractName` rules / `SmartContractIdSchema`.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Tests added/updated — added a `/v3/transactions/:tx_id/events` regression test asserting HTTP 200 and intact identifiers for an NFT event (`...BNS-V2::BNS-V2`) and an FT event (`...::wrapped-btc-2`).
- [ ] Docs updated (if needed) — n/a.
- [ ] Breaking change — none; strictly loosens an over-strict response pattern.

### Verification
- New regex validated against valid ids (`BNS-V2`, `The-Explorer-Guild`, `sbtc-token`) and malformed ones (`::123bad`, empty asset name, non-address prefix).
- `tsc` typecheck, eslint, and prettier pass.
- Ran the new + adjacent events tests locally (Postgres via Docker): 2 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)