### PR TITLE
feat: client pkg export paths type

### DIFF
--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -11,3 +11,4 @@ export * from './socket-io';
 export * from './ws';
 export type * from './types';
 export * from 'openapi-fetch';
+export type { paths };


### PR DESCRIPTION
## Description

Exports the `paths` type from the client api package so the types can be reused in applications.

At the moment one need to do:
```ts
import type { paths } from "@stacks/blockchain-api-client/lib/generated/schema";
```
in order to access them.

@rafa-stacks this is the new pr with a signed commit

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (if needed) — https://github.com/hirosystems/docs
- [ ] Breaking change (describe impact and migration below)

<!-- If breaking: describe what breaks and how consumers should migrate. -->
