### PR TITLE
fix: support `problematic_skipped` transaction status (Epoch 4.0)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stacks/blockchain-api-client",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stacks/blockchain-api-client",
-      "version": "9.0.1",
+      "version": "9.0.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/node": "20.14.14",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/blockchain-api-client",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "access": "public",
   "description": "Client for the Stacks Blockchain API",
   "homepage": "https://github.com/stx-labs/stacks-blockchain-api/tree/master/client#readme",

--- a/client/src/generated/schema.d.ts
+++ b/client/src/generated/schema.d.ts
@@ -2720,7 +2720,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -2970,7 +2970,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -3220,7 +3220,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -3477,7 +3477,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -3726,7 +3726,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -3975,7 +3975,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -4286,7 +4286,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -4536,7 +4536,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -4786,7 +4786,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -5043,7 +5043,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -5292,7 +5292,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -5541,7 +5541,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -7772,7 +7772,7 @@ export interface operations {
                         /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                         tx_index: number;
                         /** @description Status of the transaction */
-                        tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                        tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                         /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                         tx_result: {
                             /** @description Hex string representing the value fo the transaction result */
@@ -8022,7 +8022,7 @@ export interface operations {
                         /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                         tx_index: number;
                         /** @description Status of the transaction */
-                        tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                        tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                         /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                         tx_result: {
                             /** @description Hex string representing the value fo the transaction result */
@@ -8272,7 +8272,7 @@ export interface operations {
                         /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                         tx_index: number;
                         /** @description Status of the transaction */
-                        tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                        tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                         /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                         tx_result: {
                             /** @description Hex string representing the value fo the transaction result */
@@ -8529,7 +8529,7 @@ export interface operations {
                         /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                         tx_index: number;
                         /** @description Status of the transaction */
-                        tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                        tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                         /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                         tx_result: {
                             /** @description Hex string representing the value fo the transaction result */
@@ -8778,7 +8778,7 @@ export interface operations {
                         /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                         tx_index: number;
                         /** @description Status of the transaction */
-                        tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                        tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                         /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                         tx_result: {
                             /** @description Hex string representing the value fo the transaction result */
@@ -9027,7 +9027,7 @@ export interface operations {
                         /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                         tx_index: number;
                         /** @description Status of the transaction */
-                        tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                        tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                         /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                         tx_result: {
                             /** @description Hex string representing the value fo the transaction result */
@@ -10207,7 +10207,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -10457,7 +10457,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -10707,7 +10707,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -10964,7 +10964,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -11213,7 +11213,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -11462,7 +11462,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -11776,7 +11776,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -12026,7 +12026,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -12276,7 +12276,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -12533,7 +12533,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -12782,7 +12782,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -13031,7 +13031,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -13627,7 +13627,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -13877,7 +13877,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -14127,7 +14127,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -14384,7 +14384,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -14633,7 +14633,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -14882,7 +14882,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -15217,7 +15217,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -15467,7 +15467,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -15717,7 +15717,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -15974,7 +15974,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -16223,7 +16223,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -16472,7 +16472,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -16812,7 +16812,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -17062,7 +17062,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -17312,7 +17312,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -17569,7 +17569,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -17818,7 +17818,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -18067,7 +18067,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -18836,7 +18836,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -19086,7 +19086,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -19336,7 +19336,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -19593,7 +19593,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -19842,7 +19842,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -20091,7 +20091,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -21341,7 +21341,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -21591,7 +21591,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -21841,7 +21841,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -22098,7 +22098,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -22347,7 +22347,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -22596,7 +22596,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -22898,7 +22898,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -23148,7 +23148,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -23398,7 +23398,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -23655,7 +23655,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -23904,7 +23904,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -24153,7 +24153,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -24506,7 +24506,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -24756,7 +24756,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -25006,7 +25006,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -25263,7 +25263,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -25512,7 +25512,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -25761,7 +25761,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -27364,7 +27364,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -27614,7 +27614,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -27864,7 +27864,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -28121,7 +28121,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -28370,7 +28370,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -28619,7 +28619,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -30548,7 +30548,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -30798,7 +30798,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -31048,7 +31048,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -31305,7 +31305,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -31554,7 +31554,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -31803,7 +31803,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -32717,7 +32717,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -32967,7 +32967,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -33217,7 +33217,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -33474,7 +33474,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -33723,7 +33723,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -33972,7 +33972,7 @@ export interface operations {
                             /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                             tx_index: number;
                             /** @description Status of the transaction */
-                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                             tx_result: {
                                 /** @description Hex string representing the value fo the transaction result */
@@ -35158,7 +35158,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -35408,7 +35408,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -35658,7 +35658,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -35915,7 +35915,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -36164,7 +36164,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -36413,7 +36413,7 @@ export interface operations {
                                 /** @description Index of the transaction, indicating the order. Starts at `0` and increases with each transaction */
                                 tx_index: number;
                                 /** @description Status of the transaction */
-                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                tx_status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @description Result of the transaction. For contract calls, this will show the value returned by the call. For other transaction types, this will return a boolean indicating the success of the transaction. */
                                 tx_result: {
                                     /** @description Hex string representing the value fo the transaction result */
@@ -36961,7 +36961,7 @@ export interface operations {
                                 time: number;
                             };
                             /** @description Status of the transaction */
-                            status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @enum {string} */
                             type: "token_transfer";
                             token_transfer: {
@@ -37009,7 +37009,7 @@ export interface operations {
                                 time: number;
                             };
                             /** @description Status of the transaction */
-                            status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @enum {string} */
                             type: "smart_contract";
                             smart_contract: {
@@ -37053,7 +37053,7 @@ export interface operations {
                                 time: number;
                             };
                             /** @description Status of the transaction */
-                            status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @enum {string} */
                             type: "contract_call";
                             contract_call: {
@@ -37098,7 +37098,7 @@ export interface operations {
                                 time: number;
                             };
                             /** @description Status of the transaction */
-                            status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @enum {string} */
                             type: "poison_microblock";
                         } | {
@@ -37137,7 +37137,7 @@ export interface operations {
                                 time: number;
                             };
                             /** @description Status of the transaction */
-                            status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @enum {string} */
                             type: "coinbase";
                             coinbase: {
@@ -37179,7 +37179,7 @@ export interface operations {
                                 time: number;
                             };
                             /** @description Status of the transaction */
-                            status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @enum {string} */
                             type: "tenure_change";
                             tenure_change: {
@@ -37501,7 +37501,7 @@ export interface operations {
                                     time: number;
                                 };
                                 /** @description Status of the transaction */
-                                status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @enum {string} */
                                 type: "token_transfer";
                                 token_transfer: {
@@ -37549,7 +37549,7 @@ export interface operations {
                                     time: number;
                                 };
                                 /** @description Status of the transaction */
-                                status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @enum {string} */
                                 type: "smart_contract";
                                 smart_contract: {
@@ -37593,7 +37593,7 @@ export interface operations {
                                     time: number;
                                 };
                                 /** @description Status of the transaction */
-                                status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @enum {string} */
                                 type: "contract_call";
                                 contract_call: {
@@ -37638,7 +37638,7 @@ export interface operations {
                                     time: number;
                                 };
                                 /** @description Status of the transaction */
-                                status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @enum {string} */
                                 type: "poison_microblock";
                             } | {
@@ -37677,7 +37677,7 @@ export interface operations {
                                     time: number;
                                 };
                                 /** @description Status of the transaction */
-                                status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @enum {string} */
                                 type: "coinbase";
                                 coinbase: {
@@ -37719,7 +37719,7 @@ export interface operations {
                                     time: number;
                                 };
                                 /** @description Status of the transaction */
-                                status: "success" | "abort_by_response" | "abort_by_post_condition";
+                                status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                                 /** @enum {string} */
                                 type: "tenure_change";
                                 tenure_change: {
@@ -39340,7 +39340,7 @@ export interface operations {
                                 time: number;
                             };
                             /** @description Status of the transaction */
-                            status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @enum {string} */
                             type: "token_transfer";
                             token_transfer: {
@@ -39388,7 +39388,7 @@ export interface operations {
                                 time: number;
                             };
                             /** @description Status of the transaction */
-                            status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @enum {string} */
                             type: "smart_contract";
                             smart_contract: {
@@ -39432,7 +39432,7 @@ export interface operations {
                                 time: number;
                             };
                             /** @description Status of the transaction */
-                            status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @enum {string} */
                             type: "contract_call";
                             contract_call: {
@@ -39477,7 +39477,7 @@ export interface operations {
                                 time: number;
                             };
                             /** @description Status of the transaction */
-                            status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @enum {string} */
                             type: "poison_microblock";
                         } | {
@@ -39516,7 +39516,7 @@ export interface operations {
                                 time: number;
                             };
                             /** @description Status of the transaction */
-                            status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @enum {string} */
                             type: "coinbase";
                             coinbase: {
@@ -39558,7 +39558,7 @@ export interface operations {
                                 time: number;
                             };
                             /** @description Status of the transaction */
-                            status: "success" | "abort_by_response" | "abort_by_post_condition";
+                            status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                             /** @enum {string} */
                             type: "tenure_change";
                             tenure_change: {
@@ -39645,7 +39645,7 @@ export interface operations {
                             time: number;
                         };
                         /** @description Status of the transaction */
-                        status: "success" | "abort_by_response" | "abort_by_post_condition";
+                        status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                         parent_block: {
                             /** @description Hash of the parent block */
                             hash: string;
@@ -39823,7 +39823,7 @@ export interface operations {
                             time: number;
                         };
                         /** @description Status of the transaction */
-                        status: "success" | "abort_by_response" | "abort_by_post_condition";
+                        status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                         parent_block: {
                             /** @description Hash of the parent block */
                             hash: string;
@@ -39998,7 +39998,7 @@ export interface operations {
                             time: number;
                         };
                         /** @description Status of the transaction */
-                        status: "success" | "abort_by_response" | "abort_by_post_condition";
+                        status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                         parent_block: {
                             /** @description Hash of the parent block */
                             hash: string;
@@ -40177,7 +40177,7 @@ export interface operations {
                             time: number;
                         };
                         /** @description Status of the transaction */
-                        status: "success" | "abort_by_response" | "abort_by_post_condition";
+                        status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                         parent_block: {
                             /** @description Hash of the parent block */
                             hash: string;
@@ -40345,7 +40345,7 @@ export interface operations {
                             time: number;
                         };
                         /** @description Status of the transaction */
-                        status: "success" | "abort_by_response" | "abort_by_post_condition";
+                        status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                         parent_block: {
                             /** @description Hash of the parent block */
                             hash: string;
@@ -40529,7 +40529,7 @@ export interface operations {
                             time: number;
                         };
                         /** @description Status of the transaction */
-                        status: "success" | "abort_by_response" | "abort_by_post_condition";
+                        status: "success" | "abort_by_response" | "abort_by_post_condition" | "problematic_skipped";
                         parent_block: {
                             /** @description Hash of the parent block */
                             hash: string;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: Welcome to the API reference overview for the [Stacks Blockchain
     API](https://docs.hiro.so/stacks-blockchain-api). [Download Postman
     collection](https://hirosystems.github.io/stacks-blockchain-api/collection.json).
-  version: 9.0.1
+  version: 9.0.2
 components:
   schemas: {}
 paths:
@@ -656,6 +656,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -1482,6 +1485,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -2313,6 +2319,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -3161,6 +3170,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -3983,6 +3995,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -4817,6 +4832,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -9115,6 +9133,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -9941,6 +9962,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -10772,6 +10796,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -11620,6 +11647,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -12442,6 +12472,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -13276,6 +13309,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -14297,6 +14333,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -15123,6 +15162,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -15954,6 +15996,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -16802,6 +16847,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -17624,6 +17672,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -18458,6 +18509,9 @@ paths:
                                         - type: string
                                           enum:
                                             - abort_by_post_condition
+                                        - type: string
+                                          enum:
+                                            - problematic_skipped
                                     tx_result:
                                       description: Result of the transaction. For contract calls, this will show the
                                         value returned by the call. For other
@@ -20434,6 +20488,9 @@ paths:
                                           - type: string
                                             enum:
                                               - abort_by_post_condition
+                                          - type: string
+                                            enum:
+                                              - problematic_skipped
                                       tx_result:
                                         description: Result of the transaction. For contract calls, this will show the
                                           value returned by the call. For other
@@ -21262,6 +21319,9 @@ paths:
                                           - type: string
                                             enum:
                                               - abort_by_post_condition
+                                          - type: string
+                                            enum:
+                                              - problematic_skipped
                                       tx_result:
                                         description: Result of the transaction. For contract calls, this will show the
                                           value returned by the call. For other
@@ -22095,6 +22155,9 @@ paths:
                                           - type: string
                                             enum:
                                               - abort_by_post_condition
+                                          - type: string
+                                            enum:
+                                              - problematic_skipped
                                       tx_result:
                                         description: Result of the transaction. For contract calls, this will show the
                                           value returned by the call. For other
@@ -22945,6 +23008,9 @@ paths:
                                           - type: string
                                             enum:
                                               - abort_by_post_condition
+                                          - type: string
+                                            enum:
+                                              - problematic_skipped
                                       tx_result:
                                         description: Result of the transaction. For contract calls, this will show the
                                           value returned by the call. For other
@@ -23769,6 +23835,9 @@ paths:
                                           - type: string
                                             enum:
                                               - abort_by_post_condition
+                                          - type: string
+                                            enum:
+                                              - problematic_skipped
                                       tx_result:
                                         description: Result of the transaction. For contract calls, this will show the
                                           value returned by the call. For other
@@ -24605,6 +24674,9 @@ paths:
                                           - type: string
                                             enum:
                                               - abort_by_post_condition
+                                          - type: string
+                                            enum:
+                                              - problematic_skipped
                                       tx_result:
                                         description: Result of the transaction. For contract calls, this will show the
                                           value returned by the call. For other
@@ -31424,6 +31496,9 @@ paths:
                                       - type: string
                                         enum:
                                           - abort_by_post_condition
+                                      - type: string
+                                        enum:
+                                          - problematic_skipped
                                   tx_result:
                                     description: Result of the transaction. For contract calls, this will show the
                                       value returned by the call. For other
@@ -32250,6 +32325,9 @@ paths:
                                       - type: string
                                         enum:
                                           - abort_by_post_condition
+                                      - type: string
+                                        enum:
+                                          - problematic_skipped
                                   tx_result:
                                     description: Result of the transaction. For contract calls, this will show the
                                       value returned by the call. For other
@@ -33081,6 +33159,9 @@ paths:
                                       - type: string
                                         enum:
                                           - abort_by_post_condition
+                                      - type: string
+                                        enum:
+                                          - problematic_skipped
                                   tx_result:
                                     description: Result of the transaction. For contract calls, this will show the
                                       value returned by the call. For other
@@ -33929,6 +34010,9 @@ paths:
                                       - type: string
                                         enum:
                                           - abort_by_post_condition
+                                      - type: string
+                                        enum:
+                                          - problematic_skipped
                                   tx_result:
                                     description: Result of the transaction. For contract calls, this will show the
                                       value returned by the call. For other
@@ -34751,6 +34835,9 @@ paths:
                                       - type: string
                                         enum:
                                           - abort_by_post_condition
+                                      - type: string
+                                        enum:
+                                          - problematic_skipped
                                   tx_result:
                                     description: Result of the transaction. For contract calls, this will show the
                                       value returned by the call. For other
@@ -35584,6 +35671,9 @@ paths:
                                       - type: string
                                         enum:
                                           - abort_by_post_condition
+                                      - type: string
+                                        enum:
+                                          - problematic_skipped
                                   tx_result:
                                     description: Result of the transaction. For contract calls, this will show the
                                       value returned by the call. For other
@@ -38806,6 +38896,9 @@ paths:
                                 - type: string
                                   enum:
                                     - abort_by_post_condition
+                                - type: string
+                                  enum:
+                                    - problematic_skipped
                             type:
                               type: string
                               enum:
@@ -38929,6 +39022,9 @@ paths:
                                 - type: string
                                   enum:
                                     - abort_by_post_condition
+                                - type: string
+                                  enum:
+                                    - problematic_skipped
                             type:
                               type: string
                               enum:
@@ -39044,6 +39140,9 @@ paths:
                                 - type: string
                                   enum:
                                     - abort_by_post_condition
+                                - type: string
+                                  enum:
+                                    - problematic_skipped
                             type:
                               type: string
                               enum:
@@ -39155,6 +39254,9 @@ paths:
                                 - type: string
                                   enum:
                                     - abort_by_post_condition
+                                - type: string
+                                  enum:
+                                    - problematic_skipped
                             type:
                               type: string
                               enum:
@@ -39254,6 +39356,9 @@ paths:
                                 - type: string
                                   enum:
                                     - abort_by_post_condition
+                                - type: string
+                                  enum:
+                                    - problematic_skipped
                             type:
                               type: string
                               enum:
@@ -39368,6 +39473,9 @@ paths:
                                 - type: string
                                   enum:
                                     - abort_by_post_condition
+                                - type: string
+                                  enum:
+                                    - problematic_skipped
                             type:
                               type: string
                               enum:
@@ -40231,6 +40339,9 @@ paths:
                                     - type: string
                                       enum:
                                         - abort_by_post_condition
+                                    - type: string
+                                      enum:
+                                        - problematic_skipped
                                 type:
                                   type: string
                                   enum:
@@ -40354,6 +40465,9 @@ paths:
                                     - type: string
                                       enum:
                                         - abort_by_post_condition
+                                    - type: string
+                                      enum:
+                                        - problematic_skipped
                                 type:
                                   type: string
                                   enum:
@@ -40470,6 +40584,9 @@ paths:
                                     - type: string
                                       enum:
                                         - abort_by_post_condition
+                                    - type: string
+                                      enum:
+                                        - problematic_skipped
                                 type:
                                   type: string
                                   enum:
@@ -40581,6 +40698,9 @@ paths:
                                     - type: string
                                       enum:
                                         - abort_by_post_condition
+                                    - type: string
+                                      enum:
+                                        - problematic_skipped
                                 type:
                                   type: string
                                   enum:
@@ -40680,6 +40800,9 @@ paths:
                                     - type: string
                                       enum:
                                         - abort_by_post_condition
+                                    - type: string
+                                      enum:
+                                        - problematic_skipped
                                 type:
                                   type: string
                                   enum:
@@ -40794,6 +40917,9 @@ paths:
                                     - type: string
                                       enum:
                                         - abort_by_post_condition
+                                    - type: string
+                                      enum:
+                                        - problematic_skipped
                                 type:
                                   type: string
                                   enum:
@@ -41857,7 +41983,7 @@ paths:
           name: principal
           required: true
         - schema:
-            pattern: ^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z-]+$
+            pattern: ^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*]){0,127}$
             title: Asset Identifier
             type: string
           example: SP000000000000000000002Q6VF78.pox-3::stx-token
@@ -44198,6 +44324,9 @@ paths:
                                 - type: string
                                   enum:
                                     - abort_by_post_condition
+                                - type: string
+                                  enum:
+                                    - problematic_skipped
                             type:
                               type: string
                               enum:
@@ -44321,6 +44450,9 @@ paths:
                                 - type: string
                                   enum:
                                     - abort_by_post_condition
+                                - type: string
+                                  enum:
+                                    - problematic_skipped
                             type:
                               type: string
                               enum:
@@ -44436,6 +44568,9 @@ paths:
                                 - type: string
                                   enum:
                                     - abort_by_post_condition
+                                - type: string
+                                  enum:
+                                    - problematic_skipped
                             type:
                               type: string
                               enum:
@@ -44547,6 +44682,9 @@ paths:
                                 - type: string
                                   enum:
                                     - abort_by_post_condition
+                                - type: string
+                                  enum:
+                                    - problematic_skipped
                             type:
                               type: string
                               enum:
@@ -44646,6 +44784,9 @@ paths:
                                 - type: string
                                   enum:
                                     - abort_by_post_condition
+                                - type: string
+                                  enum:
+                                    - problematic_skipped
                             type:
                               type: string
                               enum:
@@ -44760,6 +44901,9 @@ paths:
                                 - type: string
                                   enum:
                                     - abort_by_post_condition
+                                - type: string
+                                  enum:
+                                    - problematic_skipped
                             type:
                               type: string
                               enum:
@@ -44956,6 +45100,9 @@ paths:
                               - type: string
                                 enum:
                                   - abort_by_post_condition
+                              - type: string
+                                enum:
+                                  - problematic_skipped
                           parent_block:
                             type: object
                             required:
@@ -45488,6 +45635,9 @@ paths:
                               - type: string
                                 enum:
                                   - abort_by_post_condition
+                              - type: string
+                                enum:
+                                  - problematic_skipped
                           parent_block:
                             type: object
                             required:
@@ -46013,6 +46163,9 @@ paths:
                               - type: string
                                 enum:
                                   - abort_by_post_condition
+                              - type: string
+                                enum:
+                                  - problematic_skipped
                           parent_block:
                             type: object
                             required:
@@ -46546,6 +46699,9 @@ paths:
                               - type: string
                                 enum:
                                   - abort_by_post_condition
+                              - type: string
+                                enum:
+                                  - problematic_skipped
                           parent_block:
                             type: object
                             required:
@@ -47053,6 +47209,9 @@ paths:
                               - type: string
                                 enum:
                                   - abort_by_post_condition
+                              - type: string
+                                enum:
+                                  - problematic_skipped
                           parent_block:
                             type: object
                             required:
@@ -47617,6 +47776,9 @@ paths:
                               - type: string
                                 enum:
                                   - abort_by_post_condition
+                              - type: string
+                                enum:
+                                  - problematic_skipped
                           parent_block:
                             type: object
                             required:
@@ -51066,7 +51228,7 @@ paths:
                                       enum:
                                         - transfer
                                     asset_identifier:
-                                      pattern: ^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z-]+$
+                                      pattern: ^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*]){0,127}$
                                       title: Asset Identifier
                                       description: Asset Identifier
                                       examples:
@@ -51133,7 +51295,7 @@ paths:
                                             - SP000000000000000000002Q6VF78.pox-3
                                           type: string
                                     asset_identifier:
-                                      pattern: ^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z-]+$
+                                      pattern: ^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*]){0,127}$
                                       title: Asset Identifier
                                       description: Asset Identifier
                                       examples:
@@ -51172,7 +51334,7 @@ paths:
                                             - SP000000000000000000002Q6VF78.pox-3
                                           type: string
                                     asset_identifier:
-                                      pattern: ^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z-]+$
+                                      pattern: ^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*]){0,127}$
                                       title: Asset Identifier
                                       description: Asset Identifier
                                       examples:
@@ -51212,7 +51374,7 @@ paths:
                                       enum:
                                         - transfer
                                     asset_identifier:
-                                      pattern: ^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z-]+$
+                                      pattern: ^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*]){0,127}$
                                       title: Asset Identifier
                                       description: Asset Identifier
                                       examples:
@@ -51282,7 +51444,7 @@ paths:
                                             - SP000000000000000000002Q6VF78.pox-3
                                           type: string
                                     asset_identifier:
-                                      pattern: ^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z-]+$
+                                      pattern: ^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*]){0,127}$
                                       title: Asset Identifier
                                       description: Asset Identifier
                                       examples:
@@ -51324,7 +51486,7 @@ paths:
                                             - SP000000000000000000002Q6VF78.pox-3
                                           type: string
                                     asset_identifier:
-                                      pattern: ^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z-]+$
+                                      pattern: ^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}::[a-zA-Z]([a-zA-Z0-9]|[-_!?+<>=/*]){0,127}$
                                       title: Asset Identifier
                                       description: Asset Identifier
                                       examples:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@stacks/common": "7.5.0",
         "@stacks/encryption": "7.5.0",
         "@stacks/network": "7.5.0",
-        "@stacks/node-publisher-client": "2.2.1",
+        "@stacks/node-publisher-client": "2.3.0",
         "@stacks/stacking": "7.5.0",
         "@stacks/transactions": "7.5.0",
         "bignumber.js": "10.0.2",
@@ -1230,6 +1230,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1364,6 +1365,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -1495,7 +1497,8 @@
       "version": "0.34.48",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
       "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
@@ -1758,9 +1761,9 @@
       }
     },
     "node_modules/@stacks/node-publisher-client": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@stacks/node-publisher-client/-/node-publisher-client-2.2.1.tgz",
-      "integrity": "sha512-W1FwbGlSBd0XawoVd6kc5dHFdi4iDC/38wqORH5yIMqbgzBTSZ67YUrDYJPSv6iNFAp8j7Gg4iKCxaxIMpFy3A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@stacks/node-publisher-client/-/node-publisher-client-2.3.0.tgz",
+      "integrity": "sha512-XP00zFh/uYOZI1VBeumGTRozbH5JxNyMkgXPTPoKxjY7odj/anGQpyY6QGYM5VSy3Yd4nx/GfxJDSjPamcXSCg==",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@stacks/api-toolkit": "^1.13.0",
@@ -2048,6 +2051,7 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -2637,6 +2641,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3750,6 +3755,7 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5606,22 +5612,19 @@
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/pg-connection-string": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
       "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -5631,7 +5634,6 @@
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
       "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
@@ -5640,15 +5642,13 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
       "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-int8": "1.0.1",
         "postgres-array": "~2.0.0",
@@ -5665,7 +5665,6 @@
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "split2": "^4.1.0"
       }
@@ -5675,7 +5674,6 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -5800,7 +5798,6 @@
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -5810,7 +5807,6 @@
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5820,7 +5816,6 @@
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5830,7 +5825,6 @@
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "xtend": "^4.0.0"
       },
@@ -5853,6 +5847,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7001,6 +6996,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7150,6 +7146,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7397,6 +7394,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7427,7 +7425,6 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stx-labs/stacks-blockchain-api",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stx-labs/stacks-blockchain-api",
-      "version": "9.0.1",
+      "version": "9.0.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@fastify/cors": "11.2.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@stacks/common": "7.5.0",
     "@stacks/encryption": "7.5.0",
     "@stacks/network": "7.5.0",
-    "@stacks/node-publisher-client": "2.2.1",
+    "@stacks/node-publisher-client": "2.3.0",
     "@stacks/stacking": "7.5.0",
     "@stacks/transactions": "7.5.0",
     "bignumber.js": "10.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stx-labs/stacks-blockchain-api",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "type": "module",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/api/controllers/db-controller.ts
+++ b/src/api/controllers/db-controller.ts
@@ -77,7 +77,12 @@ const TransactionAnchorModeTypes = ['on_chain_only', 'off_chain_only', 'any'] as
 type TransactionAnchorModeType = (typeof TransactionAnchorModeTypes)[number];
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const TransactionStatuses = ['success', 'abort_by_response', 'abort_by_post_condition'] as const;
+const TransactionStatuses = [
+  'success',
+  'abort_by_response',
+  'abort_by_post_condition',
+  'problematic_skipped',
+] as const;
 type TransactionStatus = (typeof TransactionStatuses)[number];
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -194,6 +199,8 @@ export function getTxStatusString(
       return 'abort_by_response';
     case DbTxStatus.AbortByPostCondition:
       return 'abort_by_post_condition';
+    case DbTxStatus.ProblematicSkipped:
+      return 'problematic_skipped';
     case DbTxStatus.DroppedReplaceByFee:
       return 'dropped_replace_by_fee';
     case DbTxStatus.DroppedReplaceAcrossFork:

--- a/src/api/schemas/v1/entities/transactions.ts
+++ b/src/api/schemas/v1/entities/transactions.ts
@@ -94,6 +94,7 @@ const AbstractTransactionProperties = {
       Type.Literal('success'),
       Type.Literal('abort_by_response'),
       Type.Literal('abort_by_post_condition'),
+      Type.Literal('problematic_skipped'),
     ],
     {
       description: 'Status of the transaction',

--- a/src/api/schemas/v3/entities/transaction-summaries.ts
+++ b/src/api/schemas/v3/entities/transaction-summaries.ts
@@ -38,6 +38,7 @@ const TransactionStatusSchema = Type.Union(
     Type.Literal('success'),
     Type.Literal('abort_by_response'),
     Type.Literal('abort_by_post_condition'),
+    Type.Literal('problematic_skipped'),
   ],
   { description: 'Status of the transaction' }
 );

--- a/src/api/serializers/v3/transactions.ts
+++ b/src/api/serializers/v3/transactions.ts
@@ -50,6 +50,8 @@ function serializeDbTransactionStatus(status: DbTxStatus): TransactionStatus {
       return 'abort_by_response';
     case DbTxStatus.AbortByPostCondition:
       return 'abort_by_post_condition';
+    case DbTxStatus.ProblematicSkipped:
+      return 'problematic_skipped';
     case DbTxStatus.Success:
       return 'success';
     default:

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -134,6 +134,12 @@ export enum DbTxStatus {
   Success = 1,
   AbortByResponse = -1,
   AbortByPostCondition = -2,
+  /**
+   * Mined but skipped: the transaction was marked problematic by the block's `problematic_txs`
+   * list (Epoch 4.0+). Its payload was not executed, but the fee was debited and the origin
+   * (and sponsor) nonces were bumped.
+   */
+  ProblematicSkipped = -3,
   /** Replaced by a transaction with the same nonce, but a higher fee. */
   DroppedReplaceByFee = -10,
   /** Replaced by a transaction with the same nonce but in the canonical fork. */

--- a/src/datastore/helpers.ts
+++ b/src/datastore/helpers.ts
@@ -1131,6 +1131,8 @@ export function getTxDbStatus(
       return DbTxStatus.AbortByResponse;
     case 'abort_by_post_condition':
       return DbTxStatus.AbortByPostCondition;
+    case 'problematic_skipped':
+      return DbTxStatus.ProblematicSkipped;
     case 'ReplaceByFee':
       return DbTxStatus.DroppedReplaceByFee;
     case 'ReplaceAcrossFork':

--- a/tests/api/transactions/tx.test.ts
+++ b/tests/api/transactions/tx.test.ts
@@ -1937,6 +1937,116 @@ describe('tx tests', () => {
     assert.deepEqual(JSON.parse(fetchTx.text), expectedResp);
   });
 
+  test('tx store and processing - problematic_skipped', async () => {
+    const dbBlock: DbBlock = {
+      block_hash: '0xff',
+      index_block_hash: '0x1234',
+      parent_index_block_hash: '0x5678',
+      parent_block_hash: '0x5678',
+      parent_microblock_hash: '',
+      parent_microblock_sequence: 0,
+      block_height: 1,
+      tenure_height: 1,
+      block_time: 1594647995,
+      burn_block_time: 1594647995,
+      burn_block_hash: '0x1234',
+      burn_block_height: 123,
+      miner_txid: '0x4321',
+      tx_count: 1,
+      tx_total_size: 1,
+      canonical: true,
+      execution_cost_read_count: 0,
+      execution_cost_read_length: 0,
+      execution_cost_runtime: 0,
+      execution_cost_write_count: 0,
+      execution_cost_write_length: 0,
+      signer_bitvec: null,
+      signer_signatures: null,
+    };
+    const txBuilder = await makeContractDeploy({
+      contractName: 'hello-world',
+      codeBody: '()',
+      fee: 200,
+      nonce: 0,
+      senderKey: 'b8d99fd45da58038d630d9855d3ca2466e8e0f89d3894c4724f0efc9ff4b51f001',
+      postConditions: [],
+    });
+    const serializedHex = txBuilder.serialize();
+    const tx = decodeTransaction(serializedHex);
+    const dbTx = createDbTxFromCoreMsg({
+      core_tx: {
+        raw_tx: '0x' + serializedHex,
+        raw_result: '0x0809', // (err none)
+        status: 'problematic_skipped',
+        txid: '0x' + txBuilder.txid(),
+        tx_index: 2,
+        contract_interface: null,
+        microblock_hash: null,
+        microblock_parent_hash: null,
+        microblock_sequence: null,
+        vm_error: null,
+        problematic_skipped: 7,
+        execution_cost: {
+          read_count: 0,
+          read_length: 0,
+          runtime: 0,
+          write_count: 0,
+          write_length: 0,
+        },
+      },
+      nonce: 0,
+      raw_tx: bufferToHex(Buffer.from('')),
+      parsed_tx: tx,
+      sender_address: 'SP2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7GB36ZAR0',
+      sponsor_address: undefined,
+      index_block_hash: dbBlock.index_block_hash,
+      parent_index_block_hash: dbBlock.parent_index_block_hash,
+      parent_block_hash: dbBlock.parent_block_hash,
+      microblock_hash: '',
+      microblock_sequence: I32_MAX,
+      burn_block_height: dbBlock.burn_block_height,
+      block_hash: dbBlock.parent_block_hash,
+      block_height: dbBlock.block_height,
+      block_time: 1594647995,
+      burn_block_time: 1594647995,
+      parent_burn_block_hash: '0xaa',
+      parent_burn_block_time: 1626122935,
+    });
+    assert.equal(dbTx.status, DbTxStatus.ProblematicSkipped);
+    await db.update({
+      block: dbBlock,
+      microblocks: [],
+      minerRewards: [],
+      txs: [
+        {
+          tx: dbTx,
+          stxEvents: [],
+          stxLockEvents: [],
+          ftEvents: [],
+          nftEvents: [],
+          contractLogEvents: [],
+          names: [],
+          namespaces: [],
+          smartContracts: [],
+          pox2Events: [],
+          pox3Events: [],
+          pox4Events: [],
+          pox5Events: [],
+        },
+      ],
+    });
+
+    const fetchTx = await supertest(api.server).get(`/extended/v1/tx/${dbTx.tx_id}`);
+    assert.equal(fetchTx.status, 200);
+    assert.equal(fetchTx.type, 'application/json');
+    const fetchTxBody = JSON.parse(fetchTx.text);
+    assert.equal(fetchTxBody.tx_status, 'problematic_skipped');
+    assert.deepEqual(fetchTxBody.tx_result, {
+      hex: '0x0809',
+      repr: '(err none)',
+    });
+  });
+
   test('tx store and processing - abort_by_post_condition', async () => {
     const dbBlock: DbBlock = {
       block_hash: '0xff',

--- a/tests/api/v3/transactions.test.ts
+++ b/tests/api/v3/transactions.test.ts
@@ -165,6 +165,54 @@ describe('transactions', () => {
       });
     });
 
+    test('should return problematic_skipped status', async () => {
+      const txId = '0x' + '1'.padStart(64, '0');
+      await db.update(
+        new TestBlockBuilder({
+          block_height: 1,
+          index_block_hash: '0x0001',
+          parent_index_block_hash: '0x0000',
+          parent_block_hash: '0x0000',
+        })
+          .addTx({
+            tx_id: txId,
+            block_hash: '0x0001',
+            index_block_hash: '0x0001',
+            block_time: 1000,
+            burn_block_height: 1,
+            burn_block_time: 1000,
+            tx_index: 0,
+            fee_rate: 50n,
+            type_id: DbTxTypeId.TokenTransfer,
+            status: DbTxStatus.ProblematicSkipped,
+            sender_address: 'SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27',
+            token_transfer_recipient_address: 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6',
+            token_transfer_amount: 100n,
+            token_transfer_memo: '0x0d0000000568656c6c6f',
+          })
+          .build()
+      );
+
+      const listResponse = await api.fastifyApp.inject({
+        method: 'GET',
+        url: '/extended/v3/transactions',
+      });
+      assert.equal(listResponse.statusCode, 200);
+      const listBody = JSON.parse(listResponse.body);
+      assert.equal(listBody.total, 1);
+      assert.equal(listBody.results[0].tx_id, txId);
+      assert.equal(listBody.results[0].status, 'problematic_skipped');
+
+      const detailResponse = await api.fastifyApp.inject({
+        method: 'GET',
+        url: `/extended/v3/transactions/${txId}`,
+      });
+      assert.equal(detailResponse.statusCode, 200);
+      const detailBody = JSON.parse(detailResponse.body);
+      assert.equal(detailBody.tx_id, txId);
+      assert.equal(detailBody.status, 'problematic_skipped');
+    });
+
     test('should allow cursor pagination', async () => {
       for (let i = 1; i <= 10; i++) {
         const hex = i.toString(16).padStart(64, '0');


### PR DESCRIPTION
## Summary

Stacks 4.0 (Epoch 4.0 / pox-5) introduces a new transaction status: a transaction marked by a block's `problematic_txs` list is mined with status `problematic_skipped` — its payload is **not** executed, but the fee is still debited and the origin (and sponsor) nonces are still bumped (see SIP-044 and `make_new_block_txs_payload` in stacks-core).

Prior to this change, `getTxDbStatus` threw `Unexpected tx status` on any unrecognized status, which would 500 the `/new_block` event ingestion endpoint and **halt API ingestion entirely** (the node blocks and retries the same block indefinitely) the moment the first `problematic_skipped` transaction appears in a canonical block.

## Changes

- Add `DbTxStatus.ProblematicSkipped = -3` (mined, non-success status).
- Map `problematic_skipped` from `/new_block` payloads in `getTxDbStatus` instead of throwing.
- Return `problematic_skipped` in v1 (`tx_status`) and v3 (transaction summary `status`) responses; added to the corresponding TypeBox schema unions and the v3 serializer.
- Regenerate `client/src/generated/schema.d.ts`.
- Upgrade `@stacks/node-publisher-client` to `2.3.0`, which adds the status to `NewBlockTransactionStatus` and the optional `problematic_skipped` category field to `NewBlockTransaction` (stx-labs/stacks-node-publisher#64).

## Notes

- Event processing needs no changes: the event server already skips events for non-`Success` transactions, and the node emits no events for skipped transactions. Fee/nonce accounting matches the existing abort statuses, so balances and nonces are correct as-is.
- The `problematic_skipped` category byte (u8) from the node payload is intentionally **not** stored — that would require a `txs` migration; can be added later if we want to expose the category.

## Testing

- New test `tx store and processing - problematic_skipped`: ingests a core message with the new status, asserts the DB mapping and the `/extended/v1/tx/{txid}` response.
- Full `tx.test.ts` suite passes (44/44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)