### PR TITLE
fix: surface the actual error in event-ingestion 500 responses

### DIFF
--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -71,31 +71,25 @@ import {
 } from '@stacks/node-publisher-client';
 import { CoreNodeParsedTxMessage } from './core-node-message.js';
 
-// Max number of `cause`-chain links to include, as a backstop against pathologically deep chains.
-const EVENT_ERROR_MAX_CAUSE_DEPTH = 10;
-
 /**
- * Build the body for a failed event-ingestion response. A raw `Error` serializes to `{}` (its
- * `message`/`stack` are non-enumerable), which is why the stacks-node's event dispatcher logs an
- * empty `{"error": {}}`. This extracts the message and unwinds the `cause` chain so the underlying
- * reason (e.g. the failing DB operation) is surfaced in the response the node logs.
+ * Build the body for a failed event-ingestion response. This extracts the message and unwinds the
+ * `cause` chain so the underlying reason (e.g. the failing DB operation) is surfaced in the
+ * response the node logs.
  *
- * The walk is bounded by both a depth cap and a seen-set, since a `cause` chain can be cyclic
- * (e.g. `error.cause === error`) or arbitrarily deep. Messages are whitespace-normalized to a
- * single line so multi-line errors don't bloat the node's logs.
+ * The walk is bounded by both a depth cap and a seen-set, since a `cause` chain can be cyclic (e.g.
+ * `error.cause === error`) or arbitrarily deep. Messages are whitespace-normalized to a single line
+ * so multi-line errors don't bloat the node's logs.
  */
 export function eventErrorResponse(error: unknown): { error: string } {
   if (!(error instanceof Error)) {
     return { error: normalizeErrorMessage(String(error)) };
   }
+  // Max number of `cause`-chain links to include, as a backstop against pathologically deep chains.
+  const MAX_CAUSE_DEPTH = 10;
   const messages: string[] = [];
   const seen = new Set<unknown>();
   let current: unknown = error;
-  while (
-    current instanceof Error &&
-    !seen.has(current) &&
-    messages.length < EVENT_ERROR_MAX_CAUSE_DEPTH
-  ) {
+  while (current instanceof Error && !seen.has(current) && messages.length < MAX_CAUSE_DEPTH) {
     seen.add(current);
     messages.push(current.message);
     current = (current as { cause?: unknown }).cause;

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -71,23 +71,41 @@ import {
 } from '@stacks/node-publisher-client';
 import { CoreNodeParsedTxMessage } from './core-node-message.js';
 
+// Max number of `cause`-chain links to include, as a backstop against pathologically deep chains.
+const EVENT_ERROR_MAX_CAUSE_DEPTH = 10;
+
 /**
  * Build the body for a failed event-ingestion response. A raw `Error` serializes to `{}` (its
  * `message`/`stack` are non-enumerable), which is why the stacks-node's event dispatcher logs an
  * empty `{"error": {}}`. This extracts the message and unwinds the `cause` chain so the underlying
  * reason (e.g. the failing DB operation) is surfaced in the response the node logs.
+ *
+ * The walk is bounded by both a depth cap and a seen-set, since a `cause` chain can be cyclic
+ * (e.g. `error.cause === error`) or arbitrarily deep. Messages are whitespace-normalized to a
+ * single line so multi-line errors don't bloat the node's logs.
  */
 export function eventErrorResponse(error: unknown): { error: string } {
   if (!(error instanceof Error)) {
-    return { error: String(error) };
+    return { error: normalizeErrorMessage(String(error)) };
   }
   const messages: string[] = [];
+  const seen = new Set<unknown>();
   let current: unknown = error;
-  while (current instanceof Error) {
+  while (
+    current instanceof Error &&
+    !seen.has(current) &&
+    messages.length < EVENT_ERROR_MAX_CAUSE_DEPTH
+  ) {
+    seen.add(current);
     messages.push(current.message);
     current = (current as { cause?: unknown }).cause;
   }
-  return { error: messages.join(': ') };
+  return { error: normalizeErrorMessage(messages.join(': ')) };
+}
+
+/** Collapse all runs of whitespace (incl. newlines) to single spaces and trim. */
+function normalizeErrorMessage(message: string): string {
+  return message.replace(/\s+/g, ' ').trim();
 }
 
 async function handleRawEventRequest(

--- a/src/event-stream/event-server.ts
+++ b/src/event-stream/event-server.ts
@@ -71,6 +71,25 @@ import {
 } from '@stacks/node-publisher-client';
 import { CoreNodeParsedTxMessage } from './core-node-message.js';
 
+/**
+ * Build the body for a failed event-ingestion response. A raw `Error` serializes to `{}` (its
+ * `message`/`stack` are non-enumerable), which is why the stacks-node's event dispatcher logs an
+ * empty `{"error": {}}`. This extracts the message and unwinds the `cause` chain so the underlying
+ * reason (e.g. the failing DB operation) is surfaced in the response the node logs.
+ */
+export function eventErrorResponse(error: unknown): { error: string } {
+  if (!(error instanceof Error)) {
+    return { error: String(error) };
+  }
+  const messages: string[] = [];
+  let current: unknown = error;
+  while (current instanceof Error) {
+    messages.push(current.message);
+    current = (current as { cause?: unknown }).cause;
+  }
+  return { error: messages.join(': ') };
+}
+
 async function handleRawEventRequest(
   eventPath: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -879,7 +898,7 @@ export async function startEventServer(opts: {
       await res.status(200).send({ result: 'ok' });
     } catch (error) {
       logger.error(error, 'error processing core-node /new_block');
-      await res.status(500).send({ error: error });
+      await res.status(500).send(eventErrorResponse(error));
     }
   });
 
@@ -891,7 +910,7 @@ export async function startEventServer(opts: {
       await res.status(200).send({ result: 'ok' });
     } catch (error) {
       logger.error(error, 'error processing core-node /new_burn_block');
-      await res.status(500).send({ error: error });
+      await res.status(500).send(eventErrorResponse(error));
     }
   });
 
@@ -903,7 +922,7 @@ export async function startEventServer(opts: {
       await res.status(200).send({ result: 'ok' });
     } catch (error) {
       logger.error(error, 'error processing core-node /new_mempool_tx');
-      await res.status(500).send({ error: error });
+      await res.status(500).send(eventErrorResponse(error));
     }
   });
 
@@ -915,7 +934,7 @@ export async function startEventServer(opts: {
       await res.status(200).send({ result: 'ok' });
     } catch (error) {
       logger.error(error, 'error processing core-node /drop_mempool_tx');
-      await res.status(500).send({ error: error });
+      await res.status(500).send(eventErrorResponse(error));
     }
   });
 
@@ -927,7 +946,7 @@ export async function startEventServer(opts: {
       await res.status(200).send({ result: 'ok' });
     } catch (error) {
       logger.error(error, 'error processing core-node /attachments/new');
-      await res.status(500).send({ error: error });
+      await res.status(500).send(eventErrorResponse(error));
     }
   });
 
@@ -939,7 +958,7 @@ export async function startEventServer(opts: {
       await res.status(200).send({ result: 'ok' });
     } catch (error) {
       logger.error(error, 'error processing core-node /new_microblocks');
-      await res.status(500).send({ error: error });
+      await res.status(500).send(eventErrorResponse(error));
     }
   });
 
@@ -954,7 +973,7 @@ export async function startEventServer(opts: {
       await res.status(200).send({ result: 'ok' });
     } catch (error) {
       logger.error(error, 'error processing core-node /stackerdb_chunks');
-      await res.status(500).send({ error: error });
+      await res.status(500).send(eventErrorResponse(error));
     }
   });
 
@@ -969,7 +988,7 @@ export async function startEventServer(opts: {
       await res.status(200).send({ result: 'ok' });
     } catch (error) {
       logger.error(error, 'error processing core-node /proposal_response');
-      await res.status(500).send({ error: error });
+      await res.status(500).send(eventErrorResponse(error));
     }
   });
 

--- a/tests/api/event-server/event-error-response.test.ts
+++ b/tests/api/event-server/event-error-response.test.ts
@@ -1,0 +1,35 @@
+import { eventErrorResponse } from '../../../src/event-stream/event-server.ts';
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+describe('eventErrorResponse', () => {
+  test('surfaces the message of a plain Error (not an empty object)', () => {
+    const body = eventErrorResponse(new Error('insert into blocks failed'));
+    assert.deepEqual(body, { error: 'insert into blocks failed' });
+    // Regression: a raw Error serializes to `{}`, which is what the node used to log.
+    assert.notDeepEqual(JSON.parse(JSON.stringify(body)), { error: {} });
+  });
+
+  test('unwinds the cause chain so the underlying reason is included', () => {
+    const error = new Error('handleBlockMessage failed', {
+      cause: new Error('duplicate key value violates unique constraint', {
+        cause: new Error('conn reset'),
+      }),
+    });
+    assert.deepEqual(eventErrorResponse(error), {
+      error:
+        'handleBlockMessage failed: duplicate key value violates unique constraint: conn reset',
+    });
+  });
+
+  test('stringifies non-Error values', () => {
+    assert.deepEqual(eventErrorResponse('boom'), { error: 'boom' });
+    assert.deepEqual(eventErrorResponse(42), { error: '42' });
+    assert.deepEqual(eventErrorResponse(undefined), { error: 'undefined' });
+  });
+
+  test('ignores a non-Error cause and keeps the outer message', () => {
+    const error = new Error('outer', { cause: 'just a string cause' });
+    assert.deepEqual(eventErrorResponse(error), { error: 'outer' });
+  });
+});

--- a/tests/api/event-server/event-error-response.test.ts
+++ b/tests/api/event-server/event-error-response.test.ts
@@ -32,4 +32,36 @@ describe('eventErrorResponse', () => {
     const error = new Error('outer', { cause: 'just a string cause' });
     assert.deepEqual(eventErrorResponse(error), { error: 'outer' });
   });
+
+  test('terminates on a self-referential (cyclic) cause chain', () => {
+    const error = new Error('cyclic');
+    (error as { cause?: unknown }).cause = error;
+    assert.deepEqual(eventErrorResponse(error), { error: 'cyclic' });
+  });
+
+  test('terminates on a two-node cause cycle', () => {
+    const a = new Error('a');
+    const b = new Error('b');
+    (a as { cause?: unknown }).cause = b;
+    (b as { cause?: unknown }).cause = a;
+    // Each error is visited once; the cycle back to `a` stops the walk.
+    assert.deepEqual(eventErrorResponse(a), { error: 'a: b' });
+  });
+
+  test('caps a very deep cause chain instead of looping unbounded', () => {
+    let error = new Error('level-0');
+    for (let i = 1; i < 1000; i++) {
+      error = new Error(`level-${i}`, { cause: error });
+    }
+    // Only the first 10 links (the outermost errors) are included.
+    assert.deepEqual(eventErrorResponse(error), {
+      error:
+        'level-999: level-998: level-997: level-996: level-995: level-994: level-993: level-992: level-991: level-990',
+    });
+  });
+
+  test('normalizes whitespace so multi-line messages stay on one line', () => {
+    const error = new Error('line one\n\tline two   with   spaces\n');
+    assert.deepEqual(eventErrorResponse(error), { error: 'line one line two with spaces' });
+  });
 });


### PR DESCRIPTION
## Description

When the API failed to ingest a stacks-node event (e.g. `POST /new_block`), the 500 response body was `{"error": {}}` — an empty object. The stacks-node event dispatcher logs that body, so operators saw:

```
HTTP 'POST /new_block' did not succeed (500 != 200). Response body = JSON(Object {"error": Object {}})
```

**Cause:** every event-observer handler did `res.status(500).send({ error: error })` with a raw `Error`, and `JSON.stringify(new Error('...'))` yields `{}` because `message`/`stack` are non-enumerable.

**Fix:** added an `eventErrorResponse(error)` helper that extracts `error.message` and unwinds the `.cause` chain (ingestion failures are usually wrapped — e.g. a handler error caused by a Postgres constraint violation), and applied it to all 8 ingestion endpoints (`/new_block`, `/new_burn_block`, `/new_mempool_tx`, `/drop_mempool_tx`, `/attachments/new`, `/new_microblocks`, `/stackerdb_chunks`, `/proposal_response`). The node now logs, e.g.:

```
Response body = JSON(Object {"error": String("handleBlockMessage failed: duplicate key value violates unique constraint")})
```

Notes:
- Full error + stack is still logged server-side via the existing `logger.error(error, ...)`; only the HTTP response body changed.
- Response body kept as `{ error: <string> }` (was `{ error: <object> }`); the node just logs it as text, so no consumer contract breaks.
- Message only, not the stack — stacks are multi-line and would bloat the node's logs.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Tests added/updated — unit tests for `eventErrorResponse` (plain Error, nested cause chain, non-Error values, non-Error cause).
- [ ] Docs updated (if needed) — n/a.
- [ ] Breaking change — none.

### Verification
- `tsc` typecheck and eslint pass.
- New unit test: 4 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)