### PR TITLE
feat: add signer_manager to PoX cycle signer endpoints

### DIFF
--- a/migrations/1779800000008_staking-signers-signer-key-index.ts
+++ b/migrations/1779800000008_staking-signers-signer-key-index.ts
@@ -3,11 +3,10 @@ import type { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
 export const shorthands: ColumnDefinitions | undefined = undefined;
 
 /**
- * Backs the signing-key → signer-manager lookup used by the PoX cycle signer
- * endpoints (`/extended/v2/pox/cycles/{cycle}/signers*`), which resolve each
- * `pox_sets.signing_key` to its registered signer-manager contract. Ordered by
- * `block_height DESC` so the latest registration wins when the same key was
- * registered by more than one signer principal.
+ * Backs the signing-key → signer-manager lookup used by the PoX cycle signer endpoints
+ * (`/extended/v2/pox/cycles/{cycle}/signers*`), which resolve each `pox_sets.signing_key` to its
+ * registered signer-manager contract. Ordered by `block_height DESC` so the latest registration
+ * wins when the same key was registered by more than one signer principal.
  */
 export function up(pgm: MigrationBuilder): void {
   pgm.createIndex('staking_signers', ['signer_key', { name: 'block_height', sort: 'DESC' }], {

--- a/migrations/1779800000008_staking-signers-signer-key-index.ts
+++ b/migrations/1779800000008_staking-signers-signer-key-index.ts
@@ -1,0 +1,22 @@
+import type { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+/**
+ * Backs the signing-key → signer-manager lookup used by the PoX cycle signer
+ * endpoints (`/extended/v2/pox/cycles/{cycle}/signers*`), which resolve each
+ * `pox_sets.signing_key` to its registered signer-manager contract. Ordered by
+ * `block_height DESC` so the latest registration wins when the same key was
+ * registered by more than one signer principal.
+ */
+export function up(pgm: MigrationBuilder): void {
+  pgm.createIndex('staking_signers', ['signer_key', { name: 'block_height', sort: 'DESC' }], {
+    name: 'staking_signers_signer_key_block_height_idx',
+  });
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropIndex('staking_signers', ['signer_key', 'block_height'], {
+    name: 'staking_signers_signer_key_block_height_idx',
+  });
+}

--- a/src/api/routes/v2/helpers.ts
+++ b/src/api/routes/v2/helpers.ts
@@ -198,6 +198,7 @@ export function parseDbPoxSigner(signer: DbPoxCycleSigner, isMainnet: boolean): 
   const result: PoxSigner = {
     signing_key: signer.signing_key,
     signer_address: signerAddress,
+    signer_manager: signer.signer_manager,
     weight: signer.weight,
     stacked_amount: signer.stacked_amount,
     weight_percent: signer.weight_percent,

--- a/src/api/schemas/v1/entities/pox.ts
+++ b/src/api/schemas/v1/entities/pox.ts
@@ -1,4 +1,5 @@
 import { Static, Type } from '@sinclair/typebox';
+import { SmartContractIdParamSchema } from '../params.js';
 
 export const PoolDelegationSchema = Type.Object({
   stacker: Type.String({
@@ -39,6 +40,10 @@ export type PoxCycle = Static<typeof PoxCycleSchema>;
 export const PoxSignerSchema = Type.Object({
   signing_key: Type.String(),
   signer_address: Type.String({ description: 'The Stacks address derived from the signing_key.' }),
+  signer_manager: Type.Union([SmartContractIdParamSchema, Type.Null()], {
+    description:
+      'The principal of the signer manager contract that registered this signing key, or null if the key has no registration.',
+  }),
   weight: Type.Integer(),
   stacked_amount: Type.String(),
   weight_percent: Type.Number(),

--- a/src/api/schemas/v1/params.ts
+++ b/src/api/schemas/v1/params.ts
@@ -88,7 +88,7 @@ export const BurnchainAddressParamSchema = Type.String({
   examples: ['bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq'],
 });
 
-const SmartContractIdParamSchema = Type.String({
+export const SmartContractIdParamSchema = Type.String({
   pattern: isTestEnv
     ? undefined
     : '^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39}$',

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -966,6 +966,7 @@ export interface DbPoxCycle {
 
 export interface DbPoxCycleSigner {
   signing_key: string;
+  signer_manager: string | null;
   weight: number;
   stacked_amount: string;
   weight_percent: number;

--- a/src/datastore/pg-store-v2.ts
+++ b/src/datastore/pg-store-v2.ts
@@ -879,6 +879,12 @@ export class PgStoreV2 extends BasePgStoreModule {
         )
         SELECT
             ps.signing_key,
+            (
+                SELECT signer FROM staking_signers
+                WHERE signer_key = ps.signing_key
+                ORDER BY block_height DESC
+                LIMIT 1
+            ) AS signer_manager,
             ps.weight,
             ps.stacked_amount,
             ps.weight_percent,
@@ -949,6 +955,12 @@ export class PgStoreV2 extends BasePgStoreModule {
         )
         SELECT
             ps.signing_key,
+            (
+                SELECT signer FROM staking_signers
+                WHERE signer_key = ps.signing_key
+                ORDER BY block_height DESC
+                LIMIT 1
+            ) AS signer_manager,
             ps.weight,
             ps.stacked_amount,
             ps.weight_percent,

--- a/src/datastore/pg-store-v2.ts
+++ b/src/datastore/pg-store-v2.ts
@@ -880,9 +880,11 @@ export class PgStoreV2 extends BasePgStoreModule {
         SELECT
             ps.signing_key,
             (
-                SELECT signer FROM staking_signers
-                WHERE signer_key = ps.signing_key
-                ORDER BY block_height DESC
+                SELECT s.signer FROM staking_signers s
+                INNER JOIN txs t ON t.tx_id = s.tx_id
+                    AND t.canonical = TRUE AND t.microblock_canonical = TRUE
+                WHERE s.signer_key = ps.signing_key
+                ORDER BY s.block_height DESC, t.microblock_sequence DESC, t.tx_index DESC
                 LIMIT 1
             ) AS signer_manager,
             ps.weight,
@@ -956,9 +958,11 @@ export class PgStoreV2 extends BasePgStoreModule {
         SELECT
             ps.signing_key,
             (
-                SELECT signer FROM staking_signers
-                WHERE signer_key = ps.signing_key
-                ORDER BY block_height DESC
+                SELECT s.signer FROM staking_signers s
+                INNER JOIN txs t ON t.tx_id = s.tx_id
+                    AND t.canonical = TRUE AND t.microblock_canonical = TRUE
+                WHERE s.signer_key = ps.signing_key
+                ORDER BY s.block_height DESC, t.microblock_sequence DESC, t.tx_index DESC
                 LIMIT 1
             ) AS signer_manager,
             ps.weight,

--- a/tests/api/event-server/pox.test.ts
+++ b/tests/api/event-server/pox.test.ts
@@ -54,13 +54,20 @@ describe('PoX tests', () => {
     );
     // Register a signer-manager contract for one of the cycle's signing keys so
     // the signer endpoints surface it (the other keys stay unregistered/null).
+    // The registration must point at a canonical tx for its block position.
+    const [{ tx_id: registerTxId }] = await client<{ tx_id: string }[]>`
+      SELECT tx_id FROM txs
+      WHERE canonical = true AND microblock_canonical = true
+      ORDER BY block_height ASC, tx_index ASC
+      LIMIT 1
+    `;
     const signerManager = 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP.signer-manager';
     await client`
       INSERT INTO staking_signers (signer, signer_key, tx_id, block_height, burn_block_height)
       VALUES (
         ${signerManager},
         ${'0x038e3c4529395611be9abf6fa3b6987e81d402385e3d605a073f42f407565a4a3d'},
-        ${'0x' + 'ff'.repeat(32)},
+        ${registerTxId},
         1,
         1
       )

--- a/tests/api/event-server/pox.test.ts
+++ b/tests/api/event-server/pox.test.ts
@@ -52,6 +52,19 @@ describe('PoX tests', () => {
       true,
       true
     );
+    // Register a signer-manager contract for one of the cycle's signing keys so
+    // the signer endpoints surface it (the other keys stay unregistered/null).
+    const signerManager = 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP.signer-manager';
+    await client`
+      INSERT INTO staking_signers (signer, signer_key, tx_id, block_height, burn_block_height)
+      VALUES (
+        ${signerManager},
+        ${'0x038e3c4529395611be9abf6fa3b6987e81d402385e3d605a073f42f407565a4a3d'},
+        ${'0x' + 'ff'.repeat(32)},
+        1,
+        1
+      )
+    `;
     const cycles = await supertest(api.server).get(`/extended/v2/pox/cycles`);
     assert.equal(cycles.status, 200);
     assert.equal(cycles.type, 'application/json');
@@ -115,6 +128,7 @@ describe('PoX tests', () => {
         {
           signing_key: '0x038e3c4529395611be9abf6fa3b6987e81d402385e3d605a073f42f407565a4a3d',
           signer_address: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
+          signer_manager: signerManager,
           stacked_amount: '686251350000000000',
           stacked_amount_percent: 50,
           weight: 5,
@@ -125,6 +139,7 @@ describe('PoX tests', () => {
         {
           signing_key: '0x029874497a7952483aa23890e9d0898696f33864d3df90939930a1f45421fe3b09',
           signer_address: 'STF9B75ADQAVXQHNEQ6KGHXTG7JP305J2GRWF3A2',
+          signer_manager: null,
           stacked_amount: '457500900000000000',
           stacked_amount_percent: 33.333333333333336,
           weight: 3,
@@ -135,6 +150,7 @@ describe('PoX tests', () => {
         {
           signing_key: '0x02dcde79b38787b72d8e5e0af81cffa802f0a3c8452d6b46e08859165f49a72736',
           signer_address: 'ST18MDW2PDTBSCR1ACXYRJP2JX70FWNM6YY2VX4SS',
+          signer_manager: null,
           stacked_amount: '228750450000000000',
           stacked_amount_percent: 16.666666666666668,
           weight: 1,
@@ -153,6 +169,7 @@ describe('PoX tests', () => {
     assert.deepEqual(JSON.parse(signer.text), {
       signing_key: '0x038e3c4529395611be9abf6fa3b6987e81d402385e3d605a073f42f407565a4a3d',
       signer_address: 'STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP',
+      signer_manager: signerManager,
       stacked_amount: '686251350000000000',
       stacked_amount_percent: 50,
       weight: 5,
@@ -271,6 +288,7 @@ describe('PoX tests', () => {
           {
             signing_key: '0x028efa20fa5706567008ebaf48f7ae891342eeb944d96392f719c505c89f84ed8d',
             signer_address: 'ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0',
+            signer_manager: null,
             stacked_amount: '7500510000000000',
             stacked_amount_percent: 42.857142857142854,
             weight: 9,
@@ -281,6 +299,7 @@ describe('PoX tests', () => {
           {
             signing_key: '0x023f19d77c842b675bd8c858e9ac8b0ca2efa566f17accf8ef9ceb5a992dc67836',
             signer_address: 'ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ',
+            signer_manager: null,
             stacked_amount: '5000340000000000',
             stacked_amount_percent: 28.571428571428573,
             weight: 6,
@@ -292,6 +311,7 @@ describe('PoX tests', () => {
             // steph doubled the weight of this signer
             signing_key: '0x029fb154a570a1645af3dd43c3c668a979b59d21a46dd717fd799b13be3b2a0dc7',
             signer_address: 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP',
+            signer_manager: null,
             stacked_amount: '5000340000000000',
             stacked_amount_percent: 28.571428571428573,
             weight: 6,
@@ -311,6 +331,7 @@ describe('PoX tests', () => {
       assert.deepEqual(JSON.parse(signer.text), {
         signing_key: '0x029fb154a570a1645af3dd43c3c668a979b59d21a46dd717fd799b13be3b2a0dc7',
         signer_address: 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP',
+        signer_manager: null,
         stacked_amount: '5000340000000000',
         stacked_amount_percent: 28.571428571428573,
         weight: 6,


### PR DESCRIPTION
Adds a `signer_manager` field to the signer entries returned by the PoX cycle endpoints:

- `GET /extended/v2/pox/cycles/:cycle_number/signers`
- `GET /extended/v2/pox/cycles/:cycle_number/signers/:signer_key`

The field contains the principal of the signer manager contract that registered the entry's signing key via pox-5 `register-signer` (e.g. `SP...ADDR.signer-manager`), or `null` if the key has no registration.

```json
{
  "signing_key": "0x038e3c4529395611be9abf6fa3b6987e81d402385e3d605a073f42f407565a4a3d",
  "signer_address": "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP",
  "signer_manager": "STRYYQQ9M8KAF4NS7WNZQYY59X93XEKR31JP64CP.signer-manager",
  "weight": 5,
  "stacked_amount": "686251350000000000",
  "weight_percent": 55.55,
  "stacked_amount_percent": 50,
  "solo_stacker_count": 1,
  "pooled_stacker_count": 0
}
```