### PR TITLE
feat: cycle signers endpoint with signer manager key bindings

### DIFF
--- a/migrations/1779800000008_signer-key-grants.ts
+++ b/migrations/1779800000008_signer-key-grants.ts
@@ -4,12 +4,12 @@ export const shorthands: ColumnDefinitions | undefined = undefined;
 
 /**
  * Append-only history of pox-5 signer key bindings: one row per `register-signer`,
- * `grant-signer-key`, or `revoke-signer-grant` event. Unlike the latest-wins `staking_signers`
- * registry, this table preserves the full timeline so key bindings can be resolved *as of a PoX
- * cycle*: a binding is effective for cycle N if it landed strictly before cycle N's anchor block
- * (the block that computed the cycle's reward set, recorded in `pox_cycles`), which encodes the
- * contract rule that key changes made before the prepare phase apply next cycle and later ones the
- * cycle after. Pure event log with no derived totals — reorgs only flip the canonical flag.
+ * `grant-signer-key`, or `revoke-signer-grant` event. This table preserves the full timeline so key
+ * bindings can be resolved *as of a PoX cycle*: a binding is effective for cycle N if it landed
+ * strictly before cycle N's anchor block (the block that computed the cycle's reward set, recorded
+ * in `pox_cycles`), which encodes the contract rule that key changes made before the prepare phase
+ * apply next cycle and later ones the cycle after. Pure event log with no derived totals — reorgs
+ * only flip the canonical flag.
  */
 export function up(pgm: MigrationBuilder): void {
   pgm.createTable('signer_key_grants', {

--- a/migrations/1779800000008_signer-key-grants.ts
+++ b/migrations/1779800000008_signer-key-grants.ts
@@ -1,0 +1,159 @@
+import type { ColumnDefinitions, MigrationBuilder } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+/**
+ * Append-only history of pox-5 signer key bindings: one row per `register-signer`,
+ * `grant-signer-key`, or `revoke-signer-grant` event. Unlike the latest-wins `staking_signers`
+ * registry, this table preserves the full timeline so key bindings can be resolved *as of a PoX
+ * cycle*: a binding is effective for cycle N if it landed strictly before cycle N's anchor block
+ * (the block that computed the cycle's reward set, recorded in `pox_cycles`), which encodes the
+ * contract rule that key changes made before the prepare phase apply next cycle and later ones the
+ * cycle after. Pure event log with no derived totals — reorgs only flip the canonical flag.
+ */
+export function up(pgm: MigrationBuilder): void {
+  pgm.createTable('signer_key_grants', {
+    id: {
+      type: 'bigserial',
+      primaryKey: true,
+    },
+    // The source event, as `DbSignerKeyGrantKind`: 0 = register-signer, 1 = grant-signer-key, 2 =
+    // revoke-signer-grant.
+    kind: {
+      type: 'smallint',
+      notNull: true,
+    },
+    // The signer manager contract principal the key is bound to (the event's `signer_manager`, or
+    // `signer` for register-signer).
+    signer_manager: {
+      type: 'text',
+      notNull: true,
+    },
+    // The compressed secp256k1 public key (33 bytes).
+    signer_key: {
+      type: 'bytea',
+      notNull: true,
+    },
+    // The grant's auth id; null for registers and revokes.
+    auth_id: {
+      type: 'numeric',
+    },
+    event_index: {
+      type: 'integer',
+      notNull: true,
+    },
+    tx_id: {
+      type: 'bytea',
+      notNull: true,
+    },
+    tx_index: {
+      type: 'smallint',
+      notNull: true,
+    },
+    block_height: {
+      type: 'integer',
+      notNull: true,
+    },
+    block_hash: {
+      type: 'bytea',
+    },
+    block_time: {
+      type: 'bigint',
+    },
+    index_block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    parent_block_hash: {
+      type: 'bytea',
+    },
+    parent_index_block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    burn_block_height: {
+      type: 'integer',
+    },
+    burn_block_time: {
+      type: 'bigint',
+    },
+    microblock_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    microblock_sequence: {
+      type: 'integer',
+      notNull: true,
+    },
+    microblock_canonical: {
+      type: 'boolean',
+      notNull: true,
+    },
+    canonical: {
+      type: 'boolean',
+      notNull: true,
+    },
+  });
+
+  pgm.createIndex('signer_key_grants', 'tx_id');
+  pgm.createIndex('signer_key_grants', ['index_block_hash', 'canonical']);
+  // Latest-binding-per-pair resolution, both by key (cycle signer join) and by manager (pending key
+  // updates), always position-ordered and canonical-only.
+  pgm.createIndex(
+    'signer_key_grants',
+    [
+      'signer_key',
+      { name: 'block_height', sort: 'DESC' },
+      { name: 'microblock_sequence', sort: 'DESC' },
+      { name: 'tx_index', sort: 'DESC' },
+      { name: 'event_index', sort: 'DESC' },
+    ],
+    {
+      name: 'signer_key_grants_signer_key_idx',
+      where: 'canonical = TRUE AND microblock_canonical = TRUE',
+    }
+  );
+  pgm.createIndex(
+    'signer_key_grants',
+    [
+      'signer_manager',
+      { name: 'block_height', sort: 'DESC' },
+      { name: 'microblock_sequence', sort: 'DESC' },
+      { name: 'tx_index', sort: 'DESC' },
+      { name: 'event_index', sort: 'DESC' },
+    ],
+    {
+      name: 'signer_key_grants_signer_manager_idx',
+      where: 'canonical = TRUE AND microblock_canonical = TRUE',
+    }
+  );
+
+  // Backfill from the raw pox-5 event log.
+  pgm.sql(`
+    INSERT INTO signer_key_grants (
+      kind, signer_manager, signer_key, auth_id, event_index, tx_id, tx_index,
+      block_height, block_hash, block_time, index_block_hash, parent_block_hash,
+      parent_index_block_hash, burn_block_height, burn_block_time, microblock_hash,
+      microblock_sequence, microblock_canonical, canonical
+    )
+    SELECT
+      CASE name
+        WHEN 'register-signer' THEN 0
+        WHEN 'grant-signer-key' THEN 1
+        ELSE 2
+      END,
+      COALESCE(data->>'signer_manager', data->>'signer'),
+      decode(substr(data->>'signer_key', 3), 'hex'),
+      (data->>'auth_id')::numeric,
+      event_index, tx_id, tx_index,
+      block_height, block_hash, block_time, index_block_hash, parent_block_hash,
+      parent_index_block_hash, burn_block_height, burn_block_time, microblock_hash,
+      microblock_sequence, microblock_canonical, canonical
+    FROM pox5_events
+    WHERE name IN ('register-signer', 'grant-signer-key', 'revoke-signer-grant')
+  `);
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropTable('signer_key_grants');
+}

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -54,6 +54,7 @@ import { TransactionsRoutes } from './routes/v3/transactions.js';
 import { MempoolRoutes } from './routes/v3/mempool.js';
 import { BlocksRoutes } from './routes/v3/blocks.js';
 import { StakingBondsRoutes } from './routes/v3/staking-bonds.js';
+import { StakingCyclesRoutes } from './routes/v3/staking-cycles.js';
 import { StakingSignersRoutes } from './routes/v3/staking-signers.js';
 
 export interface ApiServer {
@@ -111,6 +112,7 @@ export const StacksApiRoutes: FastifyPluginAsync<
       await fastify.register(MempoolRoutes);
       await fastify.register(PrincipalsRoutes);
       await fastify.register(StakingBondsRoutes);
+      await fastify.register(StakingCyclesRoutes);
       await fastify.register(StakingSignersRoutes);
       await fastify.register(TransactionsRoutes);
     },

--- a/src/api/routes/v3/staking-cycles.ts
+++ b/src/api/routes/v3/staking-cycles.ts
@@ -10,7 +10,7 @@ import {
 } from '../../schemas/v3/cursors.js';
 import { CycleSignerSchema } from '../../schemas/v3/entities/staking-cycles.js';
 import { serializeDbCycleSigner } from '../../serializers/v3/staking-cycles.js';
-import { NotFoundError } from '../../../errors.js';
+import { InvalidRequestError, NotFoundError } from '../../../errors.js';
 
 export const StakingCyclesRoutes: FastifyPluginAsync<
   Record<never, never>,
@@ -44,23 +44,30 @@ export const StakingCyclesRoutes: FastifyPluginAsync<
       },
     },
     async (req, reply) => {
-      const results = await fastify.db.v3.getCurrentCycleSigners({
-        limit: req.query.limit ?? getPagingQueryLimit(ResourceType.Signer),
-        cursor: req.query.cursor,
-      });
-      if (!results) {
-        throw new NotFoundError('No PoX cycles found');
+      try {
+        const results = await fastify.db.v3.getCurrentCycleSigners({
+          limit: req.query.limit ?? getPagingQueryLimit(ResourceType.Signer),
+          cursor: req.query.cursor,
+        });
+        if (!results) {
+          throw new NotFoundError('No PoX cycles found');
+        }
+        await reply.send({
+          limit: results.limit,
+          total: results.total,
+          cursor: {
+            next: results.next_cursor,
+            previous: results.prev_cursor,
+            current: results.current_cursor,
+          },
+          results: results.results.map(r => serializeDbCycleSigner(r, results.cycle_number)),
+        });
+      } catch (error) {
+        if (error instanceof InvalidRequestError) {
+          throw new NotFoundError('Cursor not found');
+        }
+        throw error;
       }
-      await reply.send({
-        limit: results.limit,
-        total: results.total,
-        cursor: {
-          next: results.next_cursor,
-          previous: results.prev_cursor,
-          current: results.current_cursor,
-        },
-        results: results.results.map(r => serializeDbCycleSigner(r, results.cycle_number)),
-      });
     }
   );
 

--- a/src/api/routes/v3/staking-cycles.ts
+++ b/src/api/routes/v3/staking-cycles.ts
@@ -1,0 +1,68 @@
+import { FastifyPluginAsync } from 'fastify';
+import { Server } from 'node:http';
+import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+import { handleChainTipCache } from '../../controllers/cache-controller.js';
+import { getPagingQueryLimit, ResourceType } from '../../pagination.js';
+import {
+  CursorPaginatedResponse,
+  CursorPaginationQuerystring,
+  SigningKeyCursorSchema,
+} from '../../schemas/v3/cursors.js';
+import { CycleSignerSchema } from '../../schemas/v3/entities/staking-cycles.js';
+import { serializeDbCycleSigner } from '../../serializers/v3/staking-cycles.js';
+import { NotFoundError } from '../../../errors.js';
+
+export const StakingCyclesRoutes: FastifyPluginAsync<
+  Record<never, never>,
+  Server,
+  TypeBoxTypeProvider
+> = async fastify => {
+  fastify.get(
+    '/staking/cycles/:cycle_number/signers',
+    {
+      preHandler: handleChainTipCache,
+      schema: {
+        operationId: 'get_cycle_signers',
+        summary: 'Get cycle signers',
+        description:
+          "Get the signer set of a PoX cycle, including each signer's weight, stacked amount, and the signer manager contracts whose key bindings were effective when the cycle's reward set was calculated. Key bindings changed after that point are surfaced as pending updates that take effect next cycle. Currently only `current` is supported as the cycle number — the latest cycle with a computed reward set.",
+        tags: ['Staking'],
+        params: Type.Object({
+          cycle_number: Type.Literal('current', {
+            description:
+              'The PoX cycle to fetch signers for. Only `current` is supported at the moment.',
+          }),
+        }),
+        querystring: CursorPaginationQuerystring(SigningKeyCursorSchema, ResourceType.Signer),
+        response: {
+          200: CursorPaginatedResponse(
+            CycleSignerSchema,
+            SigningKeyCursorSchema,
+            ResourceType.Signer
+          ),
+        },
+      },
+    },
+    async (req, reply) => {
+      const results = await fastify.db.v3.getCurrentCycleSigners({
+        limit: req.query.limit ?? getPagingQueryLimit(ResourceType.Signer),
+        cursor: req.query.cursor,
+      });
+      if (!results) {
+        throw new NotFoundError('No PoX cycles found');
+      }
+      await reply.send({
+        limit: results.limit,
+        total: results.total,
+        cursor: {
+          next: results.next_cursor,
+          previous: results.prev_cursor,
+          current: results.current_cursor,
+        },
+        results: results.results.map(r => serializeDbCycleSigner(r, results.cycle_number)),
+      });
+    }
+  );
+
+  await Promise.resolve();
+};

--- a/src/api/routes/v3/staking-cycles.ts
+++ b/src/api/routes/v3/staking-cycles.ts
@@ -25,7 +25,7 @@ export const StakingCyclesRoutes: FastifyPluginAsync<
         operationId: 'get_cycle_signers',
         summary: 'Get cycle signers',
         description:
-          "Get the signer set of a PoX cycle, including each signer's weight, stacked amount, and the signer manager contracts whose key bindings were effective when the cycle's reward set was calculated. Key bindings changed after that point are surfaced as pending updates that take effect next cycle. Currently only `current` is supported as the cycle number — the latest cycle with a computed reward set.",
+          "Get the signer set of a PoX cycle, including each signer's weight, stacked amount, and the signer manager contracts whose key bindings were effective when the cycle's reward set was calculated. Key bindings changed after that point are surfaced as pending updates that take effect next cycle.",
         tags: ['Staking'],
         params: Type.Object({
           cycle_number: Type.Literal('current', {

--- a/src/api/routes/v3/staking-cycles.ts
+++ b/src/api/routes/v3/staking-cycles.ts
@@ -25,7 +25,7 @@ export const StakingCyclesRoutes: FastifyPluginAsync<
         operationId: 'get_cycle_signers',
         summary: 'Get cycle signers',
         description:
-          "Get the signer set of a PoX cycle, including each signer's weight, stacked amount, and the signer manager contracts whose key bindings were effective when the cycle's reward set was calculated. Key bindings changed after that point are surfaced as pending updates that take effect next cycle.",
+          "Get the signer set of a PoX cycle, including each signer's weight, staked amount, and the signer manager contracts whose registered signing key (via `register-signer`) was this key when the cycle's reward set was calculated. Each manager also lists its live `grant-signer-key` authorizations, and keys registered after the reward set was calculated are surfaced as pending updates that take effect next cycle.",
         tags: ['Staking'],
         params: Type.Object({
           cycle_number: Type.Literal('current', {

--- a/src/api/routes/v3/staking-signers.ts
+++ b/src/api/routes/v3/staking-signers.ts
@@ -34,7 +34,8 @@ export const StakingSignersRoutes: FastifyPluginAsync<
       schema: {
         operationId: 'get_staking_signers',
         summary: 'Get staking signers',
-        description: 'Get the registered pox-5 staking signers and their current signing keys.',
+        description:
+          "Get the all-time registry of pox-5 staking signers: every signer principal that has ever registered a signer key, with its most recently registered key. Registrants are never removed from this registry, even if they are no longer part of the current cycle's signer set.",
         tags: ['Staking'],
         querystring: CursorPaginationQuerystring(SignerCursorSchema, ResourceType.Signer),
         response: {

--- a/src/api/schemas/v3/cursors.ts
+++ b/src/api/schemas/v3/cursors.ts
@@ -99,6 +99,13 @@ export const SignerCursorSchema = Type.String({
 });
 export type SignerCursor = Static<typeof SignerCursorSchema>;
 
+export const SigningKeyCursorSchema = Type.String({
+  pattern: '^(0x)?[0-9a-fA-F]{66}$',
+  description:
+    "Cursor for paginating a cycle's signers (sorted by weight descending, then signing key). Format: signing key",
+});
+export type SigningKeyCursor = Static<typeof SigningKeyCursorSchema>;
+
 export const StakerCursorSchema = Type.String({
   // A Stacks principal: a standard address, optionally followed by a contract name.
   pattern: '^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{28,41}(\\.[a-zA-Z]([a-zA-Z0-9]|[-_]){0,39})?$',

--- a/src/api/schemas/v3/entities/staking-cycles.ts
+++ b/src/api/schemas/v3/entities/staking-cycles.ts
@@ -2,33 +2,49 @@ import { Static, Type } from '@sinclair/typebox';
 import { Nullable } from '../../v1/util.js';
 import { PrincipalSchema, TransactionIdSchema } from './common.js';
 
-/** A signer manager contract whose key binding is effective for the cycle. */
+/** A live `grant-signer-key` authorization held by a signer manager. */
+export const SignerKeyGrantSchema = Type.Object(
+  {
+    signer_key: Type.String({
+      description: 'The granted signing key, as a `0x`-prefixed hex string',
+    }),
+    auth_id: Type.String({
+      description: "The grant's auth id as a decimal string",
+    }),
+    tx_id: TransactionIdSchema,
+  },
+  { title: 'SignerKeyGrant' }
+);
+export type SignerKeyGrant = Static<typeof SignerKeyGrantSchema>;
+
+/** A signer manager contract whose registered key is effective for the cycle. */
 export const CycleSignerManagerSchema = Type.Object(
   {
     signer_manager: PrincipalSchema,
-    auth_id: Nullable(
-      Type.String({
-        description:
-          "The grant's auth id as a decimal string; null when the binding came from `register-signer` instead of `grant-signer-key`.",
-      })
-    ),
-    granted_at: Type.Object(
+    registered_at: Type.Object(
       {
         block_height: Type.Integer({
-          description: 'Stacks block height of the binding event',
+          description: 'Stacks block height of the `register-signer` event',
         }),
-        burn_block_height: Type.Integer({
-          description: 'Burn block height of the binding event',
+        bitcoin_block_height: Type.Integer({
+          description: 'Bitcoin block height of the `register-signer` event',
         }),
         tx_id: TransactionIdSchema,
       },
-      { description: 'The position of the event that bound this key to the manager.' }
+      {
+        description:
+          'The position of the `register-signer` event that bound this key to the manager.',
+      }
     ),
+    granted_keys: Type.Array(SignerKeyGrantSchema, {
+      description:
+        "The manager's live `grant-signer-key` authorizations (granted and not revoked). A grant authorizes a future `register-signer` for that key but does not rotate the key by itself.",
+    }),
     pending_key_update: Nullable(
       Type.Object(
         {
           signer_key: Type.String({
-            description: 'The newly bound signing key, as a `0x`-prefixed hex string',
+            description: 'The newly registered signing key, as a `0x`-prefixed hex string',
           }),
           effective_cycle: Type.Integer({
             description: 'The PoX cycle in which the new key takes effect',
@@ -37,7 +53,7 @@ export const CycleSignerManagerSchema = Type.Object(
         },
         {
           description:
-            "The manager's latest key binding made after this cycle's reward set was calculated, when it differs from the cycle's signing key. Takes effect next cycle.",
+            "The manager's latest key registered after this cycle's reward set was calculated, when it differs from the cycle's signing key. Takes effect next cycle.",
         }
       )
     ),
@@ -73,7 +89,7 @@ export const CycleSignerSchema = Type.Object(
     ),
     signer_managers: Type.Array(CycleSignerManagerSchema, {
       description:
-        "The signer manager contracts whose key bindings for this signing key were effective when the cycle's reward set was calculated.",
+        "The signer manager contracts whose registered signing key (via `register-signer`) was this key when the cycle's reward set was calculated.",
     }),
   },
   { title: 'CycleSigner' }

--- a/src/api/schemas/v3/entities/staking-cycles.ts
+++ b/src/api/schemas/v3/entities/staking-cycles.ts
@@ -62,14 +62,14 @@ export const CycleSignerSchema = Type.Object(
       },
       { description: "The signer's voting weight in the cycle" }
     ),
-    stacked_amount: Type.Object(
+    staked_stx: Type.Object(
       {
         amount: Type.String(),
         percent: Type.Number({
-          description: "Percentage of the cycle's total stacked amount",
+          description: "Percentage of the cycle's total staked STX",
         }),
       },
-      { description: 'The uSTX stacked behind this signer in the cycle' }
+      { description: 'The uSTX staked behind this signer in the cycle' }
     ),
     signer_managers: Type.Array(CycleSignerManagerSchema, {
       description:

--- a/src/api/schemas/v3/entities/staking-cycles.ts
+++ b/src/api/schemas/v3/entities/staking-cycles.ts
@@ -1,0 +1,80 @@
+import { Static, Type } from '@sinclair/typebox';
+import { Nullable } from '../../v1/util.js';
+import { PrincipalSchema, TransactionIdSchema } from './common.js';
+
+/** A signer manager contract whose key binding is effective for the cycle. */
+export const CycleSignerManagerSchema = Type.Object(
+  {
+    signer_manager: PrincipalSchema,
+    auth_id: Nullable(
+      Type.String({
+        description:
+          "The grant's auth id as a decimal string; null when the binding came from `register-signer` instead of `grant-signer-key`.",
+      })
+    ),
+    granted_at: Type.Object(
+      {
+        block_height: Type.Integer({
+          description: 'Stacks block height of the binding event',
+        }),
+        burn_block_height: Type.Integer({
+          description: 'Burn block height of the binding event',
+        }),
+        tx_id: TransactionIdSchema,
+      },
+      { description: 'The position of the event that bound this key to the manager.' }
+    ),
+    pending_key_update: Nullable(
+      Type.Object(
+        {
+          signer_key: Type.String({
+            description: 'The newly bound signing key, as a `0x`-prefixed hex string',
+          }),
+          effective_cycle: Type.Integer({
+            description: 'The PoX cycle in which the new key takes effect',
+          }),
+        },
+        {
+          description:
+            "The manager's latest key binding made after this cycle's reward set was calculated, when it differs from the cycle's signing key. Takes effect next cycle.",
+        }
+      )
+    ),
+  },
+  { title: 'CycleSignerManager' }
+);
+export type CycleSignerManager = Static<typeof CycleSignerManagerSchema>;
+
+/** A reward-set signer for a PoX cycle, with its effective signer manager bindings. */
+export const CycleSignerSchema = Type.Object(
+  {
+    signing_key: Type.String({
+      description: "The signing key in the cycle's reward set, as a `0x`-prefixed hex string",
+      examples: ['0x038e3c4529395611be9abf6fa3b6987e81d402385e3d605a073f42f407565a4a3d'],
+    }),
+    weight: Type.Object(
+      {
+        amount: Type.Integer(),
+        percent: Type.Number({
+          description: "Percentage of the cycle's total signer weight",
+        }),
+      },
+      { description: "The signer's voting weight in the cycle" }
+    ),
+    stacked_amount: Type.Object(
+      {
+        amount: Type.String(),
+        percent: Type.Number({
+          description: "Percentage of the cycle's total stacked amount",
+        }),
+      },
+      { description: 'The uSTX stacked behind this signer in the cycle' }
+    ),
+    signer_managers: Type.Array(CycleSignerManagerSchema, {
+      description:
+        "The signer manager contracts whose key bindings for this signing key were effective when the cycle's reward set was calculated. A key can be bound by more than one manager, in which case the signer's weight is the combined stake under them; empty if the key has no effective binding.",
+    }),
+  },
+  { title: 'CycleSigner' }
+);
+export type CycleSigner = Static<typeof CycleSignerSchema>;

--- a/src/api/schemas/v3/entities/staking-cycles.ts
+++ b/src/api/schemas/v3/entities/staking-cycles.ts
@@ -73,7 +73,7 @@ export const CycleSignerSchema = Type.Object(
     ),
     signer_managers: Type.Array(CycleSignerManagerSchema, {
       description:
-        "The signer manager contracts whose key bindings for this signing key were effective when the cycle's reward set was calculated. Every reward-set key has at least one effective binding — stake can only be committed under a bound key. A key can be bound by more than one manager, in which case the signer's weight is the combined stake under them.",
+        "The signer manager contracts whose key bindings for this signing key were effective when the cycle's reward set was calculated.",
     }),
   },
   { title: 'CycleSigner' }

--- a/src/api/schemas/v3/entities/staking-cycles.ts
+++ b/src/api/schemas/v3/entities/staking-cycles.ts
@@ -40,6 +40,10 @@ export const CycleSignerManagerSchema = Type.Object(
       description:
         "The manager's live `grant-signer-key` authorizations (granted and not revoked). A grant authorizes a future `register-signer` for that key but does not rotate the key by itself.",
     }),
+    grant_active: Type.Boolean({
+      description:
+        'Whether a live `grant-signer-key` authorization currently exists for the registered key.',
+    }),
     pending_key_update: Nullable(
       Type.Object(
         {

--- a/src/api/schemas/v3/entities/staking-cycles.ts
+++ b/src/api/schemas/v3/entities/staking-cycles.ts
@@ -33,6 +33,7 @@ export const CycleSignerManagerSchema = Type.Object(
           effective_cycle: Type.Integer({
             description: 'The PoX cycle in which the new key takes effect',
           }),
+          tx_id: TransactionIdSchema,
         },
         {
           description:
@@ -72,7 +73,7 @@ export const CycleSignerSchema = Type.Object(
     ),
     signer_managers: Type.Array(CycleSignerManagerSchema, {
       description:
-        "The signer manager contracts whose key bindings for this signing key were effective when the cycle's reward set was calculated. A key can be bound by more than one manager, in which case the signer's weight is the combined stake under them; empty if the key has no effective binding.",
+        "The signer manager contracts whose key bindings for this signing key were effective when the cycle's reward set was calculated. Every reward-set key has at least one effective binding — stake can only be committed under a bound key. A key can be bound by more than one manager, in which case the signer's weight is the combined stake under them.",
     }),
   },
   { title: 'CycleSigner' }

--- a/src/api/serializers/v3/staking-cycles.ts
+++ b/src/api/serializers/v3/staking-cycles.ts
@@ -14,13 +14,13 @@ export function serializeDbCycleSigner(signer: DbCycleSigner, cycleNumber: numbe
     },
     signer_managers: signer.signer_managers.map(m => ({
       signer_manager: m.signer_manager,
-      auth_id: m.auth_id,
-      granted_at: {
+      registered_at: {
         block_height: m.block_height,
-        burn_block_height: m.burn_block_height,
+        bitcoin_block_height: m.burn_block_height,
         tx_id: m.tx_id,
       },
-      // Bindings made after the cycle's anchor block take effect next cycle.
+      granted_keys: m.granted_keys,
+      // Keys registered after the cycle's anchor block take effect next cycle.
       pending_key_update:
         m.pending_signer_key && m.pending_tx_id
           ? {

--- a/src/api/serializers/v3/staking-cycles.ts
+++ b/src/api/serializers/v3/staking-cycles.ts
@@ -20,6 +20,9 @@ export function serializeDbCycleSigner(signer: DbCycleSigner, cycleNumber: numbe
         tx_id: m.tx_id,
       },
       granted_keys: m.granted_keys,
+      // The registration stays bound even if its grant is revoked; this flag surfaces whether the
+      // bound key's authorization is still live.
+      grant_active: m.granted_keys.some(g => g.signer_key === signer.signing_key),
       // Keys registered after the cycle's anchor block take effect next cycle.
       pending_key_update:
         m.pending_signer_key && m.pending_tx_id

--- a/src/api/serializers/v3/staking-cycles.ts
+++ b/src/api/serializers/v3/staking-cycles.ts
@@ -8,7 +8,7 @@ export function serializeDbCycleSigner(signer: DbCycleSigner, cycleNumber: numbe
       amount: signer.weight,
       percent: signer.weight_percent,
     },
-    stacked_amount: {
+    staked_stx: {
       amount: signer.stacked_amount,
       percent: signer.stacked_amount_percent,
     },

--- a/src/api/serializers/v3/staking-cycles.ts
+++ b/src/api/serializers/v3/staking-cycles.ts
@@ -21,9 +21,14 @@ export function serializeDbCycleSigner(signer: DbCycleSigner, cycleNumber: numbe
         tx_id: m.tx_id,
       },
       // Bindings made after the cycle's anchor block take effect next cycle.
-      pending_key_update: m.pending_signer_key
-        ? { signer_key: m.pending_signer_key, effective_cycle: cycleNumber + 1 }
-        : null,
+      pending_key_update:
+        m.pending_signer_key && m.pending_tx_id
+          ? {
+              signer_key: m.pending_signer_key,
+              effective_cycle: cycleNumber + 1,
+              tx_id: m.pending_tx_id,
+            }
+          : null,
     })),
   };
 }

--- a/src/api/serializers/v3/staking-cycles.ts
+++ b/src/api/serializers/v3/staking-cycles.ts
@@ -1,0 +1,29 @@
+import { DbCycleSigner } from '../../../datastore/v3/types.js';
+import { CycleSigner } from '../../schemas/v3/entities/staking-cycles.js';
+
+export function serializeDbCycleSigner(signer: DbCycleSigner, cycleNumber: number): CycleSigner {
+  return {
+    signing_key: signer.signing_key,
+    weight: {
+      amount: signer.weight,
+      percent: signer.weight_percent,
+    },
+    stacked_amount: {
+      amount: signer.stacked_amount,
+      percent: signer.stacked_amount_percent,
+    },
+    signer_managers: signer.signer_managers.map(m => ({
+      signer_manager: m.signer_manager,
+      auth_id: m.auth_id,
+      granted_at: {
+        block_height: m.block_height,
+        burn_block_height: m.burn_block_height,
+        tx_id: m.tx_id,
+      },
+      // Bindings made after the cycle's anchor block take effect next cycle.
+      pending_key_update: m.pending_signer_key
+        ? { signer_key: m.pending_signer_key, effective_cycle: cycleNumber + 1 }
+        : null,
+    })),
+  };
+}

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -215,9 +215,7 @@ export interface DbTx extends BaseTx {
   canonical: boolean;
 
   microblock_canonical: boolean;
-  // TODO(mb): should probably be (number | null) rather than -1 for batched tx
   microblock_sequence: number;
-  // TODO(mb): should probably be (string | null) rather than empty string for batched tx
   microblock_hash: string;
 
   post_conditions: string;
@@ -1782,6 +1780,30 @@ export interface DbPrincipalStxRewardDistributionInsertValues extends DbTxLocati
   principal: string;
   reward_cycle: number;
   reward_amount: string;
+}
+
+/** The pox-5 event a `signer_key_grants` row came from (`kind` smallint column). */
+export enum DbSignerKeyGrantKind {
+  /** `register-signer` */
+  Register = 0,
+  /** `grant-signer-key` */
+  Grant = 1,
+  /** `revoke-signer-grant` */
+  Revoke = 2,
+}
+
+/**
+ * Signer key binding history row, from a pox-5 `register-signer`,
+ * `grant-signer-key`, or `revoke-signer-grant` event. Append-only event log —
+ * key bindings are resolved as-of a cycle's anchor block at read time, so
+ * reorgs only flip the canonical flag.
+ */
+export interface DbSignerKeyGrantInsertValues extends DbTxLocation {
+  kind: DbSignerKeyGrantKind;
+  signer_manager: string;
+  signer_key: string;
+  auth_id: string | null;
+  event_index: number;
 }
 
 /**

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -1793,10 +1793,8 @@ export enum DbSignerKeyGrantKind {
 }
 
 /**
- * Signer key binding history row, from a pox-5 `register-signer`,
- * `grant-signer-key`, or `revoke-signer-grant` event. Append-only event log —
- * key bindings are resolved as-of a cycle's anchor block at read time, so
- * reorgs only flip the canonical flag.
+ * Signer key binding history row, from a pox-5 `register-signer`, `grant-signer-key`, or
+ * `revoke-signer-grant` event.
  */
 export interface DbSignerKeyGrantInsertValues extends DbTxLocation {
   kind: DbSignerKeyGrantKind;

--- a/src/datastore/pg-write-store.ts
+++ b/src/datastore/pg-write-store.ts
@@ -78,6 +78,8 @@ import {
   DbPrincipalBondRewardDistributionInsertValues,
   DbPrincipalBondRewardClaimInsertValues,
   DbPrincipalStxRewardDistributionInsertValues,
+  DbSignerKeyGrantInsertValues,
+  DbSignerKeyGrantKind,
   DbSignerRewardClaimInsertValues,
   PrincipalTxBalanceChangeInsertValues,
 } from './common.js';
@@ -127,9 +129,11 @@ import {
   Pox5EventCalculateRewards,
   Pox5EventClaimRewards,
   Pox5EventClaimStakerRewardsForSigner,
+  Pox5EventGrantSignerKey,
   Pox5EventName,
   Pox5EventRegisterForBond,
   Pox5EventRegisterSigner,
+  Pox5EventRevokeSignerGrant,
   Pox5EventSetupBond,
   Pox5EventStake,
   Pox5EventStakeUpdate,
@@ -613,11 +617,14 @@ export class PgWriteStore extends PgStore {
             break;
           case Pox5EventName.RegisterSigner:
             await this.upsertStakingSigner(sql, txLocation, poxEvent);
+            await this.insertSignerKeyGrant(sql, txLocation, poxEvent);
+            break;
+          case Pox5EventName.GrantSignerKey:
+          case Pox5EventName.RevokeSignerGrant:
+            await this.insertSignerKeyGrant(sql, txLocation, poxEvent);
             break;
           case Pox5EventName.AllowContractCaller:
           case Pox5EventName.DisallowContractCaller:
-          case Pox5EventName.GrantSignerKey:
-          case Pox5EventName.RevokeSignerGrant:
           case Pox5EventName.SetBondAdmin:
             // No-op
             break;
@@ -1172,6 +1179,37 @@ export class PgWriteStore extends PgStore {
         tx_id = EXCLUDED.tx_id,
         block_height = EXCLUDED.block_height,
         burn_block_height = EXCLUDED.burn_block_height
+    `;
+  }
+
+  /**
+   * Append a signer key binding event (pox-5 `register-signer`, `grant-signer-key`, or
+   * `revoke-signer-grant`) to the `signer_key_grants` history. Bindings are resolved against cycle
+   * anchor blocks at read time, so this is a plain insert with no derived state.
+   */
+  private async insertSignerKeyGrant(
+    sql: PgSqlClient,
+    txLocation: DbTxLocation,
+    event: (Pox5EventRegisterSigner | Pox5EventGrantSignerKey | Pox5EventRevokeSignerGrant) & {
+      event_index: number;
+    }
+  ) {
+    const grant: DbSignerKeyGrantInsertValues = {
+      ...txLocation,
+      kind:
+        event.name === Pox5EventName.RegisterSigner
+          ? DbSignerKeyGrantKind.Register
+          : event.name === Pox5EventName.GrantSignerKey
+            ? DbSignerKeyGrantKind.Grant
+            : DbSignerKeyGrantKind.Revoke,
+      signer_manager:
+        'signer_manager' in event.data ? event.data.signer_manager : event.data.signer,
+      signer_key: event.data.signer_key,
+      auth_id: 'auth_id' in event.data ? event.data.auth_id : null,
+      event_index: event.event_index,
+    };
+    await sql`
+      INSERT INTO signer_key_grants ${sql(grant)}
     `;
   }
 
@@ -4746,6 +4784,7 @@ export class PgWriteStore extends PgStore {
       'bond_reward_distributions',
       'bond_reward_calculations',
       'signer_reward_claims',
+      'signer_key_grants',
     ]) {
       q.enqueue(async () => {
         await sql`

--- a/src/datastore/v3/pg-store-v3.ts
+++ b/src/datastore/v3/pg-store-v3.ts
@@ -1701,7 +1701,7 @@ export class PgStoreV3 extends BasePgStoreModule {
             block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
         ), pending_bindings AS (
           SELECT DISTINCT ON (signer_manager)
-            signer_manager, signer_key
+            signer_manager, signer_key, tx_id
           FROM signer_key_grants
           WHERE canonical = TRUE AND microblock_canonical = TRUE
             AND block_height >= ${anchorHeight}
@@ -1735,6 +1735,10 @@ export class PgStoreV3 extends BasePgStoreModule {
               'pending_signer_key',
                 CASE WHEN pb.signer_key IS NOT NULL AND pb.signer_key != ps.signing_key
                   THEN concat('0x', encode(pb.signer_key, 'hex'))
+                END,
+              'pending_tx_id',
+                CASE WHEN pb.signer_key IS NOT NULL AND pb.signer_key != ps.signing_key
+                  THEN concat('0x', encode(pb.tx_id, 'hex'))
                 END
             ) ORDER BY eb.signer_manager)
             FROM effective_bindings eb

--- a/src/datastore/v3/pg-store-v3.ts
+++ b/src/datastore/v3/pg-store-v3.ts
@@ -1690,13 +1690,25 @@ export class PgStoreV3 extends BasePgStoreModule {
           : '0x' + args.cursor
         : undefined;
 
-      // Keyset filter: rows at or after the cursor row in (weight DESC, signing_key ASC) order. An
-      // unknown cursor key yields an empty page.
+      // Keyset filter: rows at or after the cursor row in (weight DESC, signing_key ASC) order.
+      // The cursor must be one of the cycle's signing keys — otherwise its weight is unknowable
+      // and the page would be silently empty.
+      let cursorWeight: number | undefined;
+      if (cursor) {
+        const [cursorRow] = await sql<{ weight: number }[]>`
+          SELECT weight FROM pox_sets
+          WHERE canonical = TRUE AND cycle_number = ${cycleNumber} AND signing_key = ${cursor}
+          LIMIT 1
+        `;
+        if (!cursorRow)
+          throw new InvalidRequestError('Cursor not found', InvalidRequestErrorType.invalid_param);
+        cursorWeight = cursorRow.weight;
+      }
       const cursorFilter = cursor
         ? sql`
           AND (
-            ps.weight < (SELECT weight FROM cursor_row)
-            OR (ps.weight = (SELECT weight FROM cursor_row) AND ps.signing_key >= ${cursor})
+            ps.weight < ${cursorWeight}
+            OR (ps.weight = ${cursorWeight} AND ps.signing_key >= ${cursor})
           )`
         : sql``;
 
@@ -1732,12 +1744,6 @@ export class PgStoreV3 extends BasePgStoreModule {
             AND kind IN (${DbSignerKeyGrantKind.Grant}, ${DbSignerKeyGrantKind.Revoke})
           ORDER BY signer_manager, signer_key,
             block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
-        ), cursor_row AS (
-          SELECT weight FROM pox_sets
-          WHERE canonical = TRUE
-            AND cycle_number = ${cycleNumber}
-            AND signing_key = ${cursor ?? null}
-          LIMIT 1
         )
         SELECT
           ps.signing_key,

--- a/src/datastore/v3/pg-store-v3.ts
+++ b/src/datastore/v3/pg-store-v3.ts
@@ -1717,6 +1717,13 @@ export class PgStoreV3 extends BasePgStoreModule {
       // there is no unregister, so revokes never participate. A post-anchor registration is a
       // pending key update. Grants/revokes only maintain the (key, manager) authorization map: the
       // latest grant/revoke per pair decides whether the grant is live.
+      //
+      // Deliberate trade-off: the CTEs resolve bindings for ALL managers once per request rather
+      // than only the page's — per-manager-latest semantics need each manager's full registration
+      // history, key rotation events are rare (the CTE inputs stay small indefinitely), and the
+      // chain-tip cache absorbs repeat hits. If `signer_key_grants` ever grows large, scope the
+      // scans per page row: candidate managers by `signer_key` index probe, then verify each
+      // candidate's latest registration via the `signer_manager` index.
       const resultQuery = await sql<(DbCycleSigner & { total: number })[]>`
         WITH effective_bindings AS (
           SELECT DISTINCT ON (signer_manager)

--- a/src/datastore/v3/pg-store-v3.ts
+++ b/src/datastore/v3/pg-store-v3.ts
@@ -6,6 +6,7 @@ import {
   DbBondRegistrationSummary,
   DbBondSummary,
   DbCursorPaginatedResult,
+  DbCycleSigner,
   DbMempoolTransaction,
   DbMempoolTransactionSummary,
   DbPrincipalBondPosition,
@@ -59,7 +60,7 @@ import {
   parseNftBalanceCursor,
   resolveTransactionCursor,
 } from './helpers.js';
-import { DbEventTypeId } from '../common.js';
+import { DbEventTypeId, DbSignerKeyGrantKind } from '../common.js';
 
 export class PgStoreV3 extends BasePgStoreModule {
   /**
@@ -1645,6 +1646,149 @@ export class PgStoreV3 extends BasePgStoreModule {
         current_cursor: currentCursor,
         total,
         results,
+      };
+    });
+  }
+
+  /**
+   * Gets the signer set of the current PoX cycle (the latest canonical cycle with a computed reward
+   * set) joined with the signer manager key bindings that were effective when the cycle's reward
+   * set was calculated. A binding (register/grant/revoke) is effective for the cycle if it landed
+   * strictly before the cycle's anchor block, which encodes the contract rule that key changes made
+   * before the prepare phase apply next cycle and later ones the cycle after. Bindings made at or
+   * after the anchor surface as pending key updates (effective next cycle).
+   *
+   * Keyset-paginated by weight descending, then signing key ascending, with the signing key as the
+   * cursor.
+   * @param args - The arguments for the query.
+   * @returns The cycle's signers, or null if no PoX cycle exists yet.
+   */
+  async getCurrentCycleSigners(args: {
+    limit: number;
+    cursor?: string;
+  }): Promise<(DbCursorPaginatedResult<DbCycleSigner> & { cycle_number: number }) | null> {
+    return await this.sqlTransaction(async sql => {
+      const [cycle] = await sql<{ cycle_number: number; block_height: number }[]>`
+        SELECT cycle_number, block_height
+        FROM pox_cycles
+        WHERE canonical = TRUE
+        ORDER BY cycle_number DESC
+        LIMIT 1
+      `;
+      if (!cycle) return null;
+      const cycleNumber = cycle.cycle_number;
+      const anchorHeight = cycle.block_height;
+
+      // Keyset filter: rows at or after the cursor row in (weight DESC, signing_key ASC) order. An
+      // unknown cursor key yields an empty page.
+      const cursorFilter = args.cursor
+        ? sql`
+          AND (
+            ps.weight < (SELECT weight FROM cursor_row)
+            OR (ps.weight = (SELECT weight FROM cursor_row) AND ps.signing_key >= ${args.cursor})
+          )`
+        : sql``;
+
+      const resultQuery = await sql<(DbCycleSigner & { total: number })[]>`
+        WITH effective_bindings AS (
+          SELECT DISTINCT ON (signer_manager, signer_key)
+            signer_manager, signer_key, kind, auth_id::text AS auth_id,
+            block_height, burn_block_height, tx_id
+          FROM signer_key_grants
+          WHERE canonical = TRUE AND microblock_canonical = TRUE
+            AND block_height < ${anchorHeight}
+          ORDER BY signer_manager, signer_key,
+            block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+        ), pending_bindings AS (
+          SELECT DISTINCT ON (signer_manager)
+            signer_manager, signer_key
+          FROM signer_key_grants
+          WHERE canonical = TRUE AND microblock_canonical = TRUE
+            AND block_height >= ${anchorHeight}
+            AND kind IN (${DbSignerKeyGrantKind.Register}, ${DbSignerKeyGrantKind.Grant})
+          ORDER BY signer_manager,
+            block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+        ), cursor_row AS (
+          SELECT weight FROM pox_sets
+          WHERE canonical = TRUE
+            AND cycle_number = ${cycleNumber}
+            AND signing_key = ${args.cursor ?? null}
+          LIMIT 1
+        )
+        SELECT
+          ps.signing_key,
+          ps.weight,
+          ps.stacked_amount,
+          ps.weight_percent,
+          ps.stacked_amount_percent,
+          (
+            SELECT COUNT(*)::int FROM pox_sets
+            WHERE canonical = TRUE AND cycle_number = ${cycleNumber}
+          ) AS total,
+          COALESCE((
+            SELECT json_agg(json_build_object(
+              'signer_manager', eb.signer_manager,
+              'auth_id', eb.auth_id,
+              'block_height', eb.block_height,
+              'burn_block_height', eb.burn_block_height,
+              'tx_id', concat('0x', encode(eb.tx_id, 'hex')),
+              'pending_signer_key',
+                CASE WHEN pb.signer_key IS NOT NULL AND pb.signer_key != ps.signing_key
+                  THEN concat('0x', encode(pb.signer_key, 'hex'))
+                END
+            ) ORDER BY eb.signer_manager)
+            FROM effective_bindings eb
+            LEFT JOIN pending_bindings pb ON pb.signer_manager = eb.signer_manager
+            WHERE eb.signer_key = ps.signing_key AND eb.kind != ${DbSignerKeyGrantKind.Revoke}
+          ), '[]'::json) AS signer_managers
+        FROM pox_sets ps
+        WHERE ps.canonical = TRUE AND ps.cycle_number = ${cycleNumber}
+          ${cursorFilter}
+        ORDER BY ps.weight DESC, ps.signing_key ASC
+        LIMIT ${args.limit + 1}
+      `;
+
+      const hasNextPage = resultQuery.count > args.limit;
+      const results = hasNextPage ? resultQuery.slice(0, args.limit) : [...resultQuery];
+      const total = resultQuery.count > 0 ? resultQuery[0].total : 0;
+
+      const nextResult = resultQuery[resultQuery.length - 1];
+      const nextCursor = hasNextPage && nextResult ? nextResult.signing_key : null;
+      const firstResult = results[0];
+      const currentCursor = firstResult ? firstResult.signing_key : null;
+
+      let prevCursor: string | null = null;
+      if (firstResult) {
+        const prevPageQuery = await sql<{ signing_key: string }[]>`
+          SELECT signing_key FROM pox_sets ps
+          WHERE ps.canonical = TRUE AND ps.cycle_number = ${cycleNumber}
+            AND (
+              ps.weight > ${firstResult.weight}
+              OR (ps.weight = ${firstResult.weight} AND ps.signing_key < ${firstResult.signing_key})
+            )
+          ORDER BY ps.weight ASC, ps.signing_key DESC
+          LIMIT ${args.limit}
+        `;
+        if (prevPageQuery.length > 0) {
+          prevCursor = prevPageQuery[prevPageQuery.length - 1].signing_key;
+        }
+      }
+
+      return {
+        limit: args.limit,
+        next_cursor: nextCursor,
+        prev_cursor: prevCursor,
+        current_cursor: currentCursor,
+        total,
+        cycle_number: cycleNumber,
+        results: results.map(r => ({
+          signing_key: r.signing_key,
+          weight: r.weight,
+          stacked_amount: r.stacked_amount,
+          weight_percent: r.weight_percent,
+          stacked_amount_percent: r.stacked_amount_percent,
+          signer_managers: r.signer_managers,
+        })),
       };
     });
   }

--- a/src/datastore/v3/pg-store-v3.ts
+++ b/src/datastore/v3/pg-store-v3.ts
@@ -1,4 +1,4 @@
-import { BasePgStoreModule } from '@stacks/api-toolkit';
+import { BasePgStoreModule, has0xPrefix } from '@stacks/api-toolkit';
 import {
   DbBond,
   DbBondAllowlistEntry,
@@ -1678,41 +1678,76 @@ export class PgStoreV3 extends BasePgStoreModule {
       if (!cycle) return null;
       const cycleNumber = cycle.cycle_number;
       const anchorHeight = cycle.block_height;
+      const cursor = args.cursor
+        ? has0xPrefix(args.cursor)
+          ? args.cursor
+          : '0x' + args.cursor
+        : undefined;
 
       // Keyset filter: rows at or after the cursor row in (weight DESC, signing_key ASC) order. An
       // unknown cursor key yields an empty page.
-      const cursorFilter = args.cursor
+      const cursorFilter = cursor
         ? sql`
           AND (
             ps.weight < (SELECT weight FROM cursor_row)
-            OR (ps.weight = (SELECT weight FROM cursor_row) AND ps.signing_key >= ${args.cursor})
+            OR (ps.weight = (SELECT weight FROM cursor_row) AND ps.signing_key >= ${cursor})
           )`
         : sql``;
 
+      // A manager's binding for the cycle is its latest register/grant strictly before the anchor,
+      // dropped if that same (manager, key) pair was revoked afterwards (still before the anchor).
+      // Registers and grants overwrite each other (a manager holds one current key); revoking a
+      // superseded key is a no-op. Pending bindings apply the same rule to the post-anchor window.
       const resultQuery = await sql<(DbCycleSigner & { total: number })[]>`
-        WITH effective_bindings AS (
-          SELECT DISTINCT ON (signer_manager, signer_key)
-            signer_manager, signer_key, kind, auth_id::text AS auth_id,
-            block_height, burn_block_height, tx_id
+        WITH latest_bindings AS (
+          SELECT DISTINCT ON (signer_manager)
+            signer_manager, signer_key, auth_id::text AS auth_id,
+            block_height, microblock_sequence, tx_index, event_index,
+            burn_block_height, tx_id
           FROM signer_key_grants
           WHERE canonical = TRUE AND microblock_canonical = TRUE
             AND block_height < ${anchorHeight}
-          ORDER BY signer_manager, signer_key,
+            AND kind IN (${DbSignerKeyGrantKind.Register}, ${DbSignerKeyGrantKind.Grant})
+          ORDER BY signer_manager,
             block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
-        ), pending_bindings AS (
+        ), effective_bindings AS (
+          SELECT lb.* FROM latest_bindings lb
+          WHERE NOT EXISTS (
+            SELECT 1 FROM signer_key_grants r
+            WHERE r.canonical = TRUE AND r.microblock_canonical = TRUE
+              AND r.kind = ${DbSignerKeyGrantKind.Revoke}
+              AND r.signer_manager = lb.signer_manager
+              AND r.signer_key = lb.signer_key
+              AND r.block_height < ${anchorHeight}
+              AND (r.block_height, r.microblock_sequence, r.tx_index, r.event_index)
+                > (lb.block_height, lb.microblock_sequence, lb.tx_index, lb.event_index)
+          )
+        ), pending_candidates AS (
           SELECT DISTINCT ON (signer_manager)
-            signer_manager, signer_key, tx_id
+            signer_manager, signer_key, tx_id,
+            block_height, microblock_sequence, tx_index, event_index
           FROM signer_key_grants
           WHERE canonical = TRUE AND microblock_canonical = TRUE
             AND block_height >= ${anchorHeight}
             AND kind IN (${DbSignerKeyGrantKind.Register}, ${DbSignerKeyGrantKind.Grant})
           ORDER BY signer_manager,
             block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+        ), pending_bindings AS (
+          SELECT pc.* FROM pending_candidates pc
+          WHERE NOT EXISTS (
+            SELECT 1 FROM signer_key_grants r
+            WHERE r.canonical = TRUE AND r.microblock_canonical = TRUE
+              AND r.kind = ${DbSignerKeyGrantKind.Revoke}
+              AND r.signer_manager = pc.signer_manager
+              AND r.signer_key = pc.signer_key
+              AND (r.block_height, r.microblock_sequence, r.tx_index, r.event_index)
+                > (pc.block_height, pc.microblock_sequence, pc.tx_index, pc.event_index)
+          )
         ), cursor_row AS (
           SELECT weight FROM pox_sets
           WHERE canonical = TRUE
             AND cycle_number = ${cycleNumber}
-            AND signing_key = ${args.cursor ?? null}
+            AND signing_key = ${cursor ?? null}
           LIMIT 1
         )
         SELECT
@@ -1743,7 +1778,7 @@ export class PgStoreV3 extends BasePgStoreModule {
             ) ORDER BY eb.signer_manager)
             FROM effective_bindings eb
             LEFT JOIN pending_bindings pb ON pb.signer_manager = eb.signer_manager
-            WHERE eb.signer_key = ps.signing_key AND eb.kind != ${DbSignerKeyGrantKind.Revoke}
+            WHERE eb.signer_key = ps.signing_key
           ), '[]'::json) AS signer_managers
         FROM pox_sets ps
         WHERE ps.canonical = TRUE AND ps.cycle_number = ${cycleNumber}

--- a/src/datastore/v3/pg-store-v3.ts
+++ b/src/datastore/v3/pg-store-v3.ts
@@ -1653,10 +1653,16 @@ export class PgStoreV3 extends BasePgStoreModule {
   /**
    * Gets the signer set of the current PoX cycle (the latest canonical cycle with a computed reward
    * set) joined with the signer manager key bindings that were effective when the cycle's reward
-   * set was calculated. A binding (register/grant/revoke) is effective for the cycle if it landed
+   * set was calculated.
+   *
+   * A manager's key binding lives in the contract's `signers` map, written only by
+   * `register-signer`, so a binding is effective for the cycle if its `register-signer` landed
    * strictly before the cycle's anchor block, which encodes the contract rule that key changes made
-   * before the prepare phase apply next cycle and later ones the cycle after. Bindings made at or
-   * after the anchor surface as pending key updates (effective next cycle).
+   * before the prepare phase apply next cycle and later ones the cycle after. Registrations made at
+   * or after the anchor surface as pending key updates (effective next cycle). `grant-signer-key` /
+   * `revoke-signer-grant` only maintain the `(key, manager)` authorization map — a grant authorizes
+   * a future registration but rotates nothing by itself — so live grants are surfaced separately
+   * per manager as `granted_keys`.
    *
    * Keyset-paginated by weight descending, then signing key ascending, with the signing key as the
    * cursor.
@@ -1694,55 +1700,38 @@ export class PgStoreV3 extends BasePgStoreModule {
           )`
         : sql``;
 
-      // A manager's binding for the cycle is its latest register/grant strictly before the anchor,
-      // dropped if that same (manager, key) pair was revoked afterwards (still before the anchor).
-      // Registers and grants overwrite each other (a manager holds one current key); revoking a
-      // superseded key is a no-op. Pending bindings apply the same rule to the post-anchor window.
+      // A manager's binding for the cycle is its latest register-signer strictly before the anchor:
+      // registrations overwrite each other (the contract's signers map is keyed by principal) and
+      // there is no unregister, so revokes never participate. A post-anchor registration is a
+      // pending key update. Grants/revokes only maintain the (key, manager) authorization map: the
+      // latest grant/revoke per pair decides whether the grant is live.
       const resultQuery = await sql<(DbCycleSigner & { total: number })[]>`
-        WITH latest_bindings AS (
+        WITH effective_bindings AS (
           SELECT DISTINCT ON (signer_manager)
-            signer_manager, signer_key, auth_id::text AS auth_id,
-            block_height, microblock_sequence, tx_index, event_index,
-            burn_block_height, tx_id
+            signer_manager, signer_key, block_height, burn_block_height, tx_id
           FROM signer_key_grants
           WHERE canonical = TRUE AND microblock_canonical = TRUE
             AND block_height < ${anchorHeight}
-            AND kind IN (${DbSignerKeyGrantKind.Register}, ${DbSignerKeyGrantKind.Grant})
-          ORDER BY signer_manager,
-            block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
-        ), effective_bindings AS (
-          SELECT lb.* FROM latest_bindings lb
-          WHERE NOT EXISTS (
-            SELECT 1 FROM signer_key_grants r
-            WHERE r.canonical = TRUE AND r.microblock_canonical = TRUE
-              AND r.kind = ${DbSignerKeyGrantKind.Revoke}
-              AND r.signer_manager = lb.signer_manager
-              AND r.signer_key = lb.signer_key
-              AND r.block_height < ${anchorHeight}
-              AND (r.block_height, r.microblock_sequence, r.tx_index, r.event_index)
-                > (lb.block_height, lb.microblock_sequence, lb.tx_index, lb.event_index)
-          )
-        ), pending_candidates AS (
-          SELECT DISTINCT ON (signer_manager)
-            signer_manager, signer_key, tx_id,
-            block_height, microblock_sequence, tx_index, event_index
-          FROM signer_key_grants
-          WHERE canonical = TRUE AND microblock_canonical = TRUE
-            AND block_height >= ${anchorHeight}
-            AND kind IN (${DbSignerKeyGrantKind.Register}, ${DbSignerKeyGrantKind.Grant})
+            AND kind = ${DbSignerKeyGrantKind.Register}
           ORDER BY signer_manager,
             block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
         ), pending_bindings AS (
-          SELECT pc.* FROM pending_candidates pc
-          WHERE NOT EXISTS (
-            SELECT 1 FROM signer_key_grants r
-            WHERE r.canonical = TRUE AND r.microblock_canonical = TRUE
-              AND r.kind = ${DbSignerKeyGrantKind.Revoke}
-              AND r.signer_manager = pc.signer_manager
-              AND r.signer_key = pc.signer_key
-              AND (r.block_height, r.microblock_sequence, r.tx_index, r.event_index)
-                > (pc.block_height, pc.microblock_sequence, pc.tx_index, pc.event_index)
-          )
+          SELECT DISTINCT ON (signer_manager)
+            signer_manager, signer_key, tx_id
+          FROM signer_key_grants
+          WHERE canonical = TRUE AND microblock_canonical = TRUE
+            AND block_height >= ${anchorHeight}
+            AND kind = ${DbSignerKeyGrantKind.Register}
+          ORDER BY signer_manager,
+            block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
+        ), live_grants AS (
+          SELECT DISTINCT ON (signer_manager, signer_key)
+            signer_manager, signer_key, kind, auth_id::text AS auth_id, tx_id
+          FROM signer_key_grants
+          WHERE canonical = TRUE AND microblock_canonical = TRUE
+            AND kind IN (${DbSignerKeyGrantKind.Grant}, ${DbSignerKeyGrantKind.Revoke})
+          ORDER BY signer_manager, signer_key,
+            block_height DESC, microblock_sequence DESC, tx_index DESC, event_index DESC
         ), cursor_row AS (
           SELECT weight FROM pox_sets
           WHERE canonical = TRUE
@@ -1763,10 +1752,19 @@ export class PgStoreV3 extends BasePgStoreModule {
           COALESCE((
             SELECT json_agg(json_build_object(
               'signer_manager', eb.signer_manager,
-              'auth_id', eb.auth_id,
               'block_height', eb.block_height,
               'burn_block_height', eb.burn_block_height,
               'tx_id', concat('0x', encode(eb.tx_id, 'hex')),
+              'granted_keys', COALESCE((
+                SELECT json_agg(json_build_object(
+                  'signer_key', concat('0x', encode(lg.signer_key, 'hex')),
+                  'auth_id', lg.auth_id,
+                  'tx_id', concat('0x', encode(lg.tx_id, 'hex'))
+                ) ORDER BY lg.signer_key)
+                FROM live_grants lg
+                WHERE lg.signer_manager = eb.signer_manager
+                  AND lg.kind = ${DbSignerKeyGrantKind.Grant}
+              ), '[]'::json),
               'pending_signer_key',
                 CASE WHEN pb.signer_key IS NOT NULL AND pb.signer_key != ps.signing_key
                   THEN concat('0x', encode(pb.signer_key, 'hex'))
@@ -1920,9 +1918,9 @@ export class PgStoreV3 extends BasePgStoreModule {
 
   /**
    * Lists the stakers that belong to a signer, unioned across pox-5 STX staking
-   * (`stx_locked_balances.signer`, active locks) and bond staking
-   * (`bond_registrations.signer`), deduplicated by staker with a flag per
-   * staking type. Keyset-paginated by staker principal ascending.
+   * (`stx_locked_balances.signer`, active locks) and bond staking (`bond_registrations.signer`),
+   * deduplicated by staker with a flag per staking type. Keyset-paginated by staker principal
+   * ascending.
    * @param args - The arguments for the query.
    * @returns The signer's stakers.
    */

--- a/src/datastore/v3/types.ts
+++ b/src/datastore/v3/types.ts
@@ -277,6 +277,8 @@ export interface DbCycleSignerManager {
    * cycle's signing key (i.e. a pending key rotation).
    */
   pending_signer_key: string | null;
+  /** The tx of the pending key binding; set iff `pending_signer_key` is set. */
+  pending_tx_id: string | null;
 }
 
 /** A reward-set signer for a PoX cycle, with its effective signer manager bindings. */

--- a/src/datastore/v3/types.ts
+++ b/src/datastore/v3/types.ts
@@ -262,22 +262,31 @@ export interface DbStakingSignerDetail extends DbStakingSigner {
   burn_block_time: number;
 }
 
-/** A signer manager key binding active for a cycle's signing key. */
+/** A live `grant-signer-key` authorization held by a signer manager. */
+export interface DbSignerKeyGrant {
+  /** The granted signing key as a `0x`-prefixed hex string. */
+  signer_key: string;
+  /** The grant's auth id as a decimal string. */
+  auth_id: string;
+  /** The grant event's tx id as a `0x`-prefixed hex string. */
+  tx_id: string;
+}
+
 export interface DbCycleSignerManager {
   signer_manager: string;
-  /** The grant's auth id as a decimal string; null for `register-signer` bindings. */
-  auth_id: string | null;
-  /** Block position of the binding event. */
+  /** Block position of the `register-signer` event that bound this key. */
   block_height: number;
   burn_block_height: number;
-  /** The binding event's tx id as a `0x`-prefixed hex string. */
+  /** The registration tx id as a `0x`-prefixed hex string. */
   tx_id: string;
+  /** The manager's live key grants (authorizations that may later be registered). */
+  granted_keys: DbSignerKeyGrant[];
   /**
-   * The manager's latest key binding made after the cycle's anchor block, when it differs from the
+   * The manager's latest key registered after the cycle's anchor block, when it differs from the
    * cycle's signing key (i.e. a pending key rotation).
    */
   pending_signer_key: string | null;
-  /** The tx of the pending key binding; set iff `pending_signer_key` is set. */
+  /** The tx of the pending key registration; set iff `pending_signer_key` is set. */
   pending_tx_id: string | null;
 }
 

--- a/src/datastore/v3/types.ts
+++ b/src/datastore/v3/types.ts
@@ -262,6 +262,34 @@ export interface DbStakingSignerDetail extends DbStakingSigner {
   burn_block_time: number;
 }
 
+/** A signer manager key binding active for a cycle's signing key. */
+export interface DbCycleSignerManager {
+  signer_manager: string;
+  /** The grant's auth id as a decimal string; null for `register-signer` bindings. */
+  auth_id: string | null;
+  /** Block position of the binding event. */
+  block_height: number;
+  burn_block_height: number;
+  /** The binding event's tx id as a `0x`-prefixed hex string. */
+  tx_id: string;
+  /**
+   * The manager's latest key binding made after the cycle's anchor block, when it differs from the
+   * cycle's signing key (i.e. a pending key rotation).
+   */
+  pending_signer_key: string | null;
+}
+
+/** A reward-set signer for a PoX cycle, with its effective signer manager bindings. */
+export interface DbCycleSigner {
+  /** The signing key in the cycle's reward set, as a `0x`-prefixed hex string. */
+  signing_key: string;
+  weight: number;
+  stacked_amount: string;
+  weight_percent: number;
+  stacked_amount_percent: number;
+  signer_managers: DbCycleSignerManager[];
+}
+
 /** A staker that belongs to a signer, with the staking type(s) it participates in. */
 export interface DbSignerStaker {
   staker: string;

--- a/tests/api/pox5/cycle-signers.test.ts
+++ b/tests/api/pox5/cycle-signers.test.ts
@@ -25,7 +25,10 @@ const MANAGER_E = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6.manager-e';
 
 const KEY1 = '0x' + '02'.repeat(33);
 const KEY2 = '0x' + '03'.repeat(33);
-const KEY4 = '0x' + '04'.repeat(33); // in the set, never bound
+// Seeded into the set without a binding. Impossible on a real chain (stake can
+// only be committed under a bound key), but the endpoint should degrade to an
+// empty manager list rather than erroring if the data is ever inconsistent.
+const KEY4 = '0x' + '04'.repeat(33);
 const KEY5 = '0x' + '05'.repeat(33); // pending rotation target
 const KEY9 = '0x' + '09'.repeat(33); // bound, never in the set
 
@@ -236,6 +239,7 @@ describe('pox-5 cycle signers', () => {
     assert.deepEqual(entryA.pending_key_update, {
       signer_key: KEY5,
       effective_cycle: CYCLE + 1,
+      tx_id: txId(10),
     });
     // MANAGER_B's grant carries its auth id; the post-anchor revoke does not
     // affect the current cycle and is not a pending key update.
@@ -250,7 +254,8 @@ describe('pox-5 cycle signers', () => {
       [MANAGER_C]
     );
 
-    // KEY4 has no bindings at all.
+    // KEY4 was seeded without bindings (impossible on a real chain) — the
+    // endpoint degrades to an empty manager list instead of erroring.
     assert.equal(signer4.signing_key, KEY4);
     assert.deepEqual(signer4.signer_managers, []);
   });

--- a/tests/api/pox5/cycle-signers.test.ts
+++ b/tests/api/pox5/cycle-signers.test.ts
@@ -240,7 +240,7 @@ describe('pox-5 cycle signers', () => {
     assert.equal(signer1.signing_key, KEY1);
     // Weight 5 of 9 total, 500B of 900B total stacked.
     assert.deepEqual(signer1.weight, { amount: 5, percent: (5 / 9) * 100 });
-    assert.deepEqual(signer1.stacked_amount, { amount: '500000000000', percent: 55 });
+    assert.deepEqual(signer1.staked_stx, { amount: '500000000000', percent: 55 });
     // Managers sorted by principal ascending: MANAGER_B ('ST1…') < MANAGER_A ('ST3…').
     assert.deepEqual(
       signer1.signer_managers.map((m: { signer_manager: string }) => m.signer_manager),

--- a/tests/api/pox5/cycle-signers.test.ts
+++ b/tests/api/pox5/cycle-signers.test.ts
@@ -438,5 +438,10 @@ describe('pox-5 cycle signers', () => {
       JSON.parse(page2b.text).results.map((r: { signing_key: string }) => r.signing_key),
       [KEY4]
     );
+
+    // A well-formed cursor that is not one of the cycle's signing keys is a 404,
+    // not a silently empty page.
+    const unknown = await getCycleSigners({ limit: '2', cursor: KEY5 });
+    assert.equal(unknown.status, 404, unknown.text);
   });
 });

--- a/tests/api/pox5/cycle-signers.test.ts
+++ b/tests/api/pox5/cycle-signers.test.ts
@@ -134,69 +134,69 @@ describe('pox-5 cycle signers', () => {
         data: { signer: MANAGER_A, signer_key: KEY1 },
       })
     );
-    // 2: MANAGER_B also registers KEY1 (multi-manager key).
+    // 2: KEY1 granted to MANAGER_B, 3: which registers it (multi-manager key).
     await db.update(
       bindingBlock({
         height: 2,
-        name: Pox5EventName.RegisterSigner,
-        data: { signer: MANAGER_B, signer_key: KEY1 },
+        name: Pox5EventName.GrantSignerKey,
+        data: { signer_key: KEY1, signer_manager: MANAGER_B, auth_id: '111' },
       })
     );
-    // 3: MANAGER_C registers KEY2.
     await db.update(
       bindingBlock({
         height: 3,
         name: Pox5EventName.RegisterSigner,
-        data: { signer: MANAGER_C, signer_key: KEY2 },
+        data: { signer: MANAGER_B, signer_key: KEY1 },
       })
     );
-    // 4: KEY2 granted to MANAGER_D, 5: then revoked. D never registers, so it is
-    // not a binding either way and the revoked grant is not live.
+    // 4: KEY2 granted to MANAGER_C, 5: which registers it.
     await db.update(
       bindingBlock({
         height: 4,
+        name: Pox5EventName.GrantSignerKey,
+        data: { signer_key: KEY2, signer_manager: MANAGER_C, auth_id: '555' },
+      })
+    );
+    await db.update(
+      bindingBlock({
+        height: 5,
+        name: Pox5EventName.RegisterSigner,
+        data: { signer: MANAGER_C, signer_key: KEY2 },
+      })
+    );
+    // 6: KEY2 granted to MANAGER_D, 7: then revoked. D never registers, so it is
+    // not a binding either way and the revoked grant is not live.
+    await db.update(
+      bindingBlock({
+        height: 6,
         name: Pox5EventName.GrantSignerKey,
         data: { signer_key: KEY2, signer_manager: MANAGER_D, auth_id: '222' },
       })
     );
     await db.update(
       bindingBlock({
-        height: 5,
+        height: 7,
         name: Pox5EventName.RevokeSignerGrant,
         data: { signer_key: KEY2, signer_manager: MANAGER_D },
       })
     );
-    // 6: KEY9 granted to MANAGER_E — a grant alone binds nothing, and E never
+    // 8: KEY9 granted to MANAGER_E — a grant alone binds nothing, and E never
     // registers, so E must not appear as a manager anywhere.
     await db.update(
       bindingBlock({
-        height: 6,
+        height: 8,
         name: Pox5EventName.GrantSignerKey,
         data: { signer_key: KEY9, signer_manager: MANAGER_E, auth_id: '333' },
       })
     );
-    // 7: KEY5 granted to MANAGER_A — a live authorization A may register later.
+    // 9: KEY5 granted to MANAGER_A — a live authorization A may register later.
     await db.update(
       bindingBlock({
-        height: 7,
+        height: 9,
         name: Pox5EventName.GrantSignerKey,
         data: { signer_key: KEY5, signer_manager: MANAGER_A, auth_id: '444' },
       })
     );
-    // Fill the chain up to the anchor.
-    for (const height of [8, 9]) {
-      await db.update(
-        new TestBlockBuilder({
-          block_height: height,
-          block_hash: hash(height),
-          index_block_hash: hash(height),
-          parent_block_hash: hash(height - 1),
-          parent_index_block_hash: hash(height - 1),
-        })
-          .addTx({ tx_id: txId(height) })
-          .build()
-      );
-    }
 
     // The cycle's reward set, anchored at block 10.
     await seedCycle(CYCLE, ANCHOR_HEIGHT, [
@@ -214,8 +214,9 @@ describe('pox-5 cycle signers', () => {
         data: { signer: MANAGER_A, signer_key: KEY5 },
       })
     );
-    // 11: a revoke aimed at MANAGER_B's key — revokes only end grants and never
-    // unbind a registration, so B's binding is unaffected.
+    // 11: MANAGER_B's grant for KEY1 is revoked — revokes only end grants and
+    // never unbind a registration, so B stays a manager of KEY1 (with its
+    // grant no longer active).
     await db.update(
       bindingBlock({
         height: 11,
@@ -259,35 +260,43 @@ describe('pox-5 cycle signers', () => {
       [MANAGER_B, MANAGER_A]
     );
     const [entryB, entryA] = signer1.signer_managers;
-    // MANAGER_A holds a live authorization for KEY5 and registered it after the
-    // anchor, so the rotation is pending and effective next cycle.
+    // MANAGER_A self-registered KEY1 without a grant, holds a live
+    // authorization for KEY5, and registered it after the anchor, so the
+    // rotation is pending and effective next cycle.
     assert.equal(entryA.registered_at.block_height, 1);
     assert.equal(entryA.registered_at.tx_id, txId(1));
     assert.equal(typeof entryA.registered_at.bitcoin_block_height, 'number');
     assert.deepEqual(entryA.granted_keys, [
-      { signer_key: KEY5, auth_id: '444', tx_id: txId(7) },
+      { signer_key: KEY5, auth_id: '444', tx_id: txId(9) },
     ]);
+    assert.equal(entryA.grant_active, false);
     assert.deepEqual(entryA.pending_key_update, {
       signer_key: KEY5,
       effective_cycle: CYCLE + 1,
       tx_id: txId(10),
     });
-    // MANAGER_B has no grants, and the post-anchor revoke neither unbinds its
-    // registration nor creates a pending key update.
-    assert.equal(entryB.registered_at.block_height, 2);
+    // MANAGER_B's grant for KEY1 was revoked post-anchor: it stays bound (a
+    // revoke never unbinds a registration) but its grant is no longer active,
+    // and no pending key update is created.
+    assert.equal(entryB.registered_at.block_height, 3);
     assert.deepEqual(entryB.granted_keys, []);
+    assert.equal(entryB.grant_active, false);
     assert.equal(entryB.pending_key_update, null);
 
-    // KEY2: MANAGER_C bound via registration; MANAGER_D only ever held a
-    // (revoked) grant and never registered, so it is not a manager.
+    // KEY2: MANAGER_C bound via registration with its grant still live;
+    // MANAGER_D only ever held a (revoked) grant and never registered, so it
+    // is not a manager.
     assert.equal(signer2.signing_key, KEY2);
     assert.deepEqual(
       signer2.signer_managers.map((m: { signer_manager: string }) => m.signer_manager),
       [MANAGER_C]
     );
-    // MANAGER_C's grant for KEY6 was revoked (not live) and was never
-    // registered (not pending).
-    assert.deepEqual(signer2.signer_managers[0].granted_keys, []);
+    // MANAGER_C's KEY2 grant is live; its grant for KEY6 was revoked (not
+    // live) and was never registered (not pending).
+    assert.deepEqual(signer2.signer_managers[0].granted_keys, [
+      { signer_key: KEY2, auth_id: '555', tx_id: txId(4) },
+    ]);
+    assert.equal(signer2.signer_managers[0].grant_active, true);
     assert.equal(signer2.signer_managers[0].pending_key_update, null);
 
     // KEY4 was seeded without bindings (impossible on a real chain) — the

--- a/tests/api/pox5/cycle-signers.test.ts
+++ b/tests/api/pox5/cycle-signers.test.ts
@@ -124,8 +124,8 @@ describe('pox-5 cycle signers', () => {
     assert.equal(res.status, 400, res.text);
   });
 
-  test('cycle signers with effective, revoked, multi-manager, and pending bindings', async () => {
-    // Bindings before the anchor block (effective for the cycle):
+  test('cycle signers with registered, granted, revoked, and pending keys', async () => {
+    // Registrations before the anchor block (effective bindings for the cycle):
     // 1: MANAGER_A registers KEY1.
     await db.update(
       bindingBlock({
@@ -134,12 +134,12 @@ describe('pox-5 cycle signers', () => {
         data: { signer: MANAGER_A, signer_key: KEY1 },
       })
     );
-    // 2: KEY1 is also granted to MANAGER_B (multi-manager key).
+    // 2: MANAGER_B also registers KEY1 (multi-manager key).
     await db.update(
       bindingBlock({
         height: 2,
-        name: Pox5EventName.GrantSignerKey,
-        data: { signer_key: KEY1, signer_manager: MANAGER_B, auth_id: '111' },
+        name: Pox5EventName.RegisterSigner,
+        data: { signer: MANAGER_B, signer_key: KEY1 },
       })
     );
     // 3: MANAGER_C registers KEY2.
@@ -150,7 +150,8 @@ describe('pox-5 cycle signers', () => {
         data: { signer: MANAGER_C, signer_key: KEY2 },
       })
     );
-    // 4: KEY2 granted to MANAGER_D, 5: then revoked (pair inactive for the cycle).
+    // 4: KEY2 granted to MANAGER_D, 5: then revoked. D never registers, so it is
+    // not a binding either way and the revoked grant is not live.
     await db.update(
       bindingBlock({
         height: 4,
@@ -165,7 +166,8 @@ describe('pox-5 cycle signers', () => {
         data: { signer_key: KEY2, signer_manager: MANAGER_D },
       })
     );
-    // 6: KEY9 granted to MANAGER_E — key not in the reward set, no effect.
+    // 6: KEY9 granted to MANAGER_E — a grant alone binds nothing, and E never
+    // registers, so E must not appear as a manager anywhere.
     await db.update(
       bindingBlock({
         height: 6,
@@ -173,8 +175,16 @@ describe('pox-5 cycle signers', () => {
         data: { signer_key: KEY9, signer_manager: MANAGER_E, auth_id: '333' },
       })
     );
+    // 7: KEY5 granted to MANAGER_A — a live authorization A may register later.
+    await db.update(
+      bindingBlock({
+        height: 7,
+        name: Pox5EventName.GrantSignerKey,
+        data: { signer_key: KEY5, signer_manager: MANAGER_A, auth_id: '444' },
+      })
+    );
     // Fill the chain up to the anchor.
-    for (const height of [7, 8, 9]) {
+    for (const height of [8, 9]) {
       await db.update(
         new TestBlockBuilder({
           block_height: height,
@@ -195,16 +205,17 @@ describe('pox-5 cycle signers', () => {
       { key: KEY4, weight: 1, stacked: '100000000000' },
     ]);
 
-    // Bindings at/after the anchor (pending, effective next cycle):
-    // 10: MANAGER_A rotates to KEY5.
+    // Events at/after the anchor:
+    // 10: MANAGER_A registers KEY5 — a pending key update, effective next cycle.
     await db.update(
       bindingBlock({
         height: 10,
-        name: Pox5EventName.GrantSignerKey,
-        data: { signer_key: KEY5, signer_manager: MANAGER_A, auth_id: '444' },
+        name: Pox5EventName.RegisterSigner,
+        data: { signer: MANAGER_A, signer_key: KEY5 },
       })
     );
-    // 11: MANAGER_B's grant on KEY1 is revoked — does not affect the current cycle.
+    // 11: a revoke aimed at MANAGER_B's key — revokes only end grants and never
+    // unbind a registration, so B's binding is unaffected.
     await db.update(
       bindingBlock({
         height: 11,
@@ -212,7 +223,8 @@ describe('pox-5 cycle signers', () => {
         data: { signer_key: KEY1, signer_manager: MANAGER_B },
       })
     );
-    // 12/13: MANAGER_C starts a rotation to KEY6 but revokes it — no pending update.
+    // 12/13: MANAGER_C receives a grant for KEY6 but it gets revoked — not a
+    // live authorization, and never a pending update (only registrations are).
     await db.update(
       bindingBlock({
         height: 12,
@@ -247,29 +259,35 @@ describe('pox-5 cycle signers', () => {
       [MANAGER_B, MANAGER_A]
     );
     const [entryB, entryA] = signer1.signer_managers;
-    // MANAGER_A's binding came from register-signer (no auth id) and has a
-    // pending rotation to KEY5, effective next cycle.
-    assert.equal(entryA.auth_id, null);
-    assert.equal(entryA.granted_at.block_height, 1);
-    assert.equal(entryA.granted_at.tx_id, txId(1));
+    // MANAGER_A holds a live authorization for KEY5 and registered it after the
+    // anchor, so the rotation is pending and effective next cycle.
+    assert.equal(entryA.registered_at.block_height, 1);
+    assert.equal(entryA.registered_at.tx_id, txId(1));
+    assert.equal(typeof entryA.registered_at.bitcoin_block_height, 'number');
+    assert.deepEqual(entryA.granted_keys, [
+      { signer_key: KEY5, auth_id: '444', tx_id: txId(7) },
+    ]);
     assert.deepEqual(entryA.pending_key_update, {
       signer_key: KEY5,
       effective_cycle: CYCLE + 1,
       tx_id: txId(10),
     });
-    // MANAGER_B's grant carries its auth id; the post-anchor revoke does not
-    // affect the current cycle and is not a pending key update.
-    assert.equal(entryB.auth_id, '111');
-    assert.equal(entryB.granted_at.block_height, 2);
+    // MANAGER_B has no grants, and the post-anchor revoke neither unbinds its
+    // registration nor creates a pending key update.
+    assert.equal(entryB.registered_at.block_height, 2);
+    assert.deepEqual(entryB.granted_keys, []);
     assert.equal(entryB.pending_key_update, null);
 
-    // KEY2: MANAGER_C active; MANAGER_D's grant was revoked before the anchor.
+    // KEY2: MANAGER_C bound via registration; MANAGER_D only ever held a
+    // (revoked) grant and never registered, so it is not a manager.
     assert.equal(signer2.signing_key, KEY2);
     assert.deepEqual(
       signer2.signer_managers.map((m: { signer_manager: string }) => m.signer_manager),
       [MANAGER_C]
     );
-    // MANAGER_C's post-anchor rotation to KEY6 was revoked, so it is not pending.
+    // MANAGER_C's grant for KEY6 was revoked (not live) and was never
+    // registered (not pending).
+    assert.deepEqual(signer2.signer_managers[0].granted_keys, []);
     assert.equal(signer2.signer_managers[0].pending_key_update, null);
 
     // KEY4 was seeded without bindings (impossible on a real chain) — the
@@ -278,8 +296,8 @@ describe('pox-5 cycle signers', () => {
     assert.deepEqual(signer4.signer_managers, []);
   });
 
-  test('bindings after a newer cycle anchor stop being pending for it', async () => {
-    // MANAGER_A registers KEY1 before cycle 100's anchor, then rotates to KEY5
+  test('registrations after a newer cycle anchor stop being pending for it', async () => {
+    // MANAGER_A registers KEY1 before cycle 100's anchor, then registers KEY5
     // before cycle 101's anchor. For current cycle 101, KEY5 is effective (not
     // pending) and matches the new reward set entry.
     await db.update(
@@ -293,8 +311,8 @@ describe('pox-5 cycle signers', () => {
     await db.update(
       bindingBlock({
         height: 2,
-        name: Pox5EventName.GrantSignerKey,
-        data: { signer_key: KEY5, signer_manager: MANAGER_A, auth_id: '555' },
+        name: Pox5EventName.RegisterSigner,
+        data: { signer: MANAGER_A, signer_key: KEY5 },
       })
     );
     await seedCycle(CYCLE + 1, 3, [{ key: KEY5, weight: 1, stacked: '100000000000' }]);
@@ -307,12 +325,13 @@ describe('pox-5 cycle signers', () => {
     assert.equal(signer.signing_key, KEY5);
     assert.equal(signer.signer_managers.length, 1);
     assert.equal(signer.signer_managers[0].signer_manager, MANAGER_A);
-    assert.equal(signer.signer_managers[0].auth_id, '555');
+    assert.equal(signer.signer_managers[0].registered_at.block_height, 2);
     assert.equal(signer.signer_managers[0].pending_key_update, null);
   });
 
-  test('grants supersede registers, and revokes do not resurrect older keys', async () => {
-    // MANAGER_A registers KEY1 then grants itself KEY2 — only KEY2 is bound.
+  test('registrations overwrite each other; grants and revokes never change bindings', async () => {
+    // MANAGER_A registers KEY1 then registers KEY2 — the signers map is keyed
+    // by principal, so only KEY2 is bound.
     await db.update(
       bindingBlock({
         height: 1,
@@ -323,12 +342,13 @@ describe('pox-5 cycle signers', () => {
     await db.update(
       bindingBlock({
         height: 2,
-        name: Pox5EventName.GrantSignerKey,
-        data: { signer_key: KEY2, signer_manager: MANAGER_A, auth_id: '777' },
+        name: Pox5EventName.RegisterSigner,
+        data: { signer: MANAGER_A, signer_key: KEY2 },
       })
     );
-    // MANAGER_C registers KEY9, rotates to KEY4, then revokes KEY4 — fully
-    // unbound; the revoke does not resurrect the superseded KEY9 binding.
+    // MANAGER_C registers KEY9, then receives and loses a grant for KEY4 — its
+    // KEY9 registration stays bound throughout (grants rotate nothing, and
+    // revokes never unbind a registration).
     await db.update(
       bindingBlock({
         height: 3,
@@ -366,9 +386,9 @@ describe('pox-5 cycle signers', () => {
       ])
     );
     assert.deepEqual(managersByKey, {
-      [KEY1]: [], // superseded by MANAGER_A's grant of KEY2
+      [KEY1]: [], // overwritten by MANAGER_A's registration of KEY2
       [KEY2]: [MANAGER_A],
-      [KEY9]: [], // superseded by KEY4, whose revoke does not resurrect it
+      [KEY9]: [MANAGER_C], // untouched by the KEY4 grant/revoke
     });
   });
 

--- a/tests/api/pox5/cycle-signers.test.ts
+++ b/tests/api/pox5/cycle-signers.test.ts
@@ -1,0 +1,321 @@
+import supertest from 'supertest';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { STACKS_TESTNET } from '@stacks/network';
+import { Pox5EventName } from '@stacks/codec';
+import { PgSqlClient } from '@stacks/api-toolkit';
+import { ApiServer, startApiServer } from '../../../src/api/init.ts';
+import { PgWriteStore } from '../../../src/datastore/pg-write-store.ts';
+import { migrate } from '../../test-helpers.ts';
+import { TestBlockBuilder } from '../test-builders.ts';
+
+/**
+ * GET /extended/v3/staking/cycles/current/signers — the current cycle's reward set (`pox_sets`)
+ * joined with the signer manager key bindings (`signer_key_grants`: register-signer /
+ * grant-signer-key / revoke-signer-grant) that were effective when the cycle's reward set was
+ * calculated, i.e. bindings strictly before the cycle's anchor block. Bindings at or after the
+ * anchor surface as pending key updates effective next cycle.
+ */
+
+const MANAGER_A = 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP.manager-a';
+const MANAGER_B = 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5.manager-b';
+const MANAGER_C = 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG.manager-c';
+const MANAGER_D = 'ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC.manager-d';
+const MANAGER_E = 'STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6.manager-e';
+
+const KEY1 = '0x' + '02'.repeat(33);
+const KEY2 = '0x' + '03'.repeat(33);
+const KEY4 = '0x' + '04'.repeat(33); // in the set, never bound
+const KEY5 = '0x' + '05'.repeat(33); // pending rotation target
+const KEY9 = '0x' + '09'.repeat(33); // bound, never in the set
+
+const CYCLE = 100;
+const ANCHOR_HEIGHT = 10;
+
+const hash = (n: number) => '0x' + n.toString(16).padStart(2, '0');
+const txId = (n: number) => '0x' + n.toString(16).padStart(2, '0').repeat(32);
+
+describe('pox-5 cycle signers', () => {
+  let db: PgWriteStore;
+  let client: PgSqlClient;
+  let api: ApiServer;
+
+  function bindingBlock(args: { height: number; name: Pox5EventName; data: unknown }) {
+    return new TestBlockBuilder({
+      block_height: args.height,
+      block_hash: hash(args.height),
+      index_block_hash: hash(args.height),
+      parent_block_hash: hash(args.height - 1),
+      parent_index_block_hash: hash(args.height - 1),
+    })
+      .addTx({ tx_id: txId(args.height) })
+      .addTxPox5Event({ name: args.name, data: args.data })
+      .build();
+  }
+
+  async function seedCycle(
+    cycle: number,
+    anchorHeight: number,
+    signers: { key: string; weight: number; stacked: string }[]
+  ) {
+    const totalWeight = signers.reduce((acc, s) => acc + s.weight, 0);
+    const totalStacked = signers.reduce((acc, s) => acc + BigInt(s.stacked), 0n);
+    await client`
+      INSERT INTO pox_cycles (
+        block_height, index_block_hash, parent_index_block_hash, cycle_number,
+        canonical, total_weight, total_stacked_amount, total_signers
+      )
+      VALUES (
+        ${anchorHeight}, ${hash(anchorHeight)}, ${hash(anchorHeight - 1)}, ${cycle},
+        true, ${totalWeight}, ${totalStacked}, ${signers.length}
+      )
+    `;
+    for (const s of signers) {
+      await client`
+        INSERT INTO pox_sets (
+          block_height, index_block_hash, parent_index_block_hash, cycle_number,
+          pox_ustx_threshold, canonical, signing_key, weight, stacked_amount,
+          weight_percent, stacked_amount_percent, total_weight, total_stacked_amount
+        )
+        VALUES (
+          ${anchorHeight}, ${hash(anchorHeight)}, ${hash(anchorHeight - 1)}, ${cycle},
+          1000000, true, ${s.key}, ${s.weight}, ${s.stacked},
+          ${(s.weight / totalWeight) * 100},
+          ${Number((BigInt(s.stacked) * 100n) / totalStacked)},
+          ${totalWeight}, ${totalStacked}
+        )
+      `;
+    }
+  }
+
+  async function getCycleSigners(query: Record<string, string> = {}) {
+    const res = await supertest(api.server)
+      .get('/extended/v3/staking/cycles/current/signers')
+      .query(query);
+    return res;
+  }
+
+  beforeEach(async () => {
+    await migrate('up');
+    db = await PgWriteStore.connect({ usageName: 'tests', withNotifier: false, skipMigrations: true });
+    client = db.sql;
+    api = await startApiServer({ datastore: db, chainId: STACKS_TESTNET.chainId });
+  });
+
+  afterEach(async () => {
+    await api.terminate();
+    await db?.close();
+    await migrate('down');
+  });
+
+  test('404 when no PoX cycle exists', async () => {
+    const res = await getCycleSigners();
+    assert.equal(res.status, 404, res.text);
+  });
+
+  test('only `current` is accepted as the cycle number', async () => {
+    // The route is generic (`/staking/cycles/:cycle_number/signers`) so it can
+    // later serve previous cycles, but for now the param only allows `current`.
+    const res = await supertest(api.server).get('/extended/v3/staking/cycles/100/signers');
+    assert.equal(res.status, 400, res.text);
+  });
+
+  test('cycle signers with effective, revoked, multi-manager, and pending bindings', async () => {
+    // Bindings before the anchor block (effective for the cycle):
+    // 1: MANAGER_A registers KEY1.
+    await db.update(
+      bindingBlock({
+        height: 1,
+        name: Pox5EventName.RegisterSigner,
+        data: { signer: MANAGER_A, signer_key: KEY1 },
+      })
+    );
+    // 2: KEY1 is also granted to MANAGER_B (multi-manager key).
+    await db.update(
+      bindingBlock({
+        height: 2,
+        name: Pox5EventName.GrantSignerKey,
+        data: { signer_key: KEY1, signer_manager: MANAGER_B, auth_id: '111' },
+      })
+    );
+    // 3: MANAGER_C registers KEY2.
+    await db.update(
+      bindingBlock({
+        height: 3,
+        name: Pox5EventName.RegisterSigner,
+        data: { signer: MANAGER_C, signer_key: KEY2 },
+      })
+    );
+    // 4: KEY2 granted to MANAGER_D, 5: then revoked (pair inactive for the cycle).
+    await db.update(
+      bindingBlock({
+        height: 4,
+        name: Pox5EventName.GrantSignerKey,
+        data: { signer_key: KEY2, signer_manager: MANAGER_D, auth_id: '222' },
+      })
+    );
+    await db.update(
+      bindingBlock({
+        height: 5,
+        name: Pox5EventName.RevokeSignerGrant,
+        data: { signer_key: KEY2, signer_manager: MANAGER_D },
+      })
+    );
+    // 6: KEY9 granted to MANAGER_E — key not in the reward set, no effect.
+    await db.update(
+      bindingBlock({
+        height: 6,
+        name: Pox5EventName.GrantSignerKey,
+        data: { signer_key: KEY9, signer_manager: MANAGER_E, auth_id: '333' },
+      })
+    );
+    // Fill the chain up to the anchor.
+    for (const height of [7, 8, 9]) {
+      await db.update(
+        new TestBlockBuilder({
+          block_height: height,
+          block_hash: hash(height),
+          index_block_hash: hash(height),
+          parent_block_hash: hash(height - 1),
+          parent_index_block_hash: hash(height - 1),
+        })
+          .addTx({ tx_id: txId(height) })
+          .build()
+      );
+    }
+
+    // The cycle's reward set, anchored at block 10.
+    await seedCycle(CYCLE, ANCHOR_HEIGHT, [
+      { key: KEY1, weight: 5, stacked: '500000000000' },
+      { key: KEY2, weight: 3, stacked: '300000000000' },
+      { key: KEY4, weight: 1, stacked: '100000000000' },
+    ]);
+
+    // Bindings at/after the anchor (pending, effective next cycle):
+    // 10: MANAGER_A rotates to KEY5.
+    await db.update(
+      bindingBlock({
+        height: 10,
+        name: Pox5EventName.GrantSignerKey,
+        data: { signer_key: KEY5, signer_manager: MANAGER_A, auth_id: '444' },
+      })
+    );
+    // 11: MANAGER_B's grant on KEY1 is revoked — does not affect the current cycle.
+    await db.update(
+      bindingBlock({
+        height: 11,
+        name: Pox5EventName.RevokeSignerGrant,
+        data: { signer_key: KEY1, signer_manager: MANAGER_B },
+      })
+    );
+
+    const res = await getCycleSigners();
+    assert.equal(res.status, 200, res.text);
+    const body = JSON.parse(res.text);
+    assert.equal(body.total, 3);
+    assert.equal(body.results.length, 3);
+
+    // Ordered by weight descending.
+    const [signer1, signer2, signer4] = body.results;
+
+    assert.equal(signer1.signing_key, KEY1);
+    // Weight 5 of 9 total, 500B of 900B total stacked.
+    assert.deepEqual(signer1.weight, { amount: 5, percent: (5 / 9) * 100 });
+    assert.deepEqual(signer1.stacked_amount, { amount: '500000000000', percent: 55 });
+    // Managers sorted by principal ascending: MANAGER_B ('ST1…') < MANAGER_A ('ST3…').
+    assert.deepEqual(
+      signer1.signer_managers.map((m: { signer_manager: string }) => m.signer_manager),
+      [MANAGER_B, MANAGER_A]
+    );
+    const [entryB, entryA] = signer1.signer_managers;
+    // MANAGER_A's binding came from register-signer (no auth id) and has a
+    // pending rotation to KEY5, effective next cycle.
+    assert.equal(entryA.auth_id, null);
+    assert.equal(entryA.granted_at.block_height, 1);
+    assert.equal(entryA.granted_at.tx_id, txId(1));
+    assert.deepEqual(entryA.pending_key_update, {
+      signer_key: KEY5,
+      effective_cycle: CYCLE + 1,
+    });
+    // MANAGER_B's grant carries its auth id; the post-anchor revoke does not
+    // affect the current cycle and is not a pending key update.
+    assert.equal(entryB.auth_id, '111');
+    assert.equal(entryB.granted_at.block_height, 2);
+    assert.equal(entryB.pending_key_update, null);
+
+    // KEY2: MANAGER_C active; MANAGER_D's grant was revoked before the anchor.
+    assert.equal(signer2.signing_key, KEY2);
+    assert.deepEqual(
+      signer2.signer_managers.map((m: { signer_manager: string }) => m.signer_manager),
+      [MANAGER_C]
+    );
+
+    // KEY4 has no bindings at all.
+    assert.equal(signer4.signing_key, KEY4);
+    assert.deepEqual(signer4.signer_managers, []);
+  });
+
+  test('bindings after a newer cycle anchor stop being pending for it', async () => {
+    // MANAGER_A registers KEY1 before cycle 100's anchor, then rotates to KEY5
+    // before cycle 101's anchor. For current cycle 101, KEY5 is effective (not
+    // pending) and matches the new reward set entry.
+    await db.update(
+      bindingBlock({
+        height: 1,
+        name: Pox5EventName.RegisterSigner,
+        data: { signer: MANAGER_A, signer_key: KEY1 },
+      })
+    );
+    await seedCycle(CYCLE, 2, [{ key: KEY1, weight: 1, stacked: '100000000000' }]);
+    await db.update(
+      bindingBlock({
+        height: 2,
+        name: Pox5EventName.GrantSignerKey,
+        data: { signer_key: KEY5, signer_manager: MANAGER_A, auth_id: '555' },
+      })
+    );
+    await seedCycle(CYCLE + 1, 3, [{ key: KEY5, weight: 1, stacked: '100000000000' }]);
+
+    const res = await getCycleSigners();
+    assert.equal(res.status, 200, res.text);
+    const body = JSON.parse(res.text);
+    assert.equal(body.total, 1);
+    const [signer] = body.results;
+    assert.equal(signer.signing_key, KEY5);
+    assert.equal(signer.signer_managers.length, 1);
+    assert.equal(signer.signer_managers[0].signer_manager, MANAGER_A);
+    assert.equal(signer.signer_managers[0].auth_id, '555');
+    assert.equal(signer.signer_managers[0].pending_key_update, null);
+  });
+
+  test('paginates by weight descending with signing key cursor', async () => {
+    await seedCycle(CYCLE, 1, [
+      { key: KEY1, weight: 5, stacked: '500000000000' },
+      { key: KEY2, weight: 3, stacked: '300000000000' },
+      { key: KEY4, weight: 1, stacked: '100000000000' },
+    ]);
+
+    const page1 = await getCycleSigners({ limit: '2' });
+    assert.equal(page1.status, 200, page1.text);
+    const body1 = JSON.parse(page1.text);
+    assert.equal(body1.total, 3);
+    assert.deepEqual(
+      body1.results.map((r: { signing_key: string }) => r.signing_key),
+      [KEY1, KEY2]
+    );
+    assert.equal(body1.cursor.next, KEY4);
+    assert.equal(body1.cursor.previous, null);
+    assert.equal(body1.cursor.current, KEY1);
+
+    const page2 = await getCycleSigners({ limit: '2', cursor: body1.cursor.next });
+    assert.equal(page2.status, 200, page2.text);
+    const body2 = JSON.parse(page2.text);
+    assert.deepEqual(
+      body2.results.map((r: { signing_key: string }) => r.signing_key),
+      [KEY4]
+    );
+    assert.equal(body2.cursor.next, null);
+    assert.equal(body2.cursor.previous, KEY1);
+    assert.equal(body2.cursor.current, KEY4);
+  });
+});

--- a/tests/api/pox5/cycle-signers.test.ts
+++ b/tests/api/pox5/cycle-signers.test.ts
@@ -30,6 +30,7 @@ const KEY2 = '0x' + '03'.repeat(33);
 // empty manager list rather than erroring if the data is ever inconsistent.
 const KEY4 = '0x' + '04'.repeat(33);
 const KEY5 = '0x' + '05'.repeat(33); // pending rotation target
+const KEY6 = '0x' + '06'.repeat(33); // pending rotation target that gets revoked
 const KEY9 = '0x' + '09'.repeat(33); // bound, never in the set
 
 const CYCLE = 100;
@@ -211,6 +212,21 @@ describe('pox-5 cycle signers', () => {
         data: { signer_key: KEY1, signer_manager: MANAGER_B },
       })
     );
+    // 12/13: MANAGER_C starts a rotation to KEY6 but revokes it — no pending update.
+    await db.update(
+      bindingBlock({
+        height: 12,
+        name: Pox5EventName.GrantSignerKey,
+        data: { signer_key: KEY6, signer_manager: MANAGER_C, auth_id: '666' },
+      })
+    );
+    await db.update(
+      bindingBlock({
+        height: 13,
+        name: Pox5EventName.RevokeSignerGrant,
+        data: { signer_key: KEY6, signer_manager: MANAGER_C },
+      })
+    );
 
     const res = await getCycleSigners();
     assert.equal(res.status, 200, res.text);
@@ -253,6 +269,8 @@ describe('pox-5 cycle signers', () => {
       signer2.signer_managers.map((m: { signer_manager: string }) => m.signer_manager),
       [MANAGER_C]
     );
+    // MANAGER_C's post-anchor rotation to KEY6 was revoked, so it is not pending.
+    assert.equal(signer2.signer_managers[0].pending_key_update, null);
 
     // KEY4 was seeded without bindings (impossible on a real chain) — the
     // endpoint degrades to an empty manager list instead of erroring.
@@ -293,6 +311,67 @@ describe('pox-5 cycle signers', () => {
     assert.equal(signer.signer_managers[0].pending_key_update, null);
   });
 
+  test('grants supersede registers, and revokes do not resurrect older keys', async () => {
+    // MANAGER_A registers KEY1 then grants itself KEY2 — only KEY2 is bound.
+    await db.update(
+      bindingBlock({
+        height: 1,
+        name: Pox5EventName.RegisterSigner,
+        data: { signer: MANAGER_A, signer_key: KEY1 },
+      })
+    );
+    await db.update(
+      bindingBlock({
+        height: 2,
+        name: Pox5EventName.GrantSignerKey,
+        data: { signer_key: KEY2, signer_manager: MANAGER_A, auth_id: '777' },
+      })
+    );
+    // MANAGER_C registers KEY9, rotates to KEY4, then revokes KEY4 — fully
+    // unbound; the revoke does not resurrect the superseded KEY9 binding.
+    await db.update(
+      bindingBlock({
+        height: 3,
+        name: Pox5EventName.RegisterSigner,
+        data: { signer: MANAGER_C, signer_key: KEY9 },
+      })
+    );
+    await db.update(
+      bindingBlock({
+        height: 4,
+        name: Pox5EventName.GrantSignerKey,
+        data: { signer_key: KEY4, signer_manager: MANAGER_C, auth_id: '888' },
+      })
+    );
+    await db.update(
+      bindingBlock({
+        height: 5,
+        name: Pox5EventName.RevokeSignerGrant,
+        data: { signer_key: KEY4, signer_manager: MANAGER_C },
+      })
+    );
+    await seedCycle(CYCLE, 6, [
+      { key: KEY1, weight: 3, stacked: '300000000000' },
+      { key: KEY2, weight: 2, stacked: '200000000000' },
+      { key: KEY9, weight: 1, stacked: '100000000000' },
+    ]);
+
+    const res = await getCycleSigners();
+    assert.equal(res.status, 200, res.text);
+    const body = JSON.parse(res.text);
+    const managersByKey = Object.fromEntries(
+      body.results.map((r: { signing_key: string; signer_managers: { signer_manager: string }[] }) => [
+        r.signing_key,
+        r.signer_managers.map(m => m.signer_manager),
+      ])
+    );
+    assert.deepEqual(managersByKey, {
+      [KEY1]: [], // superseded by MANAGER_A's grant of KEY2
+      [KEY2]: [MANAGER_A],
+      [KEY9]: [], // superseded by KEY4, whose revoke does not resurrect it
+    });
+  });
+
   test('paginates by weight descending with signing key cursor', async () => {
     await seedCycle(CYCLE, 1, [
       { key: KEY1, weight: 5, stacked: '500000000000' },
@@ -322,5 +401,13 @@ describe('pox-5 cycle signers', () => {
     assert.equal(body2.cursor.next, null);
     assert.equal(body2.cursor.previous, KEY1);
     assert.equal(body2.cursor.current, KEY4);
+
+    // A cursor without the 0x prefix is normalized to the same page.
+    const page2b = await getCycleSigners({ limit: '2', cursor: body1.cursor.next.slice(2) });
+    assert.equal(page2b.status, 200, page2b.text);
+    assert.deepEqual(
+      JSON.parse(page2b.text).results.map((r: { signing_key: string }) => r.signing_key),
+      [KEY4]
+    );
   });
 });


### PR DESCRIPTION
Adds `GET /extended/v3/staking/cycles/{cycle_number}/signers`: the signer set of a PoX cycle joined with the signer manager contracts whose registered signing key was this key when the cycle's reward set was calculated.

Only current is accepted as `{cycle_number}` for now but the route is generic so previous cycles can be supported later without a path change.

A new append-only `signer_key_grants` table records every pox-5 `register-signer`, `grant-signer-key`, and `revoke-signer-grant` event with its full block position.

### Sample response

`GET /extended/v3/staking/cycles/current/signers?limit=2`

```json
{
  "total": 34,
  "limit": 2,
  "cursor": {
    "next": "0x03a0f9e1cdeadbeef29395611be9abf6fa3b6987e81d402385e3d605a073f42f4",
    "previous": null,
    "current": "0x0285f4c617c4065e429d1666dcfd885c52e223acfc042aa2c2855adc93034e6975"
  },
  "results": [
    {
      "signing_key": "0x0285f4c617c4065e429d1666dcfd885c52e223acfc042aa2c2855adc93034e6975",
      "weight": { "amount": 9, "percent": 2.1 },
      "staked_stx": { "amount": "8123450000000", "percent": 2.12 },
      "signer_managers": [
        {
          "signer_manager": "SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.signer-manager-xverse-v1",
          "registered_at": {
            "block_height": 498211,
            "bitcoin_block_height": 871002,
            "tx_id": "0xf6bd5f4a7b26184a3466340b2e99fd003b4962c0e382a7e4b6a13df3dd7a91c6"
          },
          "granted_keys": [
            {
              "signer_key": "0x0285f4c617c4065e429d1666dcfd885c52e223acfc042aa2c2855adc93034e6975",
              "auth_id": "340282366920938463463374607431768211455",
              "tx_id": "0x8d02b342a9e51261bd7fd54ce97acdc1e0d5e0a45de62371a3b5f0e4b6c19c3e"
            },
            {
              "signer_key": "0x03ab41e915fce8a586b13a4c728b1694f77c1a1b1381792d77db08d8ac015a1a6f",
              "auth_id": "982374652938471029384",
              "tx_id": "0x1c7a3b90d4e2f6685c1b0a9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f"
            }
          ],
          "grant_active": true,
          "pending_key_update": {
            "signer_key": "0x03ab41e915fce8a586b13a4c728b1694f77c1a1b1381792d77db08d8ac015a1a6f",
            "effective_cycle": 142,
            "tx_id": "0x59cb2447d0e069ba484db1f3672de267ffdc23ab1f4a32bbcd1b1f8bf5ae4a0c"
          }
        },
        {
          "signer_manager": "SP8HK160YD5GHXP69VGA0TC7AQJ1X4CDW3XVERSE.xverse-signer-manager-2",
          "registered_at": {
            "block_height": 471033,
            "bitcoin_block_height": 868554,
            "tx_id": "0x92e21fda3901b12fa9e0b31e5dd0e05e5eaa5262cc521bfcd6ea174a2e0f1b2e"
          },
          "granted_keys": [],
          "grant_active": false,
          "pending_key_update": null
        }
      ]
    },
    {
      "signing_key": "0x03a0f9e1cdeadbeef29395611be9abf6fa3b6987e81d402385e3d605a073f42f4",
      "weight": { "amount": 7, "percent": 1.64 },
      "staked_stx": { "amount": "6318700000000", "percent": 1.65 },
      "signer_managers": [
        {
          "signer_manager": "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7.fast-pool-signer-manager",
          "registered_at": {
            "block_height": 465102,
            "bitcoin_block_height": 867991,
            "tx_id": "0x4f0e2a8b91c3d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2"
          },
          "granted_keys": [
            {
              "signer_key": "0x03a0f9e1cdeadbeef29395611be9abf6fa3b6987e81d402385e3d605a073f42f4",
              "auth_id": "77120394857612093847",
              "tx_id": "0xa3c5e7f9b1d3a5c7e9f1b3d5a7c9e1f3b5d7a9c1e3f5b7d9a1c3e5f7b9d1a3c5"
            }
          ],
          "grant_active": true,
          "pending_key_update": null
        }
      ]
    }
  ]
}
```